### PR TITLE
Include cerrno header explictly

### DIFF
--- a/core/libjsonnet.cpp
+++ b/core/libjsonnet.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include <cstdlib>
 #include <cstring>
+#include <cerrno>
 
 #include <exception>
 #include <fstream>


### PR DESCRIPTION
It will fail to build in FreeBSD 9.3 if we don't require cerrno
header for using variable `errno`.

```
$ g++48 --version
g++48 (FreeBSD Ports Collection) 4.8.5
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is
NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
PURPOSE.

$ root@9_3amd64-local:/usr/ports/devel/jsonnet # uname -a
FreeBSD 9_3amd64-local 9.3-RELEASE-p36 FreeBSD 9.3-RELEASE-p36 amd64

$ make
===>  Building for jsonnet-0.8.6
g++48 -c -O2 -pipe -fstack-protector -Wl,-rpath=/usr/local/lib/gcc48
-fno-strict-aliasing -fPIC -Iinclude -std=c++11 core/libjsonnet.cpp
-o core/libjsonnet.o
core/libjsonnet.cpp: In function 'ImportStatus try_path(const string&,
const string&, std::string&, std::string&, std::string&)':
core/libjsonnet.cpp:112:28: error: 'errno' was not declared in this
scope
         err_msg = strerror(errno);
                            ^
```