### PR TITLE
Add Bazel WORKSPACE and BUILD files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ vgcore.*
 *.jsonnet.h
 Makefile.depend
 Makefile.depend.bak
+bazel-*
 
 # Fractal demo
 case_studies/fractal/*.packer.log

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,74 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "std",
+    srcs = ["std.jsonnet"],
+)
+
+genrule(
+    name = "gen-std-jsonnet-h",
+    srcs = ["std.jsonnet"],
+    outs = ["std.jsonnet.h"],
+    cmd = "((od -v -Anone -t u1 $< | tr \" \" \"\n\" | grep -v \"^$$\" " +
+          "| tr \"\n\" \",\" ) && echo \"0\") > $@; " +
+          "echo >> $@",
+)
+
+cc_library(
+    name = "jsonnet-common",
+    srcs = [
+        "lexer.cpp",
+        "parser.cpp",
+        "static_analysis.cpp",
+        "vm.cpp",
+        "std.jsonnet.h",
+    ],
+    hdrs = [
+        "lexer.h",
+        "parser.h",
+        "static_analysis.h",
+        "static_error.h",
+        "vm.h",
+    ],
+)
+
+cc_library(
+    name = "libjsonnet",
+    srcs = ["libjsonnet.cpp"],
+    hdrs = ["libjsonnet.h"],
+    deps = [":jsonnet-common"],
+)
+
+cc_binary(
+    name = "jsonnet",
+    srcs = ["jsonnet.cpp"],
+    deps = [":libjsonnet"],
+)
+
+cc_binary(
+    name = "libjsonnet_test_snippet",
+    srcs = ["libjsonnet_test_snippet.c"],
+    deps = [":libjsonnet"],
+)
+
+cc_binary(
+    name = "libjsonnet_test_file",
+    srcs = ["libjsonnet_test_file.c"],
+    deps = [":libjsonnet"],
+)
+
+filegroup(
+    name = "object_jsonnet",
+    srcs = ["test_suite/object.jsonnet"],
+)
+
+sh_test(
+    name = "libjsonnet_test",
+    srcs = ["libjsonnet_test.sh"],
+    data = [
+        ":jsonnet",
+        ":libjsonnet_test_snippet",
+        ":libjsonnet_test_file",
+        ":object_jsonnet",
+    ],
+)

--- a/libjsonnet_test.sh
+++ b/libjsonnet_test.sh
@@ -1,0 +1,39 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+readonly TEST_SNIPPET="std.assertEqual(({ x: 1, y: self.x } { x: 2 }).y, 2)"
+readonly JSONNET="jsonnet"
+readonly LIBJSONNET_TEST_SNIPPET="libjsonnet_test_snippet"
+readonly LIBJSONNET_TEST_FILE="libjsonnet_test_file"
+readonly OBJECT_JSONNET="test_suite/object.jsonnet"
+
+function test_snippet {
+  $JSONNET -e $TEST_SNIPPET
+}
+
+function test_libjsonnet_snippet {
+  $LIBJSONNET_TEST_SNIPPET $TEST_SNIPPET
+}
+
+function test_libjsonnet_file {
+  $LIBJSONNET_TEST_FILE $OBJECT_JSONNET
+}
+
+function main {
+  test_snippet
+  test_libjsonnet_snippet
+  test_libjsonnet_file
+}
+
+main


### PR DESCRIPTION
Add preliminary Bazel BUILD file and WORKSPACE. The BUILD file builds libjsonnet, jsonnet, and the libjsonnet tests.

For emscripten targets, I plan to first create some build rules for emscripten, which would involve writing a BUILD file for emscripten itself unless there is a binary distribution containing emcc that I can use. In any case, I will update the BUILD file with the emcc targets in a future PR.