### PR TITLE
fix bazel build

### DIFF
--- a/core/BUILD
+++ b/core/BUILD
@@ -38,7 +38,6 @@ cc_library(
         "static_analysis.cpp",
         "string_utils.cpp",
         "vm.cpp",
-        "//stdlib:std.jsonnet.h",
     ],
     hdrs = [
         "ast.h",
@@ -54,6 +53,7 @@ cc_library(
         ":common",
         ":lexer",
         "//include:libjsonnet",
+        "//stdlib:std",
     ],
     linkopts = ["-lm"],
     includes = ["."],

--- a/stdlib/BUILD
+++ b/stdlib/BUILD
@@ -1,8 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-filegroup(
+cc_library(
     name = "std",
-    srcs = ["std.jsonnet"],
+    hdrs = ["std.jsonnet.h"],
+    srcs = [":gen-std-jsonnet-h"],
+    includes = ["."],
+    linkstatic = 1,
 )
 
 genrule(


### PR DESCRIPTION
Build appears to be broken on HEAD
```console
$ bazel build //cmd:jsonnet --verbose_failures
INFO: Found 1 target...
ERROR: /home/mikedanese/jsonnet/core/BUILD:31:1: C++ compilation of rule '//core:jsonnet-common' failed: gcc failed: error executing command 
  (cd /home/mikedanese/.cache/bazel/_bazel_mikedanese/fab3a42bbd7a88931a2be2b547bd48af/jsonnet && \
  exec env - \
    PATH=/home/mikedanese/google-cloud-sdk/bin:/home/mikedanese/bin:/home/mikedanese/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games \
  /usr/bin/gcc -U_FORTIFY_SOURCE '-D_FORTIFY_SOURCE=1' -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++0x' -iquote . -iquote bazel-out/local_linux-fastbuild/genfiles -iquote external/bazel_tools -iquote bazel-out/local_linux-fastbuild/genfiles/external/bazel_tools -isystem core -isystem bazel-out/local_linux-fastbuild/genfiles/core -isystem external/bazel_tools/tools/cpp/gcc3 -isystem include -isystem bazel-out/local_linux-fastbuild/genfiles/include -no-canonical-prefixes -fno-canonical-system-headers -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' '-frandom-seed=bazel-out/local_linux-fastbuild/bin/core/_objs/jsonnet-common/core/desugarer.pic.o' -MD -MF bazel-out/local_linux-fastbuild/bin/core/_objs/jsonnet-common/core/desugarer.pic.d -fPIC -c core/desugarer.cpp -o bazel-out/local_linux-fastbuild/bin/core/_objs/jsonnet-common/core/desugarer.pic.o): gcc failed: error executing command 
  (cd /home/mikedanese/.cache/bazel/_bazel_mikedanese/fab3a42bbd7a88931a2be2b547bd48af/jsonnet && \
  exec env - \
    PATH=/home/mikedanese/google-cloud-sdk/bin:/home/mikedanese/bin:/home/mikedanese/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games \
  /usr/bin/gcc -U_FORTIFY_SOURCE '-D_FORTIFY_SOURCE=1' -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++0x' -iquote . -iquote bazel-out/local_linux-fastbuild/genfiles -iquote external/bazel_tools -iquote bazel-out/local_linux-fastbuild/genfiles/external/bazel_tools -isystem core -isystem bazel-out/local_linux-fastbuild/genfiles/core -isystem external/bazel_tools/tools/cpp/gcc3 -isystem include -isystem bazel-out/local_linux-fastbuild/genfiles/include -no-canonical-prefixes -fno-canonical-system-headers -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' '-frandom-seed=bazel-out/local_linux-fastbuild/bin/core/_objs/jsonnet-common/core/desugarer.pic.o' -MD -MF bazel-out/local_linux-fastbuild/bin/core/_objs/jsonnet-common/core/desugarer.pic.d -fPIC -c core/desugarer.cpp -o bazel-out/local_linux-fastbuild/bin/core/_objs/jsonnet-common/core/desugarer.pic.o).
core/desugarer.cpp:66:29: fatal error: std.jsonnet.h: No such file or directory
compilation terminated.
Target //cmd:jsonnet failed to build
INFO: Elapsed time: 1.630s, Critical Path: 0.62s
```
Not sure if this is the best way to fix :)

cc @davidzchen 