### PR TITLE
Add missing -lm linkopt.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -32,6 +32,7 @@ cc_library(
         "core/static_error.h",
         "core/vm.h",
     ],
+    linkopts = ["-lm"],
     includes = ["core", "include"],
 )
 


### PR DESCRIPTION
This fixes a linker error when building with Bazel on Linux.