### PR TITLE
stdlib: implement json merge

### DIFF
--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -840,6 +840,30 @@ limitations under the License.
                     aux(a, b, i, j + 1, acc) tailstrict;
         aux(a, b, 0, 0, []) tailstrict,
 
+    mergePatch(target, patch)::
+        if std.type(patch) == "object" then
+            local target_object =
+                if std.type(target) == "object" then target else {};
+
+            local target_fields =
+                if std.type(target_object) == "object" then std.objectFields(target_object) else [];
+
+            local null_fields = [k for k in std.objectFields(patch) if patch[k] == null];
+            local both_fields = std.setUnion(target_fields, std.objectFields(patch));
+
+            {
+                [k]:
+                    if !std.objectHas(patch, k) then
+                        target_object[k]
+                    else if !std.objectHas(target_object, k) then
+                        std.mergePatch(null, patch[k]) tailstrict
+                    else
+                        std.mergePatch(target_object[k], patch[k]) tailstrict
+                for k in std.setDiff(both_fields, null_fields)
+            }
+        else
+            patch,
+
     objectFields(o)::
         std.objectFieldsEx(o, false),
 

--- a/test_suite/error.equality_function.jsonnet.golden
+++ b/test_suite/error.equality_function.jsonnet.golden
@@ -1,3 +1,3 @@
 RUNTIME ERROR: Cannot test equality of functions
-	std.jsonnet:889:17-41	function <anonymous>
+	std.jsonnet:913:17-41	function <anonymous>
 	error.equality_function.jsonnet:17:1-31	

--- a/test_suite/error.inside_equals_array.jsonnet.golden
+++ b/test_suite/error.inside_equals_array.jsonnet.golden
@@ -1,11 +1,11 @@
 RUNTIME ERROR: foobar
 	error.inside_equals_array.jsonnet:18:18-31	thunk <array_element>
-	std.jsonnet:869:41-44	thunk <b>
-	std.jsonnet:857:29	thunk <x>
-	std.jsonnet:857:20-30	thunk <tb>
-	std.jsonnet:858:37-38	thunk <b>
-	std.jsonnet:858:13-39	function <anonymous>
-	std.jsonnet:869:33-44	function <aux>
-	std.jsonnet:872:29-44	function <aux>
-	std.jsonnet:873:21-32	function <anonymous>
+	std.jsonnet:893:41-44	thunk <b>
+	std.jsonnet:881:29	thunk <x>
+	std.jsonnet:881:20-30	thunk <tb>
+	std.jsonnet:882:37-38	thunk <b>
+	std.jsonnet:882:13-39	function <anonymous>
+	std.jsonnet:893:33-44	function <aux>
+	std.jsonnet:896:29-44	function <aux>
+	std.jsonnet:897:21-32	function <anonymous>
 	error.inside_equals_array.jsonnet:19:1-6	

--- a/test_suite/error.inside_equals_object.jsonnet.golden
+++ b/test_suite/error.inside_equals_object.jsonnet.golden
@@ -1,11 +1,11 @@
 RUNTIME ERROR: foobar
 	error.inside_equals_object.jsonnet:18:22-35	object <b>
-	std.jsonnet:883:62-65	thunk <b>
-	std.jsonnet:857:29	thunk <x>
-	std.jsonnet:857:20-30	thunk <tb>
-	std.jsonnet:858:37-38	thunk <b>
-	std.jsonnet:858:13-39	function <anonymous>
-	std.jsonnet:883:54-65	function <aux>
-	std.jsonnet:886:29-44	function <aux>
-	std.jsonnet:887:21-32	function <anonymous>
+	std.jsonnet:907:62-65	thunk <b>
+	std.jsonnet:881:29	thunk <x>
+	std.jsonnet:881:20-30	thunk <tb>
+	std.jsonnet:882:37-38	thunk <b>
+	std.jsonnet:882:13-39	function <anonymous>
+	std.jsonnet:907:54-65	function <aux>
+	std.jsonnet:910:29-44	function <aux>
+	std.jsonnet:911:21-32	function <anonymous>
 	error.inside_equals_object.jsonnet:19:1-6	

--- a/test_suite/error.invariant.equality.jsonnet.golden
+++ b/test_suite/error.invariant.equality.jsonnet.golden
@@ -1,10 +1,10 @@
 RUNTIME ERROR: Object assertion failed.
 	error.invariant.equality.jsonnet:17:10-14	thunk <object_assert>
-	std.jsonnet:883:54-57	thunk <a>
-	std.jsonnet:856:29	thunk <x>
-	std.jsonnet:856:20-30	thunk <ta>
-	std.jsonnet:858:33-34	thunk <a>
-	std.jsonnet:858:13-39	function <anonymous>
-	std.jsonnet:883:54-65	function <aux>
-	std.jsonnet:887:21-32	function <anonymous>
+	std.jsonnet:907:54-57	thunk <a>
+	std.jsonnet:880:29	thunk <x>
+	std.jsonnet:880:20-30	thunk <ta>
+	std.jsonnet:882:33-34	thunk <a>
+	std.jsonnet:882:13-39	function <anonymous>
+	std.jsonnet:907:54-65	function <aux>
+	std.jsonnet:911:21-32	function <anonymous>
 	error.invariant.equality.jsonnet:17:1-32	

--- a/test_suite/merge.jsonnet
+++ b/test_suite/merge.jsonnet
@@ -1,0 +1,96 @@
+/*
+Copyright 2016 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+# These cases are shamelessly lifted from 
+# https://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-07#appendix-A
+local cases = [
+    {
+        target: {"a":"b"},
+        patch:  {"a":"c"},
+        expect: {"a":"c"}
+    },
+    {
+        target: {"a":"b"},
+        patch:  {"b":"c"},
+        expect: {"a":"b", "b":"c"}
+    },
+    {
+        target: {"a":"b"},
+        patch:  {"a":null},
+        expect: {},
+    },
+    {
+        target: {"a":"b","b":"c"},
+        patch:  {"a":null},
+        expect: {"b":"c"},
+    },
+    {
+        target: {"a":["b"]},
+        patch:  {"a":"c"},
+        expect: {"a":"c"},
+    },
+    {
+        target: {"a":"c"},
+        patch:  {"a":["b"]},
+        expect: {"a":["b"]},
+    },
+    {
+        target: {"a":{"b":"c"}},
+        patch:  {"a":[1]},
+        expect: {"a":[1]},
+    },
+    {
+        target: ["a","b"],
+        patch:  ["c","d"],
+        expect: ["c","d"],
+    },
+    {
+        target: {"a":"b"},
+        patch:  ["c"],
+        expect: ["c"],
+    },
+    {
+        target: {"a":"foo"},
+        patch:  null,
+        expect: null,
+    },
+    {
+        target: {"a":"foo"},
+        patch:  "bar",
+        expect: "bar",
+    },
+    {
+        target: {"e":null},
+        patch:  {"a":1},
+        expect: {"e":null,"a":1},
+    },
+    {
+        target: [1,2],
+        patch:  {"a":"b","c":null},
+        expect: {"a":"b"},
+    },
+    {
+        target: {},
+        patch:  {"a":{"bb":{"ccc":null}}},
+        expect: {"a":{"bb":{}}},
+    },
+];
+
+local results =
+    [ std.assertEqual(std.mergePatch(case.target, case.patch), case.expect)
+      for case in cases ];
+
+std.foldl(function(a,b) a && b, results, true)


### PR DESCRIPTION
Adds a merge function to the stdlib as described in:

https://tools.ietf.org/html/rfc7386
https://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-07

There's some wierdness around patching nulls. I couldn't figure out how to remove a node from the json object so some of the test cases have an extra null in the expected output which seems okay. I've left a comment where are expected differs from the spec's expected differs from our expected.