### PR TITLE
Drop namespace indents.

### DIFF
--- a/core/ast.h
+++ b/core/ast.h
@@ -768,94 +768,96 @@ class Allocator {
 };
 
 namespace {
-    // Precedences used by various compilation units are defined here.
-    const int APPLY_PRECEDENCE = 2;  // Function calls and indexing.
-    const int UNARY_PRECEDENCE = 4;  // Logical and bitwise negation, unary + -
-    const int BEFORE_ELSE_PRECEDENCE = 15; // True branch of an if.
-    const int MAX_PRECEDENCE = 16; // Local, If, Import, Function, Error
 
-    /** These are the binary operator precedences, unary precedence is given by
-     * UNARY_PRECEDENCE.
-     */
-    std::map<BinaryOp, int> build_precedence_map(void)
-    {
-        std::map<BinaryOp, int> r;
+// Precedences used by various compilation units are defined here.
+const int APPLY_PRECEDENCE = 2;  // Function calls and indexing.
+const int UNARY_PRECEDENCE = 4;  // Logical and bitwise negation, unary + -
+const int BEFORE_ELSE_PRECEDENCE = 15; // True branch of an if.
+const int MAX_PRECEDENCE = 16; // Local, If, Import, Function, Error
 
-        r[BOP_MULT] = 5;
-        r[BOP_DIV] = 5;
-        r[BOP_PERCENT] = 5;
+/** These are the binary operator precedences, unary precedence is given by
+ * UNARY_PRECEDENCE.
+ */
+std::map<BinaryOp, int> build_precedence_map(void)
+{
+    std::map<BinaryOp, int> r;
 
-        r[BOP_PLUS] = 6;
-        r[BOP_MINUS] = 6;
+    r[BOP_MULT] = 5;
+    r[BOP_DIV] = 5;
+    r[BOP_PERCENT] = 5;
 
-        r[BOP_SHIFT_L] = 7;
-        r[BOP_SHIFT_R] = 7;
+    r[BOP_PLUS] = 6;
+    r[BOP_MINUS] = 6;
 
-        r[BOP_GREATER] = 8;
-        r[BOP_GREATER_EQ] = 8;
-        r[BOP_LESS] = 8;
-        r[BOP_LESS_EQ] = 8;
+    r[BOP_SHIFT_L] = 7;
+    r[BOP_SHIFT_R] = 7;
 
-        r[BOP_MANIFEST_EQUAL] = 9;
-        r[BOP_MANIFEST_UNEQUAL] = 9;
+    r[BOP_GREATER] = 8;
+    r[BOP_GREATER_EQ] = 8;
+    r[BOP_LESS] = 8;
+    r[BOP_LESS_EQ] = 8;
 
-        r[BOP_BITWISE_AND] = 10;
+    r[BOP_MANIFEST_EQUAL] = 9;
+    r[BOP_MANIFEST_UNEQUAL] = 9;
 
-        r[BOP_BITWISE_XOR] = 11;
+    r[BOP_BITWISE_AND] = 10;
 
-        r[BOP_BITWISE_OR] = 12;
+    r[BOP_BITWISE_XOR] = 11;
 
-        r[BOP_AND] = 13;
+    r[BOP_BITWISE_OR] = 12;
 
-        r[BOP_OR] = 14;
+    r[BOP_AND] = 13;
 
-        return r;
-    }
+    r[BOP_OR] = 14;
 
-    std::map<std::string, UnaryOp> build_unary_map(void)
-    {
-        std::map<std::string, UnaryOp> r;
-        r["!"] = UOP_NOT;
-        r["~"] = UOP_BITWISE_NOT;
-        r["+"] = UOP_PLUS;
-        r["-"] = UOP_MINUS;
-        return r;
-    }
-
-    std::map<std::string, BinaryOp> build_binary_map(void)
-    {
-        std::map<std::string, BinaryOp> r;
-
-        r["*"] = BOP_MULT;
-        r["/"] = BOP_DIV;
-        r["%"] = BOP_PERCENT;
-
-        r["+"] = BOP_PLUS;
-        r["-"] = BOP_MINUS;
-
-        r["<<"] = BOP_SHIFT_L;
-        r[">>"] = BOP_SHIFT_R;
-
-        r[">"] = BOP_GREATER;
-        r[">="] = BOP_GREATER_EQ;
-        r["<"] = BOP_LESS;
-        r["<="] = BOP_LESS_EQ;
-
-        r["=="] = BOP_MANIFEST_EQUAL;
-        r["!="] = BOP_MANIFEST_UNEQUAL;
-
-        r["&"] = BOP_BITWISE_AND;
-        r["^"] = BOP_BITWISE_XOR;
-        r["|"] = BOP_BITWISE_OR;
-
-        r["&&"] = BOP_AND;
-        r["||"] = BOP_OR;
-        return r;
-    }
-
-    auto precedence_map = build_precedence_map();
-    auto unary_map = build_unary_map();
-    auto binary_map = build_binary_map();
+    return r;
 }
+
+std::map<std::string, UnaryOp> build_unary_map(void)
+{
+    std::map<std::string, UnaryOp> r;
+    r["!"] = UOP_NOT;
+    r["~"] = UOP_BITWISE_NOT;
+    r["+"] = UOP_PLUS;
+    r["-"] = UOP_MINUS;
+    return r;
+}
+
+std::map<std::string, BinaryOp> build_binary_map(void)
+{
+    std::map<std::string, BinaryOp> r;
+
+    r["*"] = BOP_MULT;
+    r["/"] = BOP_DIV;
+    r["%"] = BOP_PERCENT;
+
+    r["+"] = BOP_PLUS;
+    r["-"] = BOP_MINUS;
+
+    r["<<"] = BOP_SHIFT_L;
+    r[">>"] = BOP_SHIFT_R;
+
+    r[">"] = BOP_GREATER;
+    r[">="] = BOP_GREATER_EQ;
+    r["<"] = BOP_LESS;
+    r["<="] = BOP_LESS_EQ;
+
+    r["=="] = BOP_MANIFEST_EQUAL;
+    r["!="] = BOP_MANIFEST_UNEQUAL;
+
+    r["&"] = BOP_BITWISE_AND;
+    r["^"] = BOP_BITWISE_XOR;
+    r["|"] = BOP_BITWISE_OR;
+
+    r["&&"] = BOP_AND;
+    r["||"] = BOP_OR;
+    return r;
+}
+
+auto precedence_map = build_precedence_map();
+auto unary_map = build_unary_map();
+auto binary_map = build_binary_map();
+
+}  // namespace
 
 #endif  // JSONNET_AST_H

--- a/core/libjsonnet.cpp
+++ b/core/libjsonnet.cpp
@@ -342,8 +342,8 @@ char *jsonnet_fmt_snippet(JsonnetVm *vm, const char *filename, const char *snipp
 
 
 namespace {
-  enum EvalKind { REGULAR, MULTI, STREAM };
-}
+enum EvalKind { REGULAR, MULTI, STREAM };
+}  // namespace
 
 static char *jsonnet_evaluate_snippet_aux(JsonnetVm *vm, const char *filename,
                                           const char *snippet, int *error, EvalKind kind)

--- a/core/parser.cpp
+++ b/core/parser.cpp
@@ -50,904 +50,895 @@ std::string jsonnet_unparse_number(double v)
 
 namespace {
 
-    static bool op_is_unary(const std::string &op, UnaryOp &uop)
+static bool op_is_unary(const std::string &op, UnaryOp &uop)
+{
+    auto it = unary_map.find(op);
+    if (it == unary_map.end()) return false;
+    uop = it->second;
+    return true;
+}
+
+static bool op_is_binary(const std::string &op, BinaryOp &bop)
+{
+    auto it = binary_map.find(op);
+    if (it == binary_map.end()) return false;
+    bop = it->second;
+    return true;
+}
+
+LocationRange span(const Token &begin)
+{
+    return LocationRange(begin.location.file, begin.location.begin, begin.location.end);
+}
+
+LocationRange span(const Token &begin, const Token &end)
+{
+    return LocationRange(begin.location.file, begin.location.begin, end.location.end);
+}
+
+LocationRange span(const Token &begin, AST *end)
+{
+    return LocationRange(begin.location.file, begin.location.begin, end->location.end);
+}
+
+/** Holds state while parsing a given token list.
+ */
+class Parser {
+
+    // The private member functions are utilities for dealing with the token stream.
+
+    StaticError unexpected(const Token &tok, const std::string &while_)
     {
-        auto it = unary_map.find(op);
-        if (it == unary_map.end()) return false;
-        uop = it->second;
-        return true;
+        std::stringstream ss;
+        ss << "Unexpected: " << tok.kind << " while " << while_;
+        return StaticError(tok.location, ss.str());
     }
 
-    static bool op_is_binary(const std::string &op, BinaryOp &bop)
+    Token pop(void)
     {
-        auto it = binary_map.find(op);
-        if (it == binary_map.end()) return false;
-        bop = it->second;
-        return true;
+        Token tok = peek();
+        tokens.pop_front();
+        return tok;
     }
 
-    LocationRange span(const Token &begin)
-    {
-        return LocationRange(begin.location.file, begin.location.begin, begin.location.end);
+    void push(Token tok) {
+        tokens.push_front(tok);
     }
 
-    LocationRange span(const Token &begin, const Token &end)
+    Token peek(void)
     {
-        return LocationRange(begin.location.file, begin.location.begin, end.location.end);
+        Token tok = tokens.front();
+        return tok;
     }
 
-    LocationRange span(const Token &begin, AST *end)
+    Token popExpect(Token::Kind k, const char *data=nullptr)
     {
-        return LocationRange(begin.location.file, begin.location.begin, end->location.end);
-    }
-
-    /** Holds state while parsing a given token list.
-     */
-    class Parser {
-
-        // The private member functions are utilities for dealing with the token stream.
-
-        StaticError unexpected(const Token &tok, const std::string &while_)
-        {
+        Token tok = pop();
+        if (tok.kind != k) {
             std::stringstream ss;
-            ss << "Unexpected: " << tok.kind << " while " << while_;
-            return StaticError(tok.location, ss.str());
+            ss << "Expected token " << k << " but got " << tok;
+            throw StaticError(tok.location, ss.str());
         }
-
-        Token pop(void)
-        {
-            Token tok = peek();
-            tokens.pop_front();
-            return tok;
+        if (data != nullptr && tok.data != data) {
+            std::stringstream ss;
+            ss << "Expected operator " << data << " but got " << tok.data;
+            throw StaticError(tok.location, ss.str());
         }
+        return tok;
+    }
 
-        void push(Token tok) {
-            tokens.push_front(tok);
-        }
+    std::list<Token> &tokens;
+    Allocator *alloc;
 
-        Token peek(void)
-        {
-            Token tok = tokens.front();
-            return tok;
-        }
+    public:
 
-        Token popExpect(Token::Kind k, const char *data=nullptr)
-        {
-            Token tok = pop();
-            if (tok.kind != k) {
-                std::stringstream ss;
-                ss << "Expected token " << k << " but got " << tok;
-                throw StaticError(tok.location, ss.str());
+    Parser(Tokens &tokens, Allocator *alloc)
+      : tokens(tokens), alloc(alloc)
+    { }
+
+    /** Parse a comma-separated list of expressions.
+     *
+     * Allows an optional ending comma.
+     * \param exprs Expressions added here.
+     * \param end The token that ends the list (e.g. ] or )).
+     * \param element_kind Used in error messages when a comma was not found.
+     * \returns The last token (the one that matched parameter end).
+     */
+    Token parseCommaList(std::vector<std::pair<AST*, Fodder>> &exprs, Token::Kind end,
+                         const std::string &element_kind,
+                         bool &got_comma)
+    {
+        got_comma = false;
+        bool first = true;
+        do {
+            Fodder comma_fodder;
+            Token next = peek();
+            if (!first && !got_comma) {
+                if (next.kind == Token::COMMA) {
+                    Token comma = pop();
+                    comma_fodder = comma.fodder;
+                    next = peek();
+                    got_comma = true;
+                }
             }
-            if (data != nullptr && tok.data != data) {
-                std::stringstream ss;
-                ss << "Expected operator " << data << " but got " << tok.data;
-                throw StaticError(tok.location, ss.str());
+            if (next.kind == end) {
+                // got_comma can be true or false here.
+                return pop();
             }
-            return tok;
-        }
-
-        std::list<Token> &tokens;
-        Allocator *alloc;
-
-        public:
-
-        Parser(Tokens &tokens, Allocator *alloc)
-          : tokens(tokens), alloc(alloc)
-        { }
-
-        /** Parse a comma-separated list of expressions.
-         *
-         * Allows an optional ending comma.
-         * \param exprs Expressions added here.
-         * \param end The token that ends the list (e.g. ] or )).
-         * \param element_kind Used in error messages when a comma was not found.
-         * \returns The last token (the one that matched parameter end).
-         */
-        Token parseCommaList(std::vector<std::pair<AST*, Fodder>> &exprs,
-                             Token::Kind end,
-                             const std::string &element_kind,
-                             bool &got_comma)
-        {
+            if (!first && !got_comma) {
+                std::stringstream ss;
+                ss << "Expected a comma before next " << element_kind <<  ".";
+                throw StaticError(next.location, ss.str());
+            }
+            exprs.emplace_back(parse(MAX_PRECEDENCE), comma_fodder);
             got_comma = false;
-            bool first = true;
-            do {
-                Fodder comma_fodder;
+            first = false;
+        } while (true);
+    }
+
+    Params parseParams(const std::string &element_kind, bool &got_comma, Fodder &close_fodder)
+    {
+        std::vector<std::pair<AST*, Fodder>> exprs;
+        Token paren_r = parseCommaList(exprs, Token::PAREN_R, element_kind, got_comma);
+
+        // Check they're all identifiers
+        Params ret;
+        for (const auto &p_ast_fodder : exprs) {
+            auto *p = dynamic_cast<Var*>(p_ast_fodder.first);
+            if (p == nullptr) {
+                throw StaticError(p_ast_fodder.first->location,
+                                  "Expected an identifier but got a complex expression.");
+            }
+            ret.emplace_back(p->openFodder, p->id, p_ast_fodder.second);
+        }
+
+        close_fodder = paren_r.fodder;
+
+        return ret;
+    }
+
+    Token parseBind(Local::Binds &binds)
+    {
+        Token var_id = popExpect(Token::IDENTIFIER);
+        auto *id = alloc->makeIdentifier(var_id.data32());
+        for (const auto &bind : binds) {
+            if (bind.var == id)
+                throw StaticError(var_id.location, "Duplicate local var: " + var_id.data);
+        }
+        bool is_function = false;
+        Params params;
+        bool trailing_comma = false;
+        Fodder fodder_l, fodder_r;
+        if (peek().kind == Token::PAREN_L) {
+            Token paren_l = pop();
+            fodder_l = paren_l.fodder;
+            params = parseParams("function parameter", trailing_comma, fodder_r);
+            is_function = true;
+        }
+        Token eq = popExpect(Token::OPERATOR, "=");
+        AST *body = parse(MAX_PRECEDENCE);
+        Token delim = pop();
+        binds.emplace_back(var_id.fodder, id, eq.fodder, body, is_function, fodder_l, params,
+                           trailing_comma, fodder_r, delim.fodder);
+        return delim;
+    }
+
+
+    Token parseObjectRemainder(AST *&obj, const Token &tok)
+    {
+        ObjectFields fields;
+        std::set<std::string> literal_fields;  // For duplicate fields detection.
+        std::set<const Identifier *> binds;  // For duplicate locals detection.
+
+        bool got_comma = false;
+        bool first = true;
+        Token next = pop();
+
+        do {
+
+            if (next.kind == Token::BRACE_R) {
+                obj = alloc->make<Object>(
+                    span(tok, next), tok.fodder, fields, got_comma, next.fodder);
+                return next;
+
+            } else if (next.kind == Token::FOR) {
+                // It's a comprehension
+                unsigned num_fields = 0;
+                unsigned num_asserts = 0;
+                const ObjectField *field_ptr = nullptr;
+                for (const auto &field : fields) {
+                    if (field.kind == ObjectField::LOCAL) continue;
+                    if (field.kind == ObjectField::ASSERT) {
+                        num_asserts++;
+                        continue;
+                    }
+                    field_ptr = &field;
+                    num_fields++;
+                }
+                if (num_asserts > 0) {
+                    auto msg = "Object comprehension cannot have asserts.";
+                    throw StaticError(next.location, msg);
+                }
+                if (num_fields != 1) {
+                    auto msg = "Object comprehension can only have one field.";
+                    throw StaticError(next.location, msg);
+                }
+                const ObjectField &field = *field_ptr;
+
+                if (field.hide != ObjectField::INHERIT) {
+                    auto msg = "Object comprehensions cannot have hidden fields.";
+                    throw StaticError(next.location, msg);
+                }
+
+                if (field.kind != ObjectField::FIELD_EXPR) {
+                    auto msg = "Object comprehensions can only have [e] fields.";
+                    throw StaticError(next.location, msg);
+                }
+
+                std::vector<ComprehensionSpec> specs;
+                Token last = parseComprehensionSpecs(Token::BRACE_R, next.fodder, specs);
+                obj = alloc->make<ObjectComprehension>(
+                    span(tok, last), tok.fodder, fields, got_comma, specs, last.fodder);
+
+                return last;
+            }
+
+            if (!got_comma && !first)
+                throw StaticError(next.location, "Expected a comma before next field.");
+
+            first = false;
+            got_comma = false;
+
+            switch (next.kind) {
+                case Token::BRACKET_L: case Token::IDENTIFIER: case Token::STRING_DOUBLE:
+                case Token::STRING_SINGLE: case Token::STRING_BLOCK: {
+                    ObjectField::Kind kind;
+                    AST *expr1 = nullptr;
+                    const Identifier *id = nullptr;
+                    Fodder fodder1, fodder2;
+                    if (next.kind == Token::IDENTIFIER) {
+                        fodder1 = next.fodder;
+                        kind = ObjectField::FIELD_ID;
+                        id = alloc->makeIdentifier(next.data32());
+                    } else if (next.kind == Token::STRING_DOUBLE) {
+                        kind = ObjectField::FIELD_STR;
+                        expr1 = alloc->make<LiteralString>(
+                            next.location, next.fodder, next.data32(), LiteralString::DOUBLE,
+                            "", "");
+                    } else if (next.kind == Token::STRING_SINGLE) {
+                        kind = ObjectField::FIELD_STR;
+                        expr1 = alloc->make<LiteralString>(
+                            next.location, next.fodder, next.data32(), LiteralString::SINGLE,
+                            "", "");
+                    } else if (next.kind == Token::STRING_BLOCK) {
+                        kind = ObjectField::FIELD_STR;
+                        expr1 = alloc->make<LiteralString>(
+                            next.location, next.fodder, next.data32(), LiteralString::BLOCK,
+                            next.stringBlockIndent, next.stringBlockTermIndent);
+                    } else {
+                        kind = ObjectField::FIELD_EXPR;
+                        fodder1 = next.fodder;
+                        expr1 = parse(MAX_PRECEDENCE);
+                        Token bracket_r = popExpect(Token::BRACKET_R);
+                        fodder2 = bracket_r.fodder;
+                    }
+
+                    bool is_method = false;
+                    bool meth_comma = false;
+                    Params params;
+                    Fodder fodder_l;
+                    Fodder fodder_r;
+                    if (peek().kind == Token::PAREN_L) {
+                        Token paren_l = pop();
+                        fodder_l = paren_l.fodder;
+                        params = parseParams("method parameter", meth_comma, fodder_r);
+                        is_method = true;
+                    }
+
+                    bool plus_sugar = false;
+
+                    Token op = popExpect(Token::OPERATOR);
+                    const char *od = op.data.c_str();
+                    if (*od == '+') {
+                        plus_sugar = true;
+                        od++;
+                    }
+                    unsigned colons = 0;
+                    for (; *od != '\0' ; ++od) {
+                        if (*od != ':') {
+                            throw StaticError(
+                                next.location,
+                                "Expected one of :, ::, :::, +:, +::, +:::, got: " + op.data);
+                        }
+                        ++colons;
+                    }
+                    ObjectField::Hide field_hide;
+                    switch (colons) {
+                        case 1:
+                        field_hide = ObjectField::INHERIT;
+                        break;
+
+                        case 2:
+                        field_hide = ObjectField::HIDDEN;
+                        break;
+
+                        case 3:
+                        field_hide = ObjectField::VISIBLE;
+                        break;
+
+                        default:
+                            throw StaticError(
+                                next.location,
+                                "Expected one of :, ::, :::, +:, +::, +:::, got: " + op.data);
+                    }
+
+                    // Basic checks for invalid Jsonnet code.
+                    if (is_method && plus_sugar) {
+                        throw StaticError(
+                            next.location, "Cannot use +: syntax sugar in a method: " + next.data);
+                    }
+                    if (kind != ObjectField::FIELD_EXPR) {
+                        if (!literal_fields.insert(next.data).second) {
+                            throw StaticError(next.location, "Duplicate field: "+next.data);
+                        }
+                    }
+
+                    AST *body = parse(MAX_PRECEDENCE);
+
+                    Fodder comma_fodder;
+                    next = pop();
+                    if (next.kind == Token::COMMA) {
+                        comma_fodder = next.fodder;
+                        next = pop();
+                        got_comma = true;
+                    }
+                    fields.emplace_back(
+                        kind, fodder1, fodder2, fodder_l, fodder_r, field_hide, plus_sugar,
+                        is_method, expr1, id, params, meth_comma, op.fodder, body, nullptr,
+                        comma_fodder);
+                }
+                break;
+
+                case Token::LOCAL: {
+                    Fodder local_fodder = next.fodder;
+                    Token var_id = popExpect(Token::IDENTIFIER);
+                    auto *id = alloc->makeIdentifier(var_id.data32());
+
+                    if (binds.find(id) != binds.end()) {
+                        throw StaticError(var_id.location, "Duplicate local var: " + var_id.data);
+                    }
+                    bool is_method = false;
+                    bool func_comma = false;
+                    Params params;
+                    Fodder paren_l_fodder;
+                    Fodder paren_r_fodder;
+                    if (peek().kind == Token::PAREN_L) {
+                        Token paren_l = pop();
+                        paren_l_fodder = paren_l.fodder;
+                        is_method = true;
+                        params = parseParams("function parameter", func_comma, paren_r_fodder);
+                    }
+                    Token eq = popExpect(Token::OPERATOR, "=");
+                    AST *body = parse(MAX_PRECEDENCE);
+                    binds.insert(id);
+
+                    Fodder comma_fodder;
+                    next = pop();
+                    if (next.kind == Token::COMMA) {
+                        comma_fodder = next.fodder;
+                        next = pop();
+                        got_comma = true;
+                    }
+                    fields.push_back(
+                        ObjectField::Local(
+                            local_fodder, var_id.fodder, paren_l_fodder, paren_r_fodder,
+                            is_method, id, params, func_comma, eq.fodder, body, comma_fodder));
+
+                }
+                break;
+
+                case Token::ASSERT: {
+                    Fodder assert_fodder = next.fodder;
+                    AST *cond = parse(MAX_PRECEDENCE);
+                    AST *msg = nullptr;
+                    Fodder colon_fodder;
+                    if (peek().kind == Token::OPERATOR && peek().data == ":") {
+                        Token colon = pop();
+                        colon_fodder = colon.fodder;
+                        msg = parse(MAX_PRECEDENCE);
+                    }
+
+                    Fodder comma_fodder;
+                    next = pop();
+                    if (next.kind == Token::COMMA) {
+                        comma_fodder = next.fodder;
+                        next = pop();
+                        got_comma = true;
+                    }
+                    fields.push_back(ObjectField::Assert(assert_fodder, cond, colon_fodder, msg,
+                                     comma_fodder));
+                }
+                break;
+
+                default:
+                throw unexpected(next, "parsing field definition");
+            }
+
+
+        } while (true);
+    }
+
+    /** parses for x in expr for y in expr if expr for z in expr ... */
+    Token parseComprehensionSpecs(Token::Kind end, Fodder for_fodder,
+                                  std::vector<ComprehensionSpec> &specs)
+    {
+        while (true) {
+            LocationRange l;
+            Token id_token = popExpect(Token::IDENTIFIER);
+            const Identifier *id = alloc->makeIdentifier(id_token.data32());
+            Token in_token = popExpect(Token::IN);
+            AST *arr = parse(MAX_PRECEDENCE);
+            specs.emplace_back(ComprehensionSpec::FOR, for_fodder, id_token.fodder, id,
+                               in_token.fodder, arr);
+
+            Token maybe_if = pop();
+            for (; maybe_if.kind == Token::IF; maybe_if = pop()) {
+                AST *cond = parse(MAX_PRECEDENCE);
+                specs.emplace_back(ComprehensionSpec::IF, maybe_if.fodder, Fodder{}, nullptr,
+                                   Fodder{}, cond);
+            }
+            if (maybe_if.kind == end) {
+                return maybe_if;
+            }
+            if (maybe_if.kind != Token::FOR) {
+                std::stringstream ss;
+                ss << "Expected for, if or " << end << " after for clause, got: " << maybe_if;
+                throw StaticError(maybe_if.location, ss.str());
+            }
+            for_fodder = maybe_if.fodder;
+        }
+    }
+
+    AST *parseTerminal(void)
+    {
+        Token tok = pop();
+        switch (tok.kind) {
+            case Token::ASSERT:
+            case Token::BRACE_R:
+            case Token::BRACKET_R:
+            case Token::COMMA:
+            case Token::DOT:
+            case Token::ELSE:
+            case Token::ERROR:
+            case Token::FOR:
+            case Token::FUNCTION:
+            case Token::IF:
+            case Token::IN:
+            case Token::IMPORT:
+            case Token::IMPORTSTR:
+            case Token::LOCAL:
+            case Token::OPERATOR:
+            case Token::PAREN_R:
+            case Token::SEMICOLON:
+            case Token::TAILSTRICT:
+            case Token::THEN:
+            throw unexpected(tok, "parsing terminal");
+
+            case Token::END_OF_FILE:
+            throw StaticError(tok.location, "Unexpected end of file.");
+
+            case Token::BRACE_L: {
+                AST *obj;
+                parseObjectRemainder(obj, tok);
+                return obj;
+            }
+
+            case Token::BRACKET_L: {
                 Token next = peek();
-                if (!first && !got_comma) {
+                if (next.kind == Token::BRACKET_R) {
+                    Token bracket_r = pop();
+                    return alloc->make<Array>(span(tok, next), tok.fodder, Array::Elements{},
+                                              false, bracket_r.fodder);
+                }
+                AST *first = parse(MAX_PRECEDENCE);
+                bool got_comma = false;
+                Fodder comma_fodder;
+                next = peek();
+                if (!got_comma && next.kind == Token::COMMA) {
+                    Token comma = pop();
+                    comma_fodder = comma.fodder;
+                    next = peek();
+                    got_comma = true;
+                }
+
+                if (next.kind == Token::FOR) {
+                    // It's a comprehension
+                    Token for_token = pop();
+                    std::vector<ComprehensionSpec> specs;
+                    Token last = parseComprehensionSpecs(Token::BRACKET_R, for_token.fodder, specs);
+                    return alloc->make<ArrayComprehension>(
+                        span(tok, last), tok.fodder, first, comma_fodder, got_comma, specs,
+                        last.fodder);
+                }
+
+                // Not a comprehension: It can have more elements.
+                Array::Elements elements;
+                elements.emplace_back(first, comma_fodder);
+                do {
+                    if (next.kind == Token::BRACKET_R) {
+                        Token bracket_r = pop();
+                        return alloc->make<Array>(
+                            span(tok, next), tok.fodder, elements, got_comma, bracket_r.fodder);
+                    }
+                    if (!got_comma) {
+                        std::stringstream ss;
+                        ss << "Expected a comma before next array element.";
+                        throw StaticError(next.location, ss.str());
+                    }
+                    AST *expr = parse(MAX_PRECEDENCE);
+                    comma_fodder.clear();
+                    got_comma = false;
+                    next = peek();
                     if (next.kind == Token::COMMA) {
                         Token comma = pop();
                         comma_fodder = comma.fodder;
                         next = peek();
                         got_comma = true;
                     }
-                }
-                if (next.kind == end) {
-                    // got_comma can be true or false here.
-                    return pop();
-                }
-                if (!first && !got_comma) {
-                    std::stringstream ss;
-                    ss << "Expected a comma before next " << element_kind <<  ".";
-                    throw StaticError(next.location, ss.str());
-                }
-                exprs.emplace_back(parse(MAX_PRECEDENCE), comma_fodder);
-                got_comma = false;
-                first = false;
-            } while (true);
-        }
-
-        Params parseParams(const std::string &element_kind, bool &got_comma, Fodder &close_fodder)
-        {
-            std::vector<std::pair<AST*, Fodder>> exprs;
-            Token paren_r = parseCommaList(exprs, Token::PAREN_R, element_kind, got_comma);
-
-            // Check they're all identifiers
-            Params ret;
-            for (const auto &p_ast_fodder : exprs) {
-                auto *p = dynamic_cast<Var*>(p_ast_fodder.first);
-                if (p == nullptr) {
-                    throw StaticError(p_ast_fodder.first->location,
-                                      "Expected an identifier but got a complex expression.");
-                }
-                ret.emplace_back(p->openFodder, p->id, p_ast_fodder.second);
+                    elements.emplace_back(expr, comma_fodder);
+                } while (true);
             }
 
-            close_fodder = paren_r.fodder;
-
-            return ret;
-        }
-
-        Token parseBind(Local::Binds &binds)
-        {
-            Token var_id = popExpect(Token::IDENTIFIER);
-            auto *id = alloc->makeIdentifier(var_id.data32());
-            for (const auto &bind : binds) {
-                if (bind.var == id)
-                    throw StaticError(var_id.location,
-                                      "Duplicate local var: " + var_id.data);
+            case Token::PAREN_L: {
+                auto *inner = parse(MAX_PRECEDENCE);
+                Token close = popExpect(Token::PAREN_R);
+                return alloc->make<Parens>(span(tok, close), tok.fodder, inner, close.fodder);
             }
-            bool is_function = false;
-            Params params;
-            bool trailing_comma = false;
-            Fodder fodder_l, fodder_r;
-            if (peek().kind == Token::PAREN_L) {
-                Token paren_l = pop();
-                fodder_l = paren_l.fodder;
-                params = parseParams("function parameter", trailing_comma, fodder_r);
-                is_function = true;
-            }
-            Token eq = popExpect(Token::OPERATOR, "=");
-            AST *body = parse(MAX_PRECEDENCE);
-            Token delim = pop();
-            binds.emplace_back(var_id.fodder, id, eq.fodder, body, is_function, fodder_l, params,
-                               trailing_comma, fodder_r, delim.fodder);
-            return delim;
-        }
 
+            // Literals
+            case Token::NUMBER:
+            return alloc->make<LiteralNumber>(span(tok), tok.fodder, tok.data);
 
-        Token parseObjectRemainder(AST *&obj, const Token &tok)
-        {
-            ObjectFields fields;
-            std::set<std::string> literal_fields;  // For duplicate fields detection.
-            std::set<const Identifier *> binds;  // For duplicate locals detection.
+            case Token::STRING_SINGLE:
+            return alloc->make<LiteralString>(
+                span(tok), tok.fodder, tok.data32(), LiteralString::SINGLE, "", "");
+            case Token::STRING_DOUBLE:
+            return alloc->make<LiteralString>(
+                span(tok), tok.fodder, tok.data32(), LiteralString::DOUBLE, "", "");
+            case Token::STRING_BLOCK:
+            return alloc->make<LiteralString>(
+                span(tok), tok.fodder, tok.data32(), LiteralString::BLOCK,
+                tok.stringBlockIndent, tok.stringBlockTermIndent);
 
-            bool got_comma = false;
-            bool first = true;
-            Token next = pop();
+            case Token::FALSE:
+            return alloc->make<LiteralBoolean>(span(tok), tok.fodder, false);
 
-            do {
+            case Token::TRUE:
+            return alloc->make<LiteralBoolean>(span(tok), tok.fodder, true);
 
-                if (next.kind == Token::BRACE_R) {
-                    obj = alloc->make<Object>(
-                        span(tok, next), tok.fodder, fields, got_comma, next.fodder);
-                    return next;
+            case Token::NULL_LIT:
+            return alloc->make<LiteralNull>(span(tok), tok.fodder);
 
-                } else if (next.kind == Token::FOR) {
-                    // It's a comprehension
-                    unsigned num_fields = 0;
-                    unsigned num_asserts = 0;
-                    const ObjectField *field_ptr = nullptr;
-                    for (const auto &field : fields) {
-                        if (field.kind == ObjectField::LOCAL) continue;
-                        if (field.kind == ObjectField::ASSERT) {
-                            num_asserts++;
-                            continue;
-                        }
-                        field_ptr = &field;
-                        num_fields++;
-                    }
-                    if (num_asserts > 0) {
-                        auto msg = "Object comprehension cannot have asserts.";
-                        throw StaticError(next.location, msg);
-                    }
-                    if (num_fields != 1) {
-                        auto msg = "Object comprehension can only have one field.";
-                        throw StaticError(next.location, msg);
-                    }
-                    const ObjectField &field = *field_ptr;
+            // Variables
+            case Token::DOLLAR:
+            return alloc->make<Dollar>(span(tok), tok.fodder);
 
-                    if (field.hide != ObjectField::INHERIT) {
-                        auto msg = "Object comprehensions cannot have hidden fields.";
-                        throw StaticError(next.location, msg);
-                    }
+            case Token::IDENTIFIER:
+            return alloc->make<Var>(span(tok), tok.fodder, alloc->makeIdentifier(tok.data32()));
 
-                    if (field.kind != ObjectField::FIELD_EXPR) {
-                        auto msg = "Object comprehensions can only have [e] fields.";
-                        throw StaticError(next.location, msg);
-                    }
+            case Token::SELF:
+            return alloc->make<Self>(span(tok), tok.fodder);
 
-                    std::vector<ComprehensionSpec> specs;
-                    Token last = parseComprehensionSpecs(Token::BRACE_R, next.fodder, specs);
-                    obj = alloc->make<ObjectComprehension>(
-                        span(tok, last), tok.fodder, fields, got_comma, specs, last.fodder);
-
-                    return last;
-                }
-
-                if (!got_comma && !first)
-                    throw StaticError(next.location, "Expected a comma before next field.");
-
-                first = false;
-                got_comma = false;
-
+            case Token::SUPER: {
+                Token next = pop();
+                AST *index = nullptr;
+                const Identifier *id = nullptr;
+                Fodder id_fodder;
                 switch (next.kind) {
-                    case Token::BRACKET_L: case Token::IDENTIFIER: case Token::STRING_DOUBLE:
-                    case Token::STRING_SINGLE: case Token::STRING_BLOCK: {
-                        ObjectField::Kind kind;
-                        AST *expr1 = nullptr;
-                        const Identifier *id = nullptr;
-                        Fodder fodder1, fodder2;
-                        if (next.kind == Token::IDENTIFIER) {
-                            fodder1 = next.fodder;
-                            kind = ObjectField::FIELD_ID;
-                            id = alloc->makeIdentifier(next.data32());
-                        } else if (next.kind == Token::STRING_DOUBLE) {
-                            kind = ObjectField::FIELD_STR;
-                            expr1 = alloc->make<LiteralString>(
-                                next.location, next.fodder, next.data32(), LiteralString::DOUBLE,
-                                "", "");
-                        } else if (next.kind == Token::STRING_SINGLE) {
-                            kind = ObjectField::FIELD_STR;
-                            expr1 = alloc->make<LiteralString>(
-                                next.location, next.fodder, next.data32(), LiteralString::SINGLE,
-                                "", "");
-                        } else if (next.kind == Token::STRING_BLOCK) {
-                            kind = ObjectField::FIELD_STR;
-                            expr1 = alloc->make<LiteralString>(
-                                next.location, next.fodder, next.data32(), LiteralString::BLOCK,
-                                next.stringBlockIndent, next.stringBlockTermIndent);
-                        } else {
-                            kind = ObjectField::FIELD_EXPR;
-                            fodder1 = next.fodder;
-                            expr1 = parse(MAX_PRECEDENCE);
-                            Token bracket_r = popExpect(Token::BRACKET_R);
-                            fodder2 = bracket_r.fodder;
-                        }
+                    case Token::DOT: {
+                        Token field_id = popExpect(Token::IDENTIFIER);
+                        id_fodder = field_id.fodder;
+                        id = alloc->makeIdentifier(field_id.data32());
+                    } break;
+                    case Token::BRACKET_L: {
+                        index = parse(MAX_PRECEDENCE);
+                        Token bracket_r = popExpect(Token::BRACKET_R);
+                        id_fodder = bracket_r.fodder;  // Not id_fodder, but use the same var.
+                    } break;
+                    default:
+                    throw StaticError(tok.location, "Expected . or [ after super.");
+                }
+                return alloc->make<SuperIndex>(span(tok), tok.fodder, next.fodder, index,
+                                               id_fodder, id);
+            }
+        }
 
-                        bool is_method = false;
-                        bool meth_comma = false;
-                        Params params;
-                        Fodder fodder_l;
-                        Fodder fodder_r;
-                        if (peek().kind == Token::PAREN_L) {
-                            Token paren_l = pop();
-                            fodder_l = paren_l.fodder;
-                            params = parseParams("method parameter", meth_comma, fodder_r);
-                            is_method = true;
-                        }
+        std::cerr << "INTERNAL ERROR: Unknown tok kind: " << tok.kind << std::endl;
+        std::abort();
+        return nullptr;  // Quiet, compiler.
+    }
 
-                        bool plus_sugar = false;
+    AST *parse(int precedence)
+    {
+        Token begin = peek();
 
-                        Token op = popExpect(Token::OPERATOR);
-                        const char *od = op.data.c_str();
-                        if (*od == '+') {
-                            plus_sugar = true;
-                            od++;
-                        }
-                        unsigned colons = 0;
-                        for (; *od != '\0' ; ++od) {
-                            if (*od != ':') {
-                                throw StaticError(
-                                    next.location,
-                                    "Expected one of :, ::, :::, +:, +::, +:::, got: " + op.data);
-                            }
-                            ++colons;
-                        }
-                        ObjectField::Hide field_hide;
-                        switch (colons) {
-                            case 1:
-                            field_hide = ObjectField::INHERIT;
-                            break;
+        switch (begin.kind) {
 
-                            case 2:
-                            field_hide = ObjectField::HIDDEN;
-                            break;
+            // These cases have effectively MAX_PRECEDENCE as the first
+            // call to parse will parse them.
+            case Token::ASSERT: {
+                pop();
+                AST *cond = parse(MAX_PRECEDENCE);
+                Fodder colonFodder;
+                AST *msg = nullptr;
+                if (peek().kind == Token::OPERATOR && peek().data == ":") {
+                    Token colon = pop();
+                    colonFodder = colon.fodder;
+                    msg = parse(MAX_PRECEDENCE);
+                }
+                Token semicolon = popExpect(Token::SEMICOLON);
+                AST *rest = parse(MAX_PRECEDENCE);
+                return alloc->make<Assert>(span(begin, rest), begin.fodder, cond, colonFodder,
+                                           msg, semicolon.fodder, rest);
+            }
 
-                            case 3:
-                            field_hide = ObjectField::VISIBLE;
-                            break;
+            case Token::ERROR: {
+                pop();
+                AST *expr = parse(MAX_PRECEDENCE);
+                return alloc->make<Error>(span(begin, expr), begin.fodder, expr);
+            }
 
-                            default:
-                                throw StaticError(
-                                    next.location,
-                                    "Expected one of :, ::, :::, +:, +::, +:::, got: " + op.data);
-                        }
+            case Token::IF: {
+                pop();
+                AST *cond = parse(MAX_PRECEDENCE);
+                Token then = popExpect(Token::THEN);
+                AST *branch_true = parse(MAX_PRECEDENCE);
+                if (peek().kind == Token::ELSE) {
+                    Token else_ = pop();
+                    AST *branch_false = parse(MAX_PRECEDENCE);
+                    return alloc->make<Conditional>(
+                        span(begin, branch_false), begin.fodder, cond, then.fodder, branch_true,
+                        else_.fodder, branch_false);
+                }
+                return alloc->make<Conditional>(span(begin, branch_true), begin.fodder, cond,
+                                                then.fodder, branch_true, Fodder{}, nullptr);
+            }
 
-                        // Basic checks for invalid Jsonnet code.
-                        if (is_method && plus_sugar) {
-                            throw StaticError(
-                                next.location,
-                                "Cannot use +: syntax sugar in a method: " + next.data);
-                        }
-                        if (kind != ObjectField::FIELD_EXPR) {
-                            if (!literal_fields.insert(next.data).second) {
-                                throw StaticError(next.location, "Duplicate field: "+next.data);
-                            }
-                        }
+            case Token::FUNCTION: {
+                pop();  // Still available in 'begin'.
+                Token paren_l = pop();
+                if (paren_l.kind == Token::PAREN_L) {
+                    std::vector<AST*> params_asts;
+                    bool got_comma;
+                    Fodder paren_r_fodder;
+                    Params params = parseParams(
+                        "function parameter", got_comma, paren_r_fodder);
+                    AST *body = parse(MAX_PRECEDENCE);
+                    return alloc->make<Function>(
+                        span(begin, body), begin.fodder, paren_l.fodder, params, got_comma,
+                        paren_r_fodder, body);
+                } else {
+                    std::stringstream ss;
+                    ss << "Expected ( but got " << paren_l;
+                    throw StaticError(paren_l.location, ss.str());
+                }
+            }
 
-                        AST *body = parse(MAX_PRECEDENCE);
-
-                        Fodder comma_fodder;
-                        next = pop();
-                        if (next.kind == Token::COMMA) {
-                            comma_fodder = next.fodder;
-                            next = pop();
-                            got_comma = true;
-                        }
-                        fields.emplace_back(
-                            kind, fodder1, fodder2, fodder_l, fodder_r, field_hide, plus_sugar,
-                            is_method, expr1, id, params, meth_comma, op.fodder, body, nullptr,
-                            comma_fodder);
+            case Token::IMPORT: {
+                pop();
+                AST *body = parse(MAX_PRECEDENCE);
+                if (auto *lit = dynamic_cast<LiteralString*>(body)) {
+                    if (lit->tokenKind == LiteralString::BLOCK) {
+                        throw StaticError(lit->location,
+                                          "Cannot use text blocks in import statements.");
                     }
+                    return alloc->make<Import>(span(begin, body), begin.fodder, lit);
+                } else {
+                    std::stringstream ss;
+                    ss << "Computed imports are not allowed.";
+                    throw StaticError(body->location, ss.str());
+                }
+            }
+
+            case Token::IMPORTSTR: {
+                pop();
+                AST *body = parse(MAX_PRECEDENCE);
+                if (auto *lit = dynamic_cast<LiteralString*>(body)) {
+                    if (lit->tokenKind == LiteralString::BLOCK) {
+                        throw StaticError(lit->location,
+                                          "Cannot use text blocks in import statements.");
+                    }
+                    return alloc->make<Importstr>(span(begin, body), begin.fodder, lit);
+                } else {
+                    std::stringstream ss;
+                    ss << "Computed imports are not allowed.";
+                    throw StaticError(body->location, ss.str());
+                }
+            }
+
+            case Token::LOCAL: {
+                pop();
+                Local::Binds binds;
+                do {
+                    Token delim = parseBind(binds);
+                    if (delim.kind != Token::SEMICOLON && delim.kind != Token::COMMA) {
+                        std::stringstream ss;
+                        ss << "Expected , or ; but got " << delim;
+                        throw StaticError(delim.location, ss.str());
+                    }
+                    if (delim.kind == Token::SEMICOLON) break;
+                } while (true);
+                AST *body = parse(MAX_PRECEDENCE);
+                return alloc->make<Local>(span(begin, body), begin.fodder, binds, body);
+            }
+
+            default:
+
+            // Unary operator.
+            if (begin.kind == Token::OPERATOR) {
+                UnaryOp uop;
+                if (!op_is_unary(begin.data, uop)) {
+                    std::stringstream ss;
+                    ss << "Not a unary operator: " << begin.data;
+                    throw StaticError(begin.location, ss.str());
+                }
+                if (UNARY_PRECEDENCE == precedence) {
+                    Token op = pop();
+                    AST *expr = parse(precedence);
+                    return alloc->make<Unary>(span(op, expr), op.fodder, uop, expr);
+                }
+            }
+
+            // Base case
+            if (precedence == 0) return parseTerminal();
+
+            AST *lhs = parse(precedence - 1);
+
+            Fodder begin_fodder;
+
+            while (true) {
+
+                // Then next token must be a binary operator.
+
+                // The compiler can't figure out that this is never used uninitialized.
+                BinaryOp bop = BOP_PLUS;
+
+                // Check precedence is correct for this level.  If we're
+                // parsing operators with higher precedence, then return
+                // lhs and let lower levels deal with the operator.
+                switch (peek().kind) {
+                    // Logical / arithmetic binary operator.
+                    case Token::OPERATOR:
+                    if (peek().data == ":") {
+                        // Special case for the colons in assert.
+                        // Since COLON is no-longer a special token, we have to make sure it
+                        // does not trip the op_is_binary test below.  It should
+                        // terminate parsing of the expression here, returning control
+                        // to the parsing of the actual assert AST.
+                        return lhs;
+                    }
+                    if (!op_is_binary(peek().data, bop)) {
+                        std::stringstream ss;
+                        ss << "Not a binary operator: " << peek().data;
+                        throw StaticError(peek().location, ss.str());
+                    }
+                    if (precedence_map[bop] != precedence) return lhs;
                     break;
 
-                    case Token::LOCAL: {
-                        Fodder local_fodder = next.fodder;
-                        Token var_id = popExpect(Token::IDENTIFIER);
-                        auto *id = alloc->makeIdentifier(var_id.data32());
-
-                        if (binds.find(id) != binds.end()) {
-                            throw StaticError(var_id.location,
-                                              "Duplicate local var: " + var_id.data);
-                        }
-                        bool is_method = false;
-                        bool func_comma = false;
-                        Params params;
-                        Fodder paren_l_fodder;
-                        Fodder paren_r_fodder;
-                        if (peek().kind == Token::PAREN_L) {
-                            Token paren_l = pop();
-                            paren_l_fodder = paren_l.fodder;
-                            is_method = true;
-                            params = parseParams("function parameter", func_comma, paren_r_fodder);
-                        }
-                        Token eq = popExpect(Token::OPERATOR, "=");
-                        AST *body = parse(MAX_PRECEDENCE);
-                        binds.insert(id);
-
-                        Fodder comma_fodder;
-                        next = pop();
-                        if (next.kind == Token::COMMA) {
-                            comma_fodder = next.fodder;
-                            next = pop();
-                            got_comma = true;
-                        }
-                        fields.push_back(
-                            ObjectField::Local(
-                                local_fodder, var_id.fodder, paren_l_fodder, paren_r_fodder,
-                                is_method, id, params, func_comma, eq.fodder, body, comma_fodder));
-
-                    }
-                    break;
-
-                    case Token::ASSERT: {
-                        Fodder assert_fodder = next.fodder;
-                        AST *cond = parse(MAX_PRECEDENCE);
-                        AST *msg = nullptr;
-                        Fodder colon_fodder;
-                        if (peek().kind == Token::OPERATOR && peek().data == ":") {
-                            Token colon = pop();
-                            colon_fodder = colon.fodder;
-                            msg = parse(MAX_PRECEDENCE);
-                        }
-
-                        Fodder comma_fodder;
-                        next = pop();
-                        if (next.kind == Token::COMMA) {
-                            comma_fodder = next.fodder;
-                            next = pop();
-                            got_comma = true;
-                        }
-                        fields.push_back(ObjectField::Assert(assert_fodder, cond, colon_fodder, msg,
-                                         comma_fodder));
-                    }
+                    // Index, Apply
+                    case Token::DOT: case Token::BRACKET_L:
+                    case Token::PAREN_L: case Token::BRACE_L:
+                    if (APPLY_PRECEDENCE != precedence) return lhs;
                     break;
 
                     default:
-                    throw unexpected(next, "parsing field definition");
+                    return lhs;
                 }
 
+                Token op = pop();
+                if (op.kind == Token::BRACKET_L) {
+                    bool is_slice;
+                    AST *first = nullptr;
+                    Fodder second_fodder;
+                    AST *second = nullptr;
+                    Fodder third_fodder;
+                    AST *third = nullptr;
 
-            } while (true);
-        }
+                    if (peek().kind == Token::BRACKET_R)
+                        throw unexpected(pop(), "parsing index");
 
-        /** parses for x in expr for y in expr if expr for z in expr ... */
-        Token parseComprehensionSpecs(Token::Kind end, Fodder for_fodder,
-                                      std::vector<ComprehensionSpec> &specs)
-        {
-            while (true) {
-                LocationRange l;
-                Token id_token = popExpect(Token::IDENTIFIER);
-                const Identifier *id = alloc->makeIdentifier(id_token.data32());
-                Token in_token = popExpect(Token::IN);
-                AST *arr = parse(MAX_PRECEDENCE);
-                specs.emplace_back(ComprehensionSpec::FOR, for_fodder, id_token.fodder, id,
-                                   in_token.fodder, arr);
-
-                Token maybe_if = pop();
-                for (; maybe_if.kind == Token::IF; maybe_if = pop()) {
-                    AST *cond = parse(MAX_PRECEDENCE);
-                    specs.emplace_back(ComprehensionSpec::IF, maybe_if.fodder, Fodder{}, nullptr,
-                                       Fodder{}, cond);
-                }
-                if (maybe_if.kind == end) {
-                    return maybe_if;
-                }
-                if (maybe_if.kind != Token::FOR) {
-                    std::stringstream ss;
-                    ss << "Expected for, if or " << end << " after for clause, got: " << maybe_if;
-                    throw StaticError(maybe_if.location, ss.str());
-                }
-                for_fodder = maybe_if.fodder;
-            } 
-        }
-
-        AST *parseTerminal(void)
-        {
-            Token tok = pop();
-            switch (tok.kind) {
-                case Token::ASSERT:
-                case Token::BRACE_R:
-                case Token::BRACKET_R:
-                case Token::COMMA:
-                case Token::DOT:
-                case Token::ELSE:
-                case Token::ERROR:
-                case Token::FOR:
-                case Token::FUNCTION:
-                case Token::IF:
-                case Token::IN:
-                case Token::IMPORT:
-                case Token::IMPORTSTR:
-                case Token::LOCAL:
-                case Token::OPERATOR:
-                case Token::PAREN_R:
-                case Token::SEMICOLON:
-                case Token::TAILSTRICT:
-                case Token::THEN:
-                throw unexpected(tok, "parsing terminal");
-
-                case Token::END_OF_FILE:
-                throw StaticError(tok.location, "Unexpected end of file.");
-
-                case Token::BRACE_L: {
-                    AST *obj;
-                    parseObjectRemainder(obj, tok);
-                    return obj;
-                }
-
-                case Token::BRACKET_L: {
-                    Token next = peek();
-                    if (next.kind == Token::BRACKET_R) {
-                        Token bracket_r = pop();
-                        return alloc->make<Array>(span(tok, next), tok.fodder, Array::Elements{},
-                                                  false, bracket_r.fodder);
-                    }
-                    AST *first = parse(MAX_PRECEDENCE);
-                    bool got_comma = false;
-                    Fodder comma_fodder;
-                    next = peek();
-                    if (!got_comma && next.kind == Token::COMMA) {
-                        Token comma = pop();
-                        comma_fodder = comma.fodder;
-                        next = peek();
-                        got_comma = true;
-                    }
- 
-                    if (next.kind == Token::FOR) {
-                        // It's a comprehension
-                        Token for_token = pop();
-                        std::vector<ComprehensionSpec> specs;
-                        Token last = parseComprehensionSpecs(Token::BRACKET_R, for_token.fodder,
-                                                             specs);
-                        return alloc->make<ArrayComprehension>(
-                            span(tok, last), tok.fodder, first, comma_fodder, got_comma, specs,
-                            last.fodder);
+                    // break up "::" into ":", ":" before we start parsing.
+                    if (peek().kind == Token::OPERATOR && peek().data == "::") {
+                        Token joined = pop();
+                        push(Token(Token::OPERATOR, joined.fodder, ":", "", "", joined.location));
+                        push(Token(Token::OPERATOR, Fodder{}, ":", "", "", joined.location));
                     }
 
-                    // Not a comprehension: It can have more elements.
-                    Array::Elements elements;
-                    elements.emplace_back(first, comma_fodder);
-                    do {
-                        if (next.kind == Token::BRACKET_R) {
-                            Token bracket_r = pop();
-                            return alloc->make<Array>(
-                                span(tok, next), tok.fodder, elements, got_comma, bracket_r.fodder);
-                        }
-                        if (!got_comma) {
-                            std::stringstream ss;
-                            ss << "Expected a comma before next array element.";
-                            throw StaticError(next.location, ss.str());
-                        }
-                        AST *expr = parse(MAX_PRECEDENCE);
-                        comma_fodder.clear();
-                        got_comma = false;
-                        next = peek();
-                        if (next.kind == Token::COMMA) {
-                            Token comma = pop();
-                            comma_fodder = comma.fodder;
-                            next = peek();
-                            got_comma = true;
-                        }
-                        elements.emplace_back(expr, comma_fodder);
-                    } while (true);
-                }
-
-                case Token::PAREN_L: {
-                    auto *inner = parse(MAX_PRECEDENCE);
-                    Token close = popExpect(Token::PAREN_R);
-                    return alloc->make<Parens>(span(tok, close), tok.fodder, inner, close.fodder);
-                }
-
-
-                // Literals
-                case Token::NUMBER:
-                return alloc->make<LiteralNumber>(span(tok), tok.fodder, tok.data);
-
-                case Token::STRING_SINGLE:
-                return alloc->make<LiteralString>(
-                    span(tok), tok.fodder, tok.data32(), LiteralString::SINGLE, "", "");
-                case Token::STRING_DOUBLE:
-                return alloc->make<LiteralString>(
-                    span(tok), tok.fodder, tok.data32(), LiteralString::DOUBLE, "", "");
-                case Token::STRING_BLOCK:
-                return alloc->make<LiteralString>(
-                    span(tok), tok.fodder, tok.data32(), LiteralString::BLOCK,
-                    tok.stringBlockIndent, tok.stringBlockTermIndent);
-
-                case Token::FALSE:
-                return alloc->make<LiteralBoolean>(span(tok), tok.fodder, false);
-
-                case Token::TRUE:
-                return alloc->make<LiteralBoolean>(span(tok), tok.fodder, true);
-
-                case Token::NULL_LIT:
-                return alloc->make<LiteralNull>(span(tok), tok.fodder);
-
-                // Variables
-                case Token::DOLLAR:
-                return alloc->make<Dollar>(span(tok), tok.fodder);
-
-                case Token::IDENTIFIER:
-                return alloc->make<Var>(span(tok), tok.fodder, alloc->makeIdentifier(tok.data32()));
-
-                case Token::SELF:
-                return alloc->make<Self>(span(tok), tok.fodder);
-
-                case Token::SUPER: {
-                    Token next = pop();
-                    AST *index = nullptr;
-                    const Identifier *id = nullptr;
-                    Fodder id_fodder;
-                    switch (next.kind) {
-                        case Token::DOT: {
-                            Token field_id = popExpect(Token::IDENTIFIER);
-                            id_fodder = field_id.fodder;
-                            id = alloc->makeIdentifier(field_id.data32());
-                        } break;
-                        case Token::BRACKET_L: {
-                            index = parse(MAX_PRECEDENCE);
-                            Token bracket_r = popExpect(Token::BRACKET_R);
-                            id_fodder = bracket_r.fodder;  // Not id_fodder, but use the same var.
-                        } break;
-                        default:
-                        throw StaticError(tok.location, "Expected . or [ after super.");
+                    Token first_token = pop();
+                    if (peek().kind == Token::OPERATOR && peek().data == "::") {
+                        Token joined = pop();
+                        push(Token(Token::OPERATOR, joined.fodder, ":", "", "", joined.location));
+                        push(Token(Token::OPERATOR, Fodder{}, ":", "", "", joined.location));
                     }
-                    return alloc->make<SuperIndex>(span(tok), tok.fodder, next.fodder, index,
-                                                   id_fodder, id);
-                }
-            }
+                    push(first_token);
 
-            std::cerr << "INTERNAL ERROR: Unknown tok kind: " << tok.kind << std::endl;
-            std::abort();
-            return nullptr;  // Quiet, compiler.
-        }
+                    if (peek().data != ":")
+                        first = parse(MAX_PRECEDENCE);
 
-        AST *parse(int precedence)
-        {
-            Token begin = peek();
+                    if (peek().kind != Token::BRACKET_R) {
+                        is_slice = true;
+                        Token delim = pop();
+                        if (delim.data != ":")
+                            throw unexpected(delim, "parsing slice");
 
-            switch (begin.kind) {
+                        second_fodder = delim.fodder;
 
-                // These cases have effectively MAX_PRECEDENCE as the first
-                // call to parse will parse them.
-                case Token::ASSERT: {
-                    pop();
-                    AST *cond = parse(MAX_PRECEDENCE);
-                    Fodder colonFodder;
-                    AST *msg = nullptr;
-                    if (peek().kind == Token::OPERATOR && peek().data == ":") {
-                        Token colon = pop();
-                        colonFodder = colon.fodder;
-                        msg = parse(MAX_PRECEDENCE);
-                    }
-                    Token semicolon = popExpect(Token::SEMICOLON);
-                    AST *rest = parse(MAX_PRECEDENCE);
-                    return alloc->make<Assert>(span(begin, rest), begin.fodder, cond, colonFodder,
-                                               msg, semicolon.fodder, rest);
-                }
-
-                case Token::ERROR: {
-                    pop();
-                    AST *expr = parse(MAX_PRECEDENCE);
-                    return alloc->make<Error>(span(begin, expr), begin.fodder, expr);
-                }
-
-                case Token::IF: {
-                    pop();
-                    AST *cond = parse(MAX_PRECEDENCE);
-                    Token then = popExpect(Token::THEN);
-                    AST *branch_true = parse(MAX_PRECEDENCE);
-                    if (peek().kind == Token::ELSE) {
-                        Token else_ = pop();
-                        AST *branch_false = parse(MAX_PRECEDENCE);
-						return alloc->make<Conditional>(
-							span(begin, branch_false), begin.fodder, cond, then.fodder, branch_true,
-							else_.fodder, branch_false);
-                    }
-                    return alloc->make<Conditional>(span(begin, branch_true), begin.fodder, cond,
-                                                    then.fodder, branch_true, Fodder{}, nullptr);
-                }
-
-                case Token::FUNCTION: {
-                    pop();  // Still available in 'begin'.
-                    Token paren_l = pop();
-                    if (paren_l.kind == Token::PAREN_L) {
-                        std::vector<AST*> params_asts;
-                        bool got_comma;
-                        Fodder paren_r_fodder;
-                        Params params = parseParams(
-                            "function parameter", got_comma, paren_r_fodder);
-                        AST *body = parse(MAX_PRECEDENCE);
-                        return alloc->make<Function>(
-                            span(begin, body), begin.fodder, paren_l.fodder, params, got_comma,
-                            paren_r_fodder, body);
-                    } else {
-                        std::stringstream ss;
-                        ss << "Expected ( but got " << paren_l;
-                        throw StaticError(paren_l.location, ss.str());
-                    }
-                }
-
-                case Token::IMPORT: {
-                    pop();
-                    AST *body = parse(MAX_PRECEDENCE);
-                    if (auto *lit = dynamic_cast<LiteralString*>(body)) {
-                        if (lit->tokenKind == LiteralString::BLOCK) {
-                            throw StaticError(lit->location,
-                                              "Cannot use text blocks in import statements.");
-                        }
-                        return alloc->make<Import>(span(begin, body), begin.fodder, lit);
-                    } else {
-                        std::stringstream ss;
-                        ss << "Computed imports are not allowed.";
-                        throw StaticError(body->location, ss.str());
-                    }
-                }
-
-                case Token::IMPORTSTR: {
-                    pop();
-                    AST *body = parse(MAX_PRECEDENCE);
-                    if (auto *lit = dynamic_cast<LiteralString*>(body)) {
-                        if (lit->tokenKind == LiteralString::BLOCK) {
-                            throw StaticError(lit->location,
-                                              "Cannot use text blocks in import statements.");
-                        }
-                        return alloc->make<Importstr>(span(begin, body), begin.fodder, lit);
-                    } else {
-                        std::stringstream ss;
-                        ss << "Computed imports are not allowed.";
-                        throw StaticError(body->location, ss.str());
-                    }
-                }
-
-                case Token::LOCAL: {
-                    pop();
-                    Local::Binds binds;
-                    do {
-                        Token delim = parseBind(binds);
-                        if (delim.kind != Token::SEMICOLON && delim.kind != Token::COMMA) {
-                            std::stringstream ss;
-                            ss << "Expected , or ; but got " << delim;
-                            throw StaticError(delim.location, ss.str());
-                        }
-                        if (delim.kind == Token::SEMICOLON) break;
-                    } while (true);
-                    AST *body = parse(MAX_PRECEDENCE);
-                    return alloc->make<Local>(span(begin, body), begin.fodder, binds, body);
-                }
-
-                default:
-
-                // Unary operator.
-                if (begin.kind == Token::OPERATOR) {
-                    UnaryOp uop;
-                    if (!op_is_unary(begin.data, uop)) {
-                        std::stringstream ss;
-                        ss << "Not a unary operator: " << begin.data;
-                        throw StaticError(begin.location, ss.str());
-                    }
-                    if (UNARY_PRECEDENCE == precedence) {
-                        Token op = pop();
-                        AST *expr = parse(precedence);
-                        return alloc->make<Unary>(span(op, expr), op.fodder, uop, expr);
-                    }
-                }
-
-                // Base case
-                if (precedence == 0) return parseTerminal();
-
-                AST *lhs = parse(precedence - 1);
-
-				Fodder begin_fodder;
-
-                while (true) {
-
-                    // Then next token must be a binary operator.
-
-                    // The compiler can't figure out that this is never used uninitialized.
-                    BinaryOp bop = BOP_PLUS;
-
-                    // Check precedence is correct for this level.  If we're
-                    // parsing operators with higher precedence, then return
-                    // lhs and let lower levels deal with the operator.
-                    switch (peek().kind) {
-                        // Logical / arithmetic binary operator.
-                        case Token::OPERATOR:
-                        if (peek().data == ":") {
-                            // Special case for the colons in assert.
-                            // Since COLON is no-longer a special token, we have to make sure it
-                            // does not trip the op_is_binary test below.  It should
-                            // terminate parsing of the expression here, returning control
-                            // to the parsing of the actual assert AST.
-                            return lhs;
-                        }
-                        if (!op_is_binary(peek().data, bop)) {
-                            std::stringstream ss;
-                            ss << "Not a binary operator: " << peek().data;
-                            throw StaticError(peek().location, ss.str());
-                        }
-                        if (precedence_map[bop] != precedence) return lhs;
-                        break;
-
-                        // Index, Apply
-                        case Token::DOT: case Token::BRACKET_L:
-                        case Token::PAREN_L: case Token::BRACE_L:
-                        if (APPLY_PRECEDENCE != precedence) return lhs;
-                        break;
-
-                        default:
-                        return lhs;
-                    }
-
-                    Token op = pop();
-                    if (op.kind == Token::BRACKET_L) {
-                        bool is_slice;
-                        AST *first = nullptr;
-                        Fodder second_fodder;
-                        AST *second = nullptr;
-                        Fodder third_fodder;
-                        AST *third = nullptr;
-
-                        if (peek().kind == Token::BRACKET_R)
-                            throw unexpected(pop(), "parsing index");
-
-                        // break up "::" into ":", ":" before we start parsing.
-                        if (peek().kind == Token::OPERATOR && peek().data == "::") {
-                            Token joined = pop();
-                            push(Token(Token::OPERATOR, joined.fodder, ":", "", "",
-                                       joined.location));
-                            push(Token(Token::OPERATOR, Fodder{}, ":", "", "", joined.location));
-                        }
-
-                        Token first_token = pop();
-                        if (peek().kind == Token::OPERATOR && peek().data == "::") {
-                            Token joined = pop();
-                            push(Token(Token::OPERATOR, joined.fodder, ":", "", "",
-                                       joined.location));
-                            push(Token(Token::OPERATOR, Fodder{}, ":", "", "", joined.location));
-                        }
-                        push(first_token);
-
-                        if (peek().data != ":")
-                            first = parse(MAX_PRECEDENCE);
+                        if (peek().data != ":" && peek().kind != Token::BRACKET_R)
+                            second = parse(MAX_PRECEDENCE);
 
                         if (peek().kind != Token::BRACKET_R) {
-                            is_slice = true;
                             Token delim = pop();
                             if (delim.data != ":")
                                 throw unexpected(delim, "parsing slice");
 
-                            second_fodder = delim.fodder;
+                            third_fodder = delim.fodder;
 
-                            if (peek().data != ":" &&
-                                peek().kind != Token::BRACKET_R)
-                                second = parse(MAX_PRECEDENCE);
-
-                            if (peek().kind != Token::BRACKET_R) {
-
-                                Token delim = pop();
-                                if (delim.data != ":")
-                                    throw unexpected(delim, "parsing slice");
-
-                                third_fodder = delim.fodder;
-
-                                if (peek().kind != Token::BRACKET_R)
-                                    third= parse(MAX_PRECEDENCE);
-                            }
-                        } else {
-                            is_slice = false;
+                            if (peek().kind != Token::BRACKET_R)
+                                third= parse(MAX_PRECEDENCE);
                         }
-                        Token end = popExpect(Token::BRACKET_R);
-                        lhs = alloc->make<Index>(span(begin, end), begin_fodder, lhs, op.fodder,
-                                                 is_slice, first, second_fodder, second,
-                                                 third_fodder, third, end.fodder);
-
-                    } else if (op.kind == Token::DOT) {
-                        Token field_id = popExpect(Token::IDENTIFIER);
-                        const Identifier *id = alloc->makeIdentifier(field_id.data32());
-                        lhs = alloc->make<Index>(span(begin, field_id), begin_fodder, lhs,
-                                                 op.fodder, field_id.fodder, id);
-
-                    } else if (op.kind == Token::PAREN_L) {
-                        std::vector<std::pair<AST*, Fodder>> args;
-                        bool got_comma;
-                        Token end = parseCommaList(args, Token::PAREN_R,
-                                                   "function argument", got_comma);
-                        bool tailstrict = false;
-                        Fodder tailstrict_fodder;
-                        if (peek().kind == Token::TAILSTRICT) {
-                            Token tailstrict_token = pop();
-                            tailstrict_fodder = tailstrict_token.fodder;
-                            tailstrict = true;
-                        }
-                        Apply::Args args2;
-                        for (const auto &pair : args) args2.emplace_back(pair.first, pair.second);
-                        lhs = alloc->make<Apply>(span(begin, end), begin_fodder, lhs, op.fodder,
-                                                 args2, got_comma, end.fodder, tailstrict_fodder,
-                                                 tailstrict);
-
-                    } else if (op.kind == Token::BRACE_L) {
-                        AST *obj;
-                        Token end = parseObjectRemainder(obj, op);
-                        lhs = alloc->make<ApplyBrace>(span(begin, end), begin_fodder, lhs, obj);
-
                     } else {
-                        // Logical / arithmetic binary operator.
-                        assert(op.kind == Token::OPERATOR);
-                        AST *rhs = parse(precedence - 1);
-                        lhs = alloc->make<Binary>(span(begin, rhs), begin_fodder, lhs, op.fodder,
-                                                  bop, rhs);
+                        is_slice = false;
                     }
+                    Token end = popExpect(Token::BRACKET_R);
+                    lhs = alloc->make<Index>(span(begin, end), begin_fodder, lhs, op.fodder,
+                                             is_slice, first, second_fodder, second,
+                                             third_fodder, third, end.fodder);
 
-					begin_fodder.clear();
+                } else if (op.kind == Token::DOT) {
+                    Token field_id = popExpect(Token::IDENTIFIER);
+                    const Identifier *id = alloc->makeIdentifier(field_id.data32());
+                    lhs = alloc->make<Index>(span(begin, field_id), begin_fodder, lhs,
+                                             op.fodder, field_id.fodder, id);
+
+                } else if (op.kind == Token::PAREN_L) {
+                    std::vector<std::pair<AST*, Fodder>> args;
+                    bool got_comma;
+                    Token end = parseCommaList(args, Token::PAREN_R,
+                                               "function argument", got_comma);
+                    bool tailstrict = false;
+                    Fodder tailstrict_fodder;
+                    if (peek().kind == Token::TAILSTRICT) {
+                        Token tailstrict_token = pop();
+                        tailstrict_fodder = tailstrict_token.fodder;
+                        tailstrict = true;
+                    }
+                    Apply::Args args2;
+                    for (const auto &pair : args) args2.emplace_back(pair.first, pair.second);
+                    lhs = alloc->make<Apply>(span(begin, end), begin_fodder, lhs, op.fodder,
+                                             args2, got_comma, end.fodder, tailstrict_fodder,
+                                             tailstrict);
+
+                } else if (op.kind == Token::BRACE_L) {
+                    AST *obj;
+                    Token end = parseObjectRemainder(obj, op);
+                    lhs = alloc->make<ApplyBrace>(span(begin, end), begin_fodder, lhs, obj);
+
+                } else {
+                    // Logical / arithmetic binary operator.
+                    assert(op.kind == Token::OPERATOR);
+                    AST *rhs = parse(precedence - 1);
+                    lhs = alloc->make<Binary>(span(begin, rhs), begin_fodder, lhs, op.fodder,
+                                              bop, rhs);
                 }
+
+                begin_fodder.clear();
             }
         }
+    }
 
-    };
-}
+};
+
+}  // namespace
 
 AST *jsonnet_parse(Allocator *alloc, Tokens &tokens)
 {

--- a/core/state.h
+++ b/core/state.h
@@ -19,415 +19,415 @@ limitations under the License.
 
 namespace {
 
-    /** Mark & sweep: advanced by 1 each GC cycle.
-     */
-    typedef unsigned char GarbageCollectionMark;
+/** Mark & sweep: advanced by 1 each GC cycle.
+ */
+typedef unsigned char GarbageCollectionMark;
 
-    /** Supertype of everything that is allocated on the heap.
-     */
-    struct HeapEntity {
-        GarbageCollectionMark mark;
-        virtual ~HeapEntity() { }
+/** Supertype of everything that is allocated on the heap.
+ */
+struct HeapEntity {
+    GarbageCollectionMark mark;
+    virtual ~HeapEntity() { }
+};
+
+/** Tagged union of all values.
+ *
+ * Primitives (<= 8 bytes) are copied by value.  Otherwise a pointer to a HeapEntity is used.
+ */
+struct Value {
+    enum Type {
+        NULL_TYPE = 0x0,  // Unfortunately NULL is a macro in C.
+        BOOLEAN = 0x1,
+        DOUBLE = 0x2,
+
+        ARRAY = 0x10,
+        FUNCTION = 0x11,
+        OBJECT = 0x12,
+        STRING = 0x13
     };
-
-    /** Tagged union of all values.
-     *
-     * Primitives (<= 8 bytes) are copied by value.  Otherwise a pointer to a HeapEntity is used.
-     */
-    struct Value {
-        enum Type {
-            NULL_TYPE = 0x0,  // Unfortunately NULL is a macro in C.
-            BOOLEAN = 0x1,
-            DOUBLE = 0x2,
-
-            ARRAY = 0x10,
-            FUNCTION = 0x11,
-            OBJECT = 0x12,
-            STRING = 0x13
-        };
-        Type t;
-        union {
-            HeapEntity *h;
-            double d;
-            bool b;
-        } v;
-        bool isHeap(void) const
-        {
-            return t & 0x10;
-        }
-    };
-
-    /** Convert the type into a string, for error messages. */
-    std::string type_str(Value::Type t)
+    Type t;
+    union {
+        HeapEntity *h;
+        double d;
+        bool b;
+    } v;
+    bool isHeap(void) const
     {
-        switch (t) {
-            case Value::NULL_TYPE: return "null";
-            case Value::BOOLEAN: return "boolean";
-            case Value::DOUBLE: return "double";
-            case Value::ARRAY: return "array";
-            case Value::FUNCTION: return "function";
-            case Value::OBJECT: return "object";
-            case Value::STRING: return "string";
-            default:
-            std::cerr << "INTERNAL ERROR: Unknown type: " << t << std::endl;
-            std::abort();
-            return "";  // Quiet, compiler.
-        }
+        return t & 0x10;
     }
+};
 
-    /** Convert the value's type into a string, for error messages. */
-    std::string type_str(const Value &v)
-    {
-        return type_str(v.t);
+/** Convert the type into a string, for error messages. */
+std::string type_str(Value::Type t)
+{
+    switch (t) {
+        case Value::NULL_TYPE: return "null";
+        case Value::BOOLEAN: return "boolean";
+        case Value::DOUBLE: return "double";
+        case Value::ARRAY: return "array";
+        case Value::FUNCTION: return "function";
+        case Value::OBJECT: return "object";
+        case Value::STRING: return "string";
+        default:
+        std::cerr << "INTERNAL ERROR: Unknown type: " << t << std::endl;
+        std::abort();
+        return "";  // Quiet, compiler.
     }
-
-    struct HeapThunk;
-
-    /** Stores the values bound to variables.
-     *
-     * Each nested local statement, function call, and field access has its own binding frame to
-     * give the values for the local variable, function parameters, or upValues.
-     */
-    typedef std::map<const Identifier*, HeapThunk*> BindingFrame;
-
-    /** Supertype of all objects.  Types of Value::OBJECT will point at these.  */
-    struct HeapObject : public HeapEntity {
-    };
-
-    /** Hold an unevaluated expression.  This implements lazy semantics.
-     */
-    struct HeapThunk : public HeapEntity {
-        /** Whether or not the thunk was forced. */
-        bool filled;
-
-        /** The result when the thunk was forced, if filled == true. */
-        Value content;
-
-        /** Used in error tracebacks. */
-        const Identifier *name;
-
-        /** The captured environment.
-         *
-         * Note, this is non-const because we have to add cyclic references to it.
-         */
-        BindingFrame upValues;
-
-        /** The captured self variable, or nullptr if there was none.  \see CallFrame. */
-        HeapObject *self;
-
-        /** The offset from the captured self variable. \see CallFrame. */
-        unsigned offset;
-
-        /** Evaluated to force the thunk. */
-        const AST *body;
-
-        HeapThunk(const Identifier *name, HeapObject *self, unsigned offset, const AST *body)
-          : filled(false), name(name), self(self), offset(offset), body(body)
-        { }
-
-        void fill(const Value &v)
-        {
-            content = v;
-            filled = true;
-            self = nullptr;
-            upValues.clear();
-        }
-    };
-
-    struct HeapArray : public HeapEntity {
-        // It is convenient for this to not be const, so that we can add elements to it one at a
-        // time after creation.  Thus, elements are not GCed as the array is being
-        // created.
-        std::vector<HeapThunk*> elements;
-        HeapArray(const std::vector<HeapThunk*> &elements)
-          : elements(elements)
-        { }
-    };
-
-    /** Supertype of all objects that are not super objects or extended objects.  */
-    struct HeapLeafObject : public HeapObject {
-    };
-
-    /** Objects created via the simple object constructor construct. */
-    struct HeapSimpleObject : public HeapLeafObject {
-        /** The captured environment. */
-        const BindingFrame upValues;
-
-        struct Field {
-            /** Will the field appear in output? */
-            ObjectField::Hide hide;
-            /** Expression that is evaluated when indexing this field. */
-            AST *body;
-        };
-
-        /** The fields.
-         *
-         * These are evaluated in the captured environment and with self and super bound
-         * dynamically.
-         */
-        const std::map<const Identifier*, Field> fields;
-
-        /** The object's invariants.
-         *
-         * These are evaluated in the captured environment with self and super bound.
-         */
-        std::vector<AST*> asserts;
-
-        HeapSimpleObject(const BindingFrame &up_values,
-                         const std::map<const Identifier*, Field> fields, std::vector<AST*> asserts)
-          : upValues(up_values), fields(fields), asserts(asserts)
-        { }
-    };
-
-    /** Objects created by the extendby construct. */
-    struct HeapExtendedObject : public HeapObject {
-        /** The left hand side of the construct. */
-        HeapObject *left;
-
-        /** The right hand side of the construct. */
-        HeapObject *right;
-
-        HeapExtendedObject(HeapObject *left, HeapObject *right)
-          : left(left), right(right)
-        { }
-    };
-
-    /** Objects created by the ObjectComprehensionSimple construct. */
-    struct HeapComprehensionObject : public HeapLeafObject {
-
-        /** The captured environment. */
-        const BindingFrame upValues;
-
-        /** The expression used to compute the field values.  */
-        const AST* value;
-
-        /** The identifier of bound variable in that construct.  */
-        const Identifier * const id;
-
-        /** Binding for id.
-         *
-         * For each field, holds the value that should be bound to id.  This is the corresponding
-         * array element from the original array used to define this object.  This should not really
-         * be a thunk, but it makes the implementation easier.
-         */
-        const std::map<const Identifier*, HeapThunk*> compValues;
-
-        HeapComprehensionObject(const BindingFrame &up_values, const AST *value,
-                                const Identifier *id,
-                                const std::map<const Identifier*, HeapThunk*> &comp_values)
-          : upValues(up_values), value(value), id(id), compValues(comp_values)
-        { }
-    };
-
-    /** Stores the function itself and also the captured environment.
-     *
-     * Either body is non-null and builtin is 0, or body is null and builtin refers to a built-in
-     * function.  In the former case, the closure represents a user function, otherwise calling it
-     * will trigger the builtin function to execute.  Params is empty when the function is a
-     * builtin.
-     */
-    struct HeapClosure : public HeapEntity {
-        /** The captured environment. */
-        const BindingFrame upValues;
-        /** The captured self variable, or nullptr if there was none.  \see Frame. */
-        HeapObject *self;
-        /** The offset from the captured self variable.  \see Frame.*/
-        unsigned offset;
-        const std::vector<const Identifier*> params;
-        const AST *body;
-        const unsigned long builtin;
-        HeapClosure(const BindingFrame &up_values,
-                     HeapObject *self,
-                     unsigned offset,
-                     const std::vector<const Identifier*> &params,
-                     const AST *body, unsigned long builtin)
-          : upValues(up_values), self(self), offset(offset),
-            params(params), body(body), builtin(builtin)
-        { }
-    };
-
-    /** Stores a simple string on the heap. */
-    struct HeapString : public HeapEntity {
-        const String value;
-        HeapString(const String &value)
-          : value(value)
-        { }
-    };
-
-    /** The heap does memory management, i.e. garbage collection. */
-    class Heap {
-
-        /** How many objects must exist in the heap before we bother doing garbage collection?
-         */
-        unsigned gcTuneMinObjects;
-
-        /** How much must the heap have grown since the last cycle to trigger a collection?
-         */
-        double gcTuneGrowthTrigger;
-
-        /** Value used to mark entities at the last garbage collection cycle. */
-        GarbageCollectionMark lastMark;
-
-        /** The heap entities (strings, arrays, objects, functions, etc).
-         *
-         * Not all may be reachable, all should have o->mark == this->lastMark.  Entities are
-         * removed from the heap via O(1) swap with last element, so the ordering of entities is
-         * arbitrary and changes every garbage collection cycle.
-         */
-        std::vector<HeapEntity*> entities;
-
-        /** The number of heap entities at the last garbage collection cycle. */
-        unsigned long lastNumEntities;
-
-        /** The number of heap entities now. */
-        unsigned long numEntities;
-
-        /** Add the HeapEntity inside v to vec, if the value exists on the heap.   
-         */
-        void addIfHeapEntity(Value v, std::vector<HeapEntity*> &vec)
-        {
-            if (v.isHeap()) vec.push_back(v.v.h);
-        }
-
-        /** Add the HeapEntity inside v to vec, if the value exists on the heap.   
-         */
-        void addIfHeapEntity(HeapEntity *v, std::vector<HeapEntity*> &vec)
-        {
-            vec.push_back(v);
-        }
-
-        public:
-
-        Heap(unsigned gc_tune_min_objects, double gc_tune_growth_trigger)
-          : gcTuneMinObjects(gc_tune_min_objects), gcTuneGrowthTrigger(gc_tune_growth_trigger),
-            lastMark(0), lastNumEntities(0), numEntities(0)
-        {
-        }
-
-        ~Heap(void)
-        {
-            // Nothing is marked, everything will be collected.
-            sweep();
-        }
-
-        /** Garbage collection: Mark v, and entities reachable from v. */
-        void markFrom(Value v)
-        {
-            if (v.isHeap()) markFrom(v.v.h);
-        }
-
-        /** Garbage collection: Mark heap entities reachable from the given heap entity. */
-        void markFrom(HeapEntity *from)
-        {
-            assert(from != nullptr);
-            const GarbageCollectionMark thisMark = lastMark + 1;
-            struct State {
-                HeapEntity *ent;
-                std::vector<HeapEntity*> children;
-                State(HeapEntity *ent) : ent(ent) { }
-            };
-
-            std::vector<State> stack;
-            stack.emplace_back(from);
-
-            while (stack.size() > 0) {
-                size_t curr_index = stack.size() - 1;
-                State &s = stack[curr_index];
-                HeapEntity *curr = s.ent;
-                if (curr->mark != thisMark) {
-                    curr->mark = thisMark;
-
-                    if (auto *obj = dynamic_cast<HeapSimpleObject*>(curr)) {
-                        for (auto upv : obj->upValues)
-                            addIfHeapEntity(upv.second, s.children);
-
-                    } else if (auto *obj = dynamic_cast<HeapExtendedObject*>(curr)) {
-                        addIfHeapEntity(obj->left, s.children);
-                        addIfHeapEntity(obj->right, s.children);
-
-                    } else if (auto *obj = dynamic_cast<HeapComprehensionObject*>(curr)) {
-                        for (auto upv : obj->upValues)
-                            addIfHeapEntity(upv.second, s.children);
-                        for (auto upv : obj->compValues)
-                            addIfHeapEntity(upv.second, s.children);
-
-
-                    } else if (auto *arr = dynamic_cast<HeapArray*>(curr)) {
-                        for (auto el : arr->elements)
-                            addIfHeapEntity(el, s.children);
-
-                    } else if (auto *func = dynamic_cast<HeapClosure*>(curr)) {
-                        for (auto upv : func->upValues)
-                            addIfHeapEntity(upv.second, s.children);
-                        if (func->self)
-                            addIfHeapEntity(func->self, s.children);
-
-                    } else if (auto *thunk = dynamic_cast<HeapThunk*>(curr)) {
-                        if (thunk->filled) {
-                            if (thunk->content.isHeap())
-                                addIfHeapEntity(thunk->content.v.h, s.children);
-                        } else {
-                            for (auto upv : thunk->upValues)
-                                addIfHeapEntity(upv.second, s.children);
-                            if (thunk->self)
-                                addIfHeapEntity(thunk->self, s.children);
-                        }
-                    }
-                }
-
-                if (s.children.size() > 0) {
-                    HeapEntity *next = s.children[s.children.size() - 1];
-                    s.children.pop_back();
-                    stack.emplace_back(next);  // CAUTION: s invalidated here
-                } else {
-                    stack.pop_back();  // CAUTION: s invalidated here
-                }
-            }
-        }
-
-        /** Delete everything that was not marked since the last collection. */
-        void sweep(void)
-        {
-            lastMark++;
-            // Heap shrinks during this loop.  Do not cache entities.size().
-            for (unsigned long i=0 ; i<entities.size() ; ++i) {
-                HeapEntity *x = entities[i];
-                if (x->mark != lastMark) {
-                    delete x;
-                    if (i != entities.size() - 1) {
-                        // Swap it with the back.
-                        entities[i] = entities[entities.size()-1];
-                    }
-                    entities.pop_back();
-                    --i;
-                }
-            }
-            lastNumEntities = numEntities = entities.size();
-        }
-
-        /** Is it time to initiate a GC cycle? */
-        bool checkHeap(void)
-        {
-            return numEntities > gcTuneMinObjects
-                && numEntities > gcTuneGrowthTrigger * lastNumEntities;
-        }
-
-        /** Allocate a heap entity.
-         *
-         * If the heap is large enough (\see gcTuneMinObjects) and has grown by enough since the
-         * last collection cycle (\see gcTuneGrowthTrigger), a collection cycle is performed.
-        */
-        template <class T, class... Args> T* makeEntity(Args&&... args)
-        {
-            T *r = new T(std::forward<Args>(args)...);
-            entities.push_back(r);
-            r->mark = lastMark;
-            numEntities = entities.size();
-            return r;
-        }
-
-    };
-
 }
+
+/** Convert the value's type into a string, for error messages. */
+std::string type_str(const Value &v)
+{
+    return type_str(v.t);
+}
+
+struct HeapThunk;
+
+/** Stores the values bound to variables.
+ *
+ * Each nested local statement, function call, and field access has its own binding frame to
+ * give the values for the local variable, function parameters, or upValues.
+ */
+typedef std::map<const Identifier*, HeapThunk*> BindingFrame;
+
+/** Supertype of all objects.  Types of Value::OBJECT will point at these.  */
+struct HeapObject : public HeapEntity {
+};
+
+/** Hold an unevaluated expression.  This implements lazy semantics.
+ */
+struct HeapThunk : public HeapEntity {
+    /** Whether or not the thunk was forced. */
+    bool filled;
+
+    /** The result when the thunk was forced, if filled == true. */
+    Value content;
+
+    /** Used in error tracebacks. */
+    const Identifier *name;
+
+    /** The captured environment.
+     *
+     * Note, this is non-const because we have to add cyclic references to it.
+     */
+    BindingFrame upValues;
+
+    /** The captured self variable, or nullptr if there was none.  \see CallFrame. */
+    HeapObject *self;
+
+    /** The offset from the captured self variable. \see CallFrame. */
+    unsigned offset;
+
+    /** Evaluated to force the thunk. */
+    const AST *body;
+
+    HeapThunk(const Identifier *name, HeapObject *self, unsigned offset, const AST *body)
+      : filled(false), name(name), self(self), offset(offset), body(body)
+    { }
+
+    void fill(const Value &v)
+    {
+        content = v;
+        filled = true;
+        self = nullptr;
+        upValues.clear();
+    }
+};
+
+struct HeapArray : public HeapEntity {
+    // It is convenient for this to not be const, so that we can add elements to it one at a
+    // time after creation.  Thus, elements are not GCed as the array is being
+    // created.
+    std::vector<HeapThunk*> elements;
+    HeapArray(const std::vector<HeapThunk*> &elements)
+      : elements(elements)
+    { }
+};
+
+/** Supertype of all objects that are not super objects or extended objects.  */
+struct HeapLeafObject : public HeapObject {
+};
+
+/** Objects created via the simple object constructor construct. */
+struct HeapSimpleObject : public HeapLeafObject {
+    /** The captured environment. */
+    const BindingFrame upValues;
+
+    struct Field {
+        /** Will the field appear in output? */
+        ObjectField::Hide hide;
+        /** Expression that is evaluated when indexing this field. */
+        AST *body;
+    };
+
+    /** The fields.
+     *
+     * These are evaluated in the captured environment and with self and super bound
+     * dynamically.
+     */
+    const std::map<const Identifier*, Field> fields;
+
+    /** The object's invariants.
+     *
+     * These are evaluated in the captured environment with self and super bound.
+     */
+    std::vector<AST*> asserts;
+
+    HeapSimpleObject(const BindingFrame &up_values,
+                     const std::map<const Identifier*, Field> fields, std::vector<AST*> asserts)
+      : upValues(up_values), fields(fields), asserts(asserts)
+    { }
+};
+
+/** Objects created by the extendby construct. */
+struct HeapExtendedObject : public HeapObject {
+    /** The left hand side of the construct. */
+    HeapObject *left;
+
+    /** The right hand side of the construct. */
+    HeapObject *right;
+
+    HeapExtendedObject(HeapObject *left, HeapObject *right)
+      : left(left), right(right)
+    { }
+};
+
+/** Objects created by the ObjectComprehensionSimple construct. */
+struct HeapComprehensionObject : public HeapLeafObject {
+
+    /** The captured environment. */
+    const BindingFrame upValues;
+
+    /** The expression used to compute the field values.  */
+    const AST* value;
+
+    /** The identifier of bound variable in that construct.  */
+    const Identifier * const id;
+
+    /** Binding for id.
+     *
+     * For each field, holds the value that should be bound to id.  This is the corresponding
+     * array element from the original array used to define this object.  This should not really
+     * be a thunk, but it makes the implementation easier.
+     */
+    const std::map<const Identifier*, HeapThunk*> compValues;
+
+    HeapComprehensionObject(const BindingFrame &up_values, const AST *value,
+                            const Identifier *id,
+                            const std::map<const Identifier*, HeapThunk*> &comp_values)
+      : upValues(up_values), value(value), id(id), compValues(comp_values)
+    { }
+};
+
+/** Stores the function itself and also the captured environment.
+ *
+ * Either body is non-null and builtin is 0, or body is null and builtin refers to a built-in
+ * function.  In the former case, the closure represents a user function, otherwise calling it
+ * will trigger the builtin function to execute.  Params is empty when the function is a
+ * builtin.
+ */
+struct HeapClosure : public HeapEntity {
+    /** The captured environment. */
+    const BindingFrame upValues;
+    /** The captured self variable, or nullptr if there was none.  \see Frame. */
+    HeapObject *self;
+    /** The offset from the captured self variable.  \see Frame.*/
+    unsigned offset;
+    const std::vector<const Identifier*> params;
+    const AST *body;
+    const unsigned long builtin;
+    HeapClosure(const BindingFrame &up_values,
+                 HeapObject *self,
+                 unsigned offset,
+                 const std::vector<const Identifier*> &params,
+                 const AST *body, unsigned long builtin)
+      : upValues(up_values), self(self), offset(offset),
+        params(params), body(body), builtin(builtin)
+    { }
+};
+
+/** Stores a simple string on the heap. */
+struct HeapString : public HeapEntity {
+    const String value;
+    HeapString(const String &value)
+      : value(value)
+    { }
+};
+
+/** The heap does memory management, i.e. garbage collection. */
+class Heap {
+
+    /** How many objects must exist in the heap before we bother doing garbage collection?
+     */
+    unsigned gcTuneMinObjects;
+
+    /** How much must the heap have grown since the last cycle to trigger a collection?
+     */
+    double gcTuneGrowthTrigger;
+
+    /** Value used to mark entities at the last garbage collection cycle. */
+    GarbageCollectionMark lastMark;
+
+    /** The heap entities (strings, arrays, objects, functions, etc).
+     *
+     * Not all may be reachable, all should have o->mark == this->lastMark.  Entities are
+     * removed from the heap via O(1) swap with last element, so the ordering of entities is
+     * arbitrary and changes every garbage collection cycle.
+     */
+    std::vector<HeapEntity*> entities;
+
+    /** The number of heap entities at the last garbage collection cycle. */
+    unsigned long lastNumEntities;
+
+    /** The number of heap entities now. */
+    unsigned long numEntities;
+
+    /** Add the HeapEntity inside v to vec, if the value exists on the heap.   
+     */
+    void addIfHeapEntity(Value v, std::vector<HeapEntity*> &vec)
+    {
+        if (v.isHeap()) vec.push_back(v.v.h);
+    }
+
+    /** Add the HeapEntity inside v to vec, if the value exists on the heap.   
+     */
+    void addIfHeapEntity(HeapEntity *v, std::vector<HeapEntity*> &vec)
+    {
+        vec.push_back(v);
+    }
+
+    public:
+
+    Heap(unsigned gc_tune_min_objects, double gc_tune_growth_trigger)
+      : gcTuneMinObjects(gc_tune_min_objects), gcTuneGrowthTrigger(gc_tune_growth_trigger),
+        lastMark(0), lastNumEntities(0), numEntities(0)
+    {
+    }
+
+    ~Heap(void)
+    {
+        // Nothing is marked, everything will be collected.
+        sweep();
+    }
+
+    /** Garbage collection: Mark v, and entities reachable from v. */
+    void markFrom(Value v)
+    {
+        if (v.isHeap()) markFrom(v.v.h);
+    }
+
+    /** Garbage collection: Mark heap entities reachable from the given heap entity. */
+    void markFrom(HeapEntity *from)
+    {
+        assert(from != nullptr);
+        const GarbageCollectionMark thisMark = lastMark + 1;
+        struct State {
+            HeapEntity *ent;
+            std::vector<HeapEntity*> children;
+            State(HeapEntity *ent) : ent(ent) { }
+        };
+
+        std::vector<State> stack;
+        stack.emplace_back(from);
+
+        while (stack.size() > 0) {
+            size_t curr_index = stack.size() - 1;
+            State &s = stack[curr_index];
+            HeapEntity *curr = s.ent;
+            if (curr->mark != thisMark) {
+                curr->mark = thisMark;
+
+                if (auto *obj = dynamic_cast<HeapSimpleObject*>(curr)) {
+                    for (auto upv : obj->upValues)
+                        addIfHeapEntity(upv.second, s.children);
+
+                } else if (auto *obj = dynamic_cast<HeapExtendedObject*>(curr)) {
+                    addIfHeapEntity(obj->left, s.children);
+                    addIfHeapEntity(obj->right, s.children);
+
+                } else if (auto *obj = dynamic_cast<HeapComprehensionObject*>(curr)) {
+                    for (auto upv : obj->upValues)
+                        addIfHeapEntity(upv.second, s.children);
+                    for (auto upv : obj->compValues)
+                        addIfHeapEntity(upv.second, s.children);
+
+
+                } else if (auto *arr = dynamic_cast<HeapArray*>(curr)) {
+                    for (auto el : arr->elements)
+                        addIfHeapEntity(el, s.children);
+
+                } else if (auto *func = dynamic_cast<HeapClosure*>(curr)) {
+                    for (auto upv : func->upValues)
+                        addIfHeapEntity(upv.second, s.children);
+                    if (func->self)
+                        addIfHeapEntity(func->self, s.children);
+
+                } else if (auto *thunk = dynamic_cast<HeapThunk*>(curr)) {
+                    if (thunk->filled) {
+                        if (thunk->content.isHeap())
+                            addIfHeapEntity(thunk->content.v.h, s.children);
+                    } else {
+                        for (auto upv : thunk->upValues)
+                            addIfHeapEntity(upv.second, s.children);
+                        if (thunk->self)
+                            addIfHeapEntity(thunk->self, s.children);
+                    }
+                }
+            }
+
+            if (s.children.size() > 0) {
+                HeapEntity *next = s.children[s.children.size() - 1];
+                s.children.pop_back();
+                stack.emplace_back(next);  // CAUTION: s invalidated here
+            } else {
+                stack.pop_back();  // CAUTION: s invalidated here
+            }
+        }
+    }
+
+    /** Delete everything that was not marked since the last collection. */
+    void sweep(void)
+    {
+        lastMark++;
+        // Heap shrinks during this loop.  Do not cache entities.size().
+        for (unsigned long i=0 ; i<entities.size() ; ++i) {
+            HeapEntity *x = entities[i];
+            if (x->mark != lastMark) {
+                delete x;
+                if (i != entities.size() - 1) {
+                    // Swap it with the back.
+                    entities[i] = entities[entities.size()-1];
+                }
+                entities.pop_back();
+                --i;
+            }
+        }
+        lastNumEntities = numEntities = entities.size();
+    }
+
+    /** Is it time to initiate a GC cycle? */
+    bool checkHeap(void)
+    {
+        return numEntities > gcTuneMinObjects
+            && numEntities > gcTuneGrowthTrigger * lastNumEntities;
+    }
+
+    /** Allocate a heap entity.
+     *
+     * If the heap is large enough (\see gcTuneMinObjects) and has grown by enough since the
+     * last collection cycle (\see gcTuneGrowthTrigger), a collection cycle is performed.
+    */
+    template <class T, class... Args> T* makeEntity(Args&&... args)
+    {
+        T *r = new T(std::forward<Args>(args)...);
+        entities.push_back(r);
+        r->mark = lastMark;
+        numEntities = entities.size();
+        return r;
+    }
+
+};
+
+}  // namespace
 
 #endif  // JSONNET_STATE_H

--- a/core/vm.cpp
+++ b/core/vm.cpp
@@ -28,2309 +28,2297 @@ limitations under the License.
 
 namespace {
 
-    /** Turn a path e.g. "/a/b/c" into a dir, e.g. "/a/b/".  If there is no path returns "".
+/** Turn a path e.g. "/a/b/c" into a dir, e.g. "/a/b/".  If there is no path returns "".
+ */
+std::string dir_name(const std::string &path)
+{
+    size_t last_slash = path.rfind('/');
+    if (last_slash != std::string::npos) {
+        return path.substr(0, last_slash+1);
+    }
+    return "";
+}
+
+/** Stack frames.
+ *
+ * Of these, FRAME_CALL is the most special, as it is the only frame the stack
+ * trace (for errors) displays.
+ */
+enum FrameKind {
+    FRAME_APPLY_TARGET,  // e in e(...)
+    FRAME_BINARY_LEFT,  // a in a + b
+    FRAME_BINARY_RIGHT,  // b in a + b
+    FRAME_BUILTIN_FILTER,  // When executing std.filter, used to hold intermediate state.
+    FRAME_BUILTIN_FORCE_THUNKS,  // When forcing builtin args, holds intermediate state.
+    FRAME_CALL,  // Used any time we have switched location in user code.
+    FRAME_ERROR,  // e in error e
+    FRAME_IF,  // e in if e then a else b
+    FRAME_INDEX_TARGET,  // e in e[x]
+    FRAME_INDEX_INDEX,  // e in x[e]
+    FRAME_INVARIANTS,  // Caches the thunks that need to be executed one at a time.
+    FRAME_LOCAL,  // Stores thunk bindings as we execute e in local ...; e
+    FRAME_OBJECT,  // Stores intermediate state as we execute es in { [e]: ..., [e]: ... }
+    FRAME_OBJECT_COMP_ARRAY,  // e in {f:a for x in e]
+    FRAME_OBJECT_COMP_ELEMENT,  // Stores intermediate state when building object
+    FRAME_STRING_CONCAT,  // Stores intermediate state while co-ercing objects
+    FRAME_SUPER_INDEX,  // e in super[e]
+    FRAME_UNARY,  // e in -e
+};
+
+/** A frame on the stack.
+ *
+ * Every time a subterm is evaluated, we first push a new stack frame to
+ * store the continuation.
+ *
+ * The stack frame is a bit like a tagged union, except not as memory
+ * efficient.  The set of member variables that are actually used depends on
+ * the value of the member varaible kind.
+ *
+ * If the stack frame is of kind FRAME_CALL, then it counts towards the
+ * maximum number of stack frames allowed.  Other stack frames are not
+ * counted.  This is because FRAME_CALL exists where there is a branch in
+ * the code, e.g. the forcing of a thunk, evaluation of a field, calling a
+ * function, etc.
+ *
+ * The stack is used to mark objects during garbage
+ * collection, so HeapObjects not referred to from the stack may be
+ * prematurely collected.
+ */
+struct Frame {
+
+    /** Tag (tagged union). */
+    FrameKind kind;
+
+    /** The code we were executing before. */
+    const AST *ast;
+
+    /** The location of the code we were executing before.
+     *
+     * location == ast->location when ast != nullptr
      */
-    std::string dir_name(const std::string &path)
+    LocationRange location;
+
+    /** Reuse this stack frame for the purpose of tail call optimization. */
+    bool tailCall;
+
+    /** Used for a variety of purposes. */
+    Value val;
+
+    /** Used for a variety of purposes. */
+    Value val2;
+
+    /** Used for a variety of purposes. */
+    DesugaredObject::Fields::const_iterator fit;
+
+    /** Used for a variety of purposes. */
+    std::map<const Identifier *, HeapSimpleObject::Field> objectFields;
+
+    /** Used for a variety of purposes. */
+    unsigned elementId;
+
+    /** Used for a variety of purposes. */
+    std::map<const Identifier *, HeapThunk*> elements;
+
+    /** Used for a variety of purposes. */
+    std::vector<HeapThunk*> thunks;
+
+    /** The context is used in error messages to attempt to find a reasonable name for the
+     * object, function, or thunk value being executed.
+     */
+    HeapEntity *context;
+
+    /** The lexically nearest object we are in, or nullptr.  Note
+     * that this is not the same as context, because we could be inside a function,
+     * inside an object and then context would be the function, but self would still point
+     * to the object.
+     */
+    HeapObject *self;
+
+    /** The "super" level of self.  Sometimes, we look upwards in the
+     * inheritance tree, e.g. via an explicit use of super, or because a given field
+     * has been inherited.  When evaluating a field from one of these super objects,
+     * we need to bind self to the concrete object (so self must point
+     * there) but uses of super should be resolved relative to the object whose
+     * field we are evaluating.  Thus, we keep a second field for that.  This is
+     * usually 0, unless we are evaluating a super object's field.
+     */
+    unsigned offset;
+
+    /** A set of variables introduced at this point. */
+    BindingFrame bindings;
+
+    Frame(const FrameKind &kind, const AST *ast)
+      : kind(kind), ast(ast), location(ast->location), tailCall(false), elementId(0),
+        context(NULL), self(NULL), offset(0)
     {
-        size_t last_slash = path.rfind('/');
-        if (last_slash != std::string::npos) {
-            return path.substr(0, last_slash+1);
-        }
-        return "";
+        val.t = Value::NULL_TYPE;
+        val2.t = Value::NULL_TYPE;
     }
 
-    /** Stack frames.
-     *
-     * Of these, FRAME_CALL is the most special, as it is the only frame the stack
-     * trace (for errors) displays.  
+    Frame(const FrameKind &kind, const LocationRange &location)
+      : kind(kind), ast(nullptr), location(location), tailCall(false), elementId(0),
+        context(NULL), self(NULL), offset(0)
+    {
+        val.t = Value::NULL_TYPE;
+        val2.t = Value::NULL_TYPE;
+    }
+
+    /** Mark everything visible from this frame. */
+    void mark(Heap &heap) const
+    {
+        heap.markFrom(val);
+        heap.markFrom(val2);
+        if (context) heap.markFrom(context);
+        if (self) heap.markFrom(self);
+        for (const auto &bind : bindings)
+            heap.markFrom(bind.second);
+        for (const auto &el : elements)
+            heap.markFrom(el.second);
+        for (const auto &th : thunks)
+            heap.markFrom(th);
+    }
+
+    bool isCall(void) const
+    {
+        return kind == FRAME_CALL;
+    }
+
+};
+
+/** The stack holds all the stack frames and manages the stack frame limit. */
+class Stack {
+
+    /** How many call frames are on the stack. */
+    unsigned calls;
+
+    /** How many call frames should be allowed before aborting the program. */
+    unsigned limit;
+
+    /** The stack frames. */
+    std::vector<Frame> stack;
+
+    public:
+
+    Stack(unsigned limit)
+      : calls(0), limit(limit)
+    {
+    }
+
+    ~Stack(void) { }
+
+    unsigned size(void)
+    {
+        return stack.size();
+    }
+
+    /** Search for the closest variable in scope that matches the given name. */
+    HeapThunk *lookUpVar(const Identifier *id)
+    {
+        for (int i=stack.size()-1 ; i>=0 ; --i) {
+            const auto &binds = stack[i].bindings;
+            auto it = binds.find(id);
+            if (it != binds.end()) {
+                return it->second;
+            }
+            if (stack[i].isCall()) break;
+        }
+        return nullptr;
+    }
+
+    /** Mark everything visible from the stack (any frame). */
+    void mark(Heap &heap)
+    {
+        for (const auto &f : stack) {
+            f.mark(heap);
+        }
+    }
+
+    Frame &top(void)
+    {
+        return stack.back();
+    }
+
+    const Frame &top(void) const
+    {
+        return stack.back();
+    }
+
+    void pop(void)
+    {
+        if (top().isCall()) calls--;
+        stack.pop_back();
+    }
+
+    /** Attempt to find a name for a given heap entity.  This may not be possible, but we try
+     * reasonably hard.  We look in the bindings for a variable in the closest scope that
+     * happens to point at the entity in question.  Otherwise, the best we can do is use its
+     * type.
      */
-    enum FrameKind {
-        FRAME_APPLY_TARGET,  // e in e(...)
-        FRAME_BINARY_LEFT,  // a in a + b 
-        FRAME_BINARY_RIGHT,  // b in a + b
-        FRAME_BUILTIN_FILTER,  // When executing std.filter, used to hold intermediate state.
-        FRAME_BUILTIN_FORCE_THUNKS,  // When forcing builtin args, holds intermediate state. 
-        FRAME_CALL,  // Used any time we have switched location in user code.
-        FRAME_ERROR,  // e in error e
-        FRAME_IF,  // e in if e then a else b
-        FRAME_INDEX_TARGET,  // e in e[x]
-        FRAME_INDEX_INDEX,  // e in x[e]
-        FRAME_INVARIANTS,  // Caches the thunks that need to be executed one at a time.
-        FRAME_LOCAL,  // Stores thunk bindings as we execute e in local ...; e
-        FRAME_OBJECT,  // Stores intermediate state as we execute es in { [e]: ..., [e]: ... }
-        FRAME_OBJECT_COMP_ARRAY,  // e in {f:a for x in e]
-        FRAME_OBJECT_COMP_ELEMENT,  // Stores intermediate state when building object
-        FRAME_STRING_CONCAT,  // Stores intermediate state while co-ercing objects
-        FRAME_SUPER_INDEX,  // e in super[e]
-        FRAME_UNARY,  // e in -e
-    };
+    std::string getName(unsigned from_here, const HeapEntity *e)
+    {
+        std::string name;
+        for (int i=from_here-1 ; i>=0; --i) {
+            const auto &f = stack[i];
+            for (const auto &pair : f.bindings) {
+                HeapThunk *thunk = pair.second;
+                if (!thunk->filled) continue;
+                if (!thunk->content.isHeap()) continue;
+                if (e != thunk->content.v.h) continue;
+                name = encode_utf8(pair.first->name);
+            }
+            // Do not go into the next call frame, keep local reasoning.
+            if (f.isCall()) break;
+        }
 
-    /** A frame on the stack.
+        if (name == "") name = "anonymous";
+        if (dynamic_cast<const HeapObject*>(e)) {
+            return "object <" + name + ">";
+        } else if (auto *thunk = dynamic_cast<const HeapThunk*>(e)) {
+            return "thunk <" + encode_utf8(thunk->name->name) + ">";
+        } else {
+            const auto *func = static_cast<const HeapClosure *>(e);
+            if (func->body == nullptr) {
+                name = encode_utf8(jsonnet_builtin_decl(func->builtin).name);
+                return "builtin function <" + name + ">";
+            }
+            return "function <" + name + ">";
+        }
+    }
+
+    /** Dump the stack.
      *
-     * Every time a subterm is evaluated, we first push a new stack frame to
-     * store the continuation.
-     *
-     * The stack frame is a bit like a tagged union, except not as memory
-     * efficient.  The set of member variables that are actually used depends on
-     * the value of the member varaible kind.
-     *
-     * If the stack frame is of kind FRAME_CALL, then it counts towards the
-     * maximum number of stack frames allowed.  Other stack frames are not
-     * counted.  This is because FRAME_CALL exists where there is a branch in
-     * the code, e.g. the forcing of a thunk, evaluation of a field, calling a
-     * function, etc.
-     *
-     * The stack is used to mark objects during garbage
-     * collection, so HeapObjects not referred to from the stack may be
-     * prematurely collected.
+     * This is useful to help debug the VM in gdb.  It is virtual to stop it
+     * being removed by the compiler.
      */
-    struct Frame {
-
-        /** Tag (tagged union). */
-        FrameKind kind;
-
-        /** The code we were executing before. */
-        const AST *ast;
-
-        /** The location of the code we were executing before.
-         *
-         * location == ast->location when ast != nullptr
-         */
-        LocationRange location;
-
-        /** Reuse this stack frame for the purpose of tail call optimization. */
-        bool tailCall;
-
-        /** Used for a variety of purposes. */
-        Value val;
-
-        /** Used for a variety of purposes. */
-        Value val2;
-
-        /** Used for a variety of purposes. */
-        DesugaredObject::Fields::const_iterator fit;
-
-        /** Used for a variety of purposes. */
-        std::map<const Identifier *, HeapSimpleObject::Field> objectFields;
-
-        /** Used for a variety of purposes. */
-        unsigned elementId;
-
-        /** Used for a variety of purposes. */
-        std::map<const Identifier *, HeapThunk*> elements;
-
-        /** Used for a variety of purposes. */
-        std::vector<HeapThunk*> thunks;
-
-        /** The context is used in error messages to attempt to find a reasonable name for the
-         * object, function, or thunk value being executed.
-         */
-        HeapEntity *context;
-
-        /** The lexically nearest object we are in, or nullptr.  Note
-         * that this is not the same as context, because we could be inside a function,
-         * inside an object and then context would be the function, but self would still point
-         * to the object.
-         */
-        HeapObject *self;
-
-        /** The "super" level of self.  Sometimes, we look upwards in the
-         * inheritance tree, e.g. via an explicit use of super, or because a given field
-         * has been inherited.  When evaluating a field from one of these super objects,
-         * we need to bind self to the concrete object (so self must point
-         * there) but uses of super should be resolved relative to the object whose
-         * field we are evaluating.  Thus, we keep a second field for that.  This is
-         * usually 0, unless we are evaluating a super object's field.
-         */
-        unsigned offset;
-
-        /** A set of variables introduced at this point. */
-        BindingFrame bindings;
-
-        Frame(const FrameKind &kind, const AST *ast)
-          : kind(kind), ast(ast), location(ast->location), tailCall(false), elementId(0),
-            context(NULL), self(NULL), offset(0)
-        {
-            val.t = Value::NULL_TYPE;
-            val2.t = Value::NULL_TYPE;
+    virtual void dump(void)
+    {
+        for (unsigned i=0 ; i<stack.size() ; ++i) {
+            std::cout << "stack[" << i << "] = " << stack[i].location
+                      << " (" << stack[i].kind << ")"
+                      << std::endl;
         }
+        std::cout << std::endl;
+    }
 
-        Frame(const FrameKind &kind, const LocationRange &location)
-          : kind(kind), ast(nullptr), location(location), tailCall(false), elementId(0),
-            context(NULL), self(NULL), offset(0)
-        {
-            val.t = Value::NULL_TYPE;
-            val2.t = Value::NULL_TYPE;
-        }
-
-        /** Mark everything visible from this frame. */
-        void mark(Heap &heap) const
-        {
-            heap.markFrom(val);
-            heap.markFrom(val2);
-            if (context) heap.markFrom(context);
-            if (self) heap.markFrom(self);
-            for (const auto &bind : bindings)
-                heap.markFrom(bind.second);
-            for (const auto &el : elements)
-                heap.markFrom(el.second);
-            for (const auto &th : thunks)
-                heap.markFrom(th);
-        }
-
-        bool isCall(void) const
-        {
-            return kind == FRAME_CALL;
-        }
-
-    };
-
-    /** The stack holds all the stack frames and manages the stack frame limit. */
-    class Stack {
-
-        /** How many call frames are on the stack. */
-        unsigned calls;
-
-        /** How many call frames should be allowed before aborting the program. */
-        unsigned limit;
-
-        /** The stack frames. */
-        std::vector<Frame> stack;
-
-        public:
-
-        Stack(unsigned limit)
-          : calls(0), limit(limit)
-        {
-        }
-
-        ~Stack(void) { }
-
-        unsigned size(void)
-        {
-            return stack.size();
-        }
-
-        /** Search for the closest variable in scope that matches the given name. */
-        HeapThunk *lookUpVar(const Identifier *id)
-        {
-            for (int i=stack.size()-1 ; i>=0 ; --i) {
-                const auto &binds = stack[i].bindings;
-                auto it = binds.find(id);
-                if (it != binds.end()) {
-                    return it->second;
+    /** Creates the error object for throwing, and also populates it with the stack trace.
+     */
+    RuntimeError makeError(const LocationRange &loc, const std::string &msg)
+    {
+        std::vector<TraceFrame> stack_trace;
+        stack_trace.push_back(TraceFrame(loc));
+        for (int i=stack.size()-1 ; i>=0 ; --i) {
+            const auto &f = stack[i];
+            if (f.isCall()) {
+                if (f.context != nullptr) {
+                    // Give the last line a name.
+                    stack_trace[stack_trace.size()-1].name = getName(i, f.context);
                 }
-                if (stack[i].isCall()) break;
-            }
-            return nullptr;
-        }
-
-        /** Mark everything visible from the stack (any frame). */
-        void mark(Heap &heap)
-        {
-            for (const auto &f : stack) {
-                f.mark(heap);
+                stack_trace.push_back(TraceFrame(f.location));
             }
         }
+        return RuntimeError(stack_trace, msg);
+    }
 
-        Frame &top(void)
-        {
-            return stack.back();
-        }
+    /** New (non-call) frame. */
+    template <class... Args> void newFrame(Args... args)
+    {
+        stack.emplace_back(args...);
+    }
 
-        const Frame &top(void) const
-        {
-            return stack.back();
-        }
-
-        void pop(void)
-        {
-            if (top().isCall()) calls--;
-            stack.pop_back();
-        }
-
-        /** Attempt to find a name for a given heap entity.  This may not be possible, but we try
-         * reasonably hard.  We look in the bindings for a variable in the closest scope that
-         * happens to point at the entity in question.  Otherwise, the best we can do is use its
-         * type.
-         */
-        std::string getName(unsigned from_here, const HeapEntity *e)
-        {
-            std::string name;
-            for (int i=from_here-1 ; i>=0; --i) {
-                const auto &f = stack[i];
-                for (const auto &pair : f.bindings) {
-                    HeapThunk *thunk = pair.second;
-                    if (!thunk->filled) continue;
-                    if (!thunk->content.isHeap()) continue;
-                    if (e != thunk->content.v.h) continue;
-                    name = encode_utf8(pair.first->name);
-                }
-                // Do not go into the next call frame, keep local reasoning.
-                if (f.isCall()) break;
-            }
-
-            if (name == "") name = "anonymous";
-            if (dynamic_cast<const HeapObject*>(e)) {
-                return "object <" + name + ">";
-            } else if (auto *thunk = dynamic_cast<const HeapThunk*>(e)) {
-                return "thunk <" + encode_utf8(thunk->name->name) + ">";
-            } else {
-                const auto *func = static_cast<const HeapClosure *>(e);
-                if (func->body == nullptr) {
-                    name = encode_utf8(jsonnet_builtin_decl(func->builtin).name);
-                    return "builtin function <" + name + ">";
-                }
-                return "function <" + name + ">";
-            }
-        }
-
-        /** Dump the stack.
-         *
-         * This is useful to help debug the VM in gdb.  It is virtual to stop it
-         * being removed by the compiler.
-         */
-        virtual void dump(void)
-        {
-            for (unsigned i=0 ; i<stack.size() ; ++i) {
-                std::cout << "stack[" << i << "] = " << stack[i].location
-                          << " (" << stack[i].kind << ")"
-                          << std::endl;
-            }
-            std::cout << std::endl;
-        }
-
-        /** Creates the error object for throwing, and also populates it with the stack trace.
-         */
-        RuntimeError makeError(const LocationRange &loc, const std::string &msg)
-        {
-            std::vector<TraceFrame> stack_trace;
-            stack_trace.push_back(TraceFrame(loc));
-            for (int i=stack.size()-1 ; i>=0 ; --i) {
-                const auto &f = stack[i];
-                if (f.isCall()) {
-                    if (f.context != nullptr) {
-                        // Give the last line a name.
-                        stack_trace[stack_trace.size()-1].name = getName(i, f.context);
-                    }
-                    stack_trace.push_back(TraceFrame(f.location));
-                }
-            }
-            return RuntimeError(stack_trace, msg);
-        }
-
-        /** New (non-call) frame. */
-        template <class... Args> void newFrame(Args... args)
-        {
-            stack.emplace_back(args...);
-        }
-
-        /** If there is a tailstrict annotated frame followed by some locals, pop them all. */
-        void tailCallTrimStack (void)
-        {
-            for (int i=stack.size()-1 ; i>=0 ; --i) {
-                switch (stack[i].kind) {
-                    case FRAME_CALL: {
-                        if (!stack[i].tailCall || stack[i].thunks.size() > 0) {
-                            return;
-                        }
-                        // Remove all stack frames including this one.
-                        while (stack.size() > unsigned(i)) stack.pop_back();
-                        calls--;
+    /** If there is a tailstrict annotated frame followed by some locals, pop them all. */
+    void tailCallTrimStack (void)
+    {
+        for (int i=stack.size()-1 ; i>=0 ; --i) {
+            switch (stack[i].kind) {
+                case FRAME_CALL: {
+                    if (!stack[i].tailCall || stack[i].thunks.size() > 0) {
                         return;
-                    } break;
-
-                    case FRAME_LOCAL: break;
-
-                    default: return;
-                }
-            }
-        }
-
-        /** New call frame. */
-        void newCall(const LocationRange &loc, HeapEntity *context, HeapObject *self,
-                     unsigned offset, const BindingFrame &up_values)
-        {
-            tailCallTrimStack();
-            if (calls >= limit) {
-                throw makeError(loc, "Max stack frames exceeded.");
-            }
-            stack.emplace_back(FRAME_CALL, loc);
-            calls++;
-            top().context = context;
-            top().self = self;
-            top().offset = offset;
-            top().bindings = up_values;
-            top().tailCall = false;
-
-            #ifndef NDEBUG
-            for (const auto &bind : up_values) {
-                assert(bind.second != nullptr);
-            }
-            #endif
-        }
-
-        /** Look up the stack to find the self binding. */
-        void getSelfBinding(HeapObject *&self, unsigned &offset)
-        {
-            self = nullptr;
-            offset = 0;
-            for (int i=stack.size() - 1 ; i>=0 ; --i) {
-                if (stack[i].isCall()) {
-                    self = stack[i].self;
-                    offset = stack[i].offset;
+                    }
+                    // Remove all stack frames including this one.
+                    while (stack.size() > unsigned(i)) stack.pop_back();
+                    calls--;
                     return;
-                }
-            }
-        }
+                } break;
 
-        /** Look up the stack to see if we're running assertions for this object. */
-        bool alreadyExecutingInvariants(HeapObject *self)
-        {
-            for (int i=stack.size() - 1 ; i>=0 ; --i) {
-                if (stack[i].kind == FRAME_INVARIANTS) {
-                    if (stack[i].self == self) return true;
-                }
+                case FRAME_LOCAL: break;
+
+                default: return;
             }
-            return false;
         }
+    }
+
+    /** New call frame. */
+    void newCall(const LocationRange &loc, HeapEntity *context, HeapObject *self,
+                 unsigned offset, const BindingFrame &up_values)
+    {
+        tailCallTrimStack();
+        if (calls >= limit) {
+            throw makeError(loc, "Max stack frames exceeded.");
+        }
+        stack.emplace_back(FRAME_CALL, loc);
+        calls++;
+        top().context = context;
+        top().self = self;
+        top().offset = offset;
+        top().bindings = up_values;
+        top().tailCall = false;
+
+        #ifndef NDEBUG
+        for (const auto &bind : up_values) {
+            assert(bind.second != nullptr);
+        }
+        #endif
+    }
+
+    /** Look up the stack to find the self binding. */
+    void getSelfBinding(HeapObject *&self, unsigned &offset)
+    {
+        self = nullptr;
+        offset = 0;
+        for (int i=stack.size() - 1 ; i>=0 ; --i) {
+            if (stack[i].isCall()) {
+                self = stack[i].self;
+                offset = stack[i].offset;
+                return;
+            }
+        }
+    }
+
+    /** Look up the stack to see if we're running assertions for this object. */
+    bool alreadyExecutingInvariants(HeapObject *self)
+    {
+        for (int i=stack.size() - 1 ; i>=0 ; --i) {
+            if (stack[i].kind == FRAME_INVARIANTS) {
+                if (stack[i].self == self) return true;
+            }
+        }
+        return false;
+    }
+};
+
+/** Typedef to save some typing. */
+typedef std::map<std::string, VmExt> ExtMap;
+
+/** Typedef to save some typing. */
+typedef std::map<std::string, std::string> StrMap;
+
+
+/** Holds the intermediate state during execution and implements the necessary functions to
+ * implement the semantics of the language.
+ *
+ * The garbage collector used is a simple stop-the-world mark and sweep collector.  It runs upon
+ * memory allocation if the heap is large enough and has grown enough since the last collection.
+ * All reachable entities have their mark field incremented.  Then all entities with the old
+ * mark are removed from the heap.
+ */
+class Interpreter {
+
+    /** The heap. */
+    Heap heap;
+
+    /** The value last computed. */
+    Value scratch;
+
+    /** The stack. */
+    Stack stack;
+
+    /** Used to create ASTs if needed.
+     *
+     * This is used at import time, and in a few other cases.
+     */
+    Allocator *alloc;
+
+    /** Used to "name" thunks created on the inside of an array. */
+    const Identifier *idArrayElement;
+
+    /** Used to "name" thunks created to execute invariants. */
+    const Identifier *idInvariant;
+
+    struct ImportCacheValue {
+        std::string foundHere;
+        std::string content;
     };
 
-    /** Typedef to save some typing. */
-    typedef std::map<std::string, VmExt> ExtMap;
+    /** Cache for imported Jsonnet files. */
+    std::map<std::pair<std::string, String>,
+             const ImportCacheValue *> cachedImports;
 
-    /** Typedef to save some typing. */
-    typedef std::map<std::string, std::string> StrMap;
+    /** External variables for std.extVar. */
+    ExtMap externalVars;
 
+    /** The callback used for loading imported files. */
+    JsonnetImportCallback *importCallback;
 
-    /** Holds the intermediate state during execution and implements the necessary functions to
-     * implement the semantics of the language.
-     *
-     * The garbage collector used is a simple stop-the-world mark and sweep collector.  It runs upon
-     * memory allocation if the heap is large enough and has grown enough since the last collection.
-     * All reachable entities have their mark field incremented.  Then all entities with the old
-     * mark are removed from the heap.
+    /** User context pointer for the import callback. */
+    void *importCallbackContext;
+
+    RuntimeError makeError(const LocationRange &loc, const std::string &msg)
+    {
+        return stack.makeError(loc, msg);
+    }
+
+    /** Create an object on the heap, maybe collect garbage.
+     * \param T Something under HeapEntity
+     * \returns The new object
      */
-    class Interpreter {
+    template <class T, class... Args> T* makeHeap(Args&&... args)
+    {
+        T *r = heap.makeEntity<T, Args...>(std::forward<Args>(args)...);
+        if (heap.checkHeap()) {  // Do a GC cycle?
+            // Avoid the object we just made being collected.
+            heap.markFrom(r);
 
-        /** The heap. */
-        Heap heap;
+            // Mark from the stack.
+            stack.mark(heap);
 
-        /** The value last computed. */
-        Value scratch;
+            // Mark from the scratch register
+            heap.markFrom(scratch);
 
-        /** The stack. */
-        Stack stack;
-
-        /** Used to create ASTs if needed.
-         *
-         * This is used at import time, and in a few other cases.
-         */
-        Allocator *alloc;
-
-        /** Used to "name" thunks created on the inside of an array. */
-        const Identifier *idArrayElement;
-
-        /** Used to "name" thunks created to execute invariants. */
-        const Identifier *idInvariant;
-
-        struct ImportCacheValue {
-            std::string foundHere;
-            std::string content;
-        };
-
-        /** Cache for imported Jsonnet files. */
-        std::map<std::pair<std::string, String>,
-                 const ImportCacheValue *> cachedImports;
-
-        /** External variables for std.extVar. */
-        ExtMap externalVars;
-
-        /** The callback used for loading imported files. */
-        JsonnetImportCallback *importCallback;
-
-        /** User context pointer for the import callback. */
-        void *importCallbackContext;
-
-        RuntimeError makeError(const LocationRange &loc, const std::string &msg)
-        {
-            return stack.makeError(loc, msg);
+            // Delete unreachable objects.
+            heap.sweep();
         }
+        return r;
+    }
 
-        /** Create an object on the heap, maybe collect garbage.
-         * \param T Something under HeapEntity
-         * \returns The new object
-         */
-        template <class T, class... Args> T* makeHeap(Args&&... args)
-        {
-            T *r = heap.makeEntity<T, Args...>(std::forward<Args>(args)...);
-            if (heap.checkHeap()) {  // Do a GC cycle?
-                // Avoid the object we just made being collected.
-                heap.markFrom(r);
+    Value makeBoolean(bool v)
+    {
+        Value r;
+        r.t = Value::BOOLEAN;
+        r.v.b = v;
+        return r;
+    }
 
-                // Mark from the stack.
-                stack.mark(heap);
+    Value makeDouble(double v)
+    {
+        Value r;
+        r.t = Value::DOUBLE;
+        r.v.d = v;
+        return r;
+    }
 
-                // Mark from the scratch register
-                heap.markFrom(scratch);
-
-                // Delete unreachable objects.
-                heap.sweep();
-            }
-            return r;
+    Value makeDoubleCheck(const LocationRange &loc, double v)
+    {
+        if (std::isnan(v)) {
+            throw makeError(loc, "Not a number");
         }
-
-        Value makeBoolean(bool v)
-        {
-            Value r;
-            r.t = Value::BOOLEAN;
-            r.v.b = v;
-            return r;
+        if (std::isinf(v)) {
+            throw makeError(loc, "Overflow");
         }
+        return makeDouble(v);
+    }
 
-        Value makeDouble(double v)
-        {
-            Value r;
-            r.t = Value::DOUBLE;
-            r.v.d = v;
-            return r;
-        }
+    Value makeNull(void)
+    {
+        Value r;
+        r.t = Value::NULL_TYPE;
+        return r;
+    }
 
-        Value makeDoubleCheck(const LocationRange &loc, double v)
-        {
-            if (std::isnan(v)) {
-                throw makeError(loc, "Not a number");
-            }
-            if (std::isinf(v)) {
-                throw makeError(loc, "Overflow");
-            }
-            return makeDouble(v);
-        }
+    Value makeArray(const std::vector<HeapThunk*> &v)
+    {
+        Value r;
+        r.t = Value::ARRAY;
+        r.v.h = makeHeap<HeapArray>(v);
+        return r;
+    }
 
-        Value makeNull(void)
-        {
-            Value r;
-            r.t = Value::NULL_TYPE;
-            return r;
-        }
+    Value makeClosure(const BindingFrame &env,
+                       HeapObject *self,
+                       unsigned offset,
+                       const std::vector<const Identifier *> &params,
+                       AST *body)
+    {
+        Value r;
+        r.t = Value::FUNCTION;
+        r.v.h = makeHeap<HeapClosure>(env, self, offset, params, body, 0);
+        return r;
+    }
 
-        Value makeArray(const std::vector<HeapThunk*> &v)
-        {
-            Value r;
-            r.t = Value::ARRAY;
-            r.v.h = makeHeap<HeapArray>(v);
-            return r;
-        }
+    Value makeBuiltin(unsigned long builtin_id, const std::vector<const Identifier *> &params)
+    {
+        AST *body = nullptr;
+        Value r;
+        r.t = Value::FUNCTION;
+        r.v.h = makeHeap<HeapClosure>(BindingFrame(), nullptr, 0, params, body, builtin_id);
+        return r;
+    }
 
-        Value makeClosure(const BindingFrame &env,
-                           HeapObject *self,
-                           unsigned offset,
-                           const std::vector<const Identifier *> &params,
-                           AST *body)
-        {
-            Value r;
-            r.t = Value::FUNCTION;
-            r.v.h = makeHeap<HeapClosure>(env, self, offset, params, body, 0);
-            return r;
-        }
+    template <class T, class... Args> Value makeObject(Args... args)
+    {
+        Value r;
+        r.t = Value::OBJECT;
+        r.v.h = makeHeap<T>(args...);
+        return r;
+    }
 
-        Value makeBuiltin(unsigned long builtin_id, const std::vector<const Identifier *> &params)
-        {
-            AST *body = nullptr;
-            Value r;
-            r.t = Value::FUNCTION;
-            r.v.h = makeHeap<HeapClosure>(BindingFrame(), nullptr, 0,
-                                          params, body, builtin_id);
-            return r;
-        }
+    Value makeString(const String &v)
+    {
+        Value r;
+        r.t = Value::STRING;
+        r.v.h = makeHeap<HeapString>(v);
+        return r;
+    }
 
-        template <class T, class... Args> Value makeObject(Args... args)
-        {
-            Value r;
-            r.t = Value::OBJECT;
-            r.v.h = makeHeap<T>(args...);
-            return r;
-        }
-
-        Value makeString(const String &v)
-        {
-            Value r;
-            r.t = Value::STRING;
-            r.v.h = makeHeap<HeapString>(v);
-            return r;
-        }
-
-        /** Auxiliary function of objectIndex.
-         *
-         * Traverse the object's tree from right to left, looking for an object
-         * with the given field.  Call with offset initially set to 0.
-         *
-         * \param f The field we're looking for.
-         * \param curr The root object.
-         * \param start_from Step over this many leaves first.
-         * \param counter Return the level of "super" that contained the field.
-         * \param self Return the new root.
-         * \returns The first object with the field, or nullptr if it could not be found.
-         */
-        HeapLeafObject *findObject(const Identifier *f, HeapObject *root, HeapObject *curr,
-                                   unsigned start_from, unsigned &counter,
-                                   HeapObject *&self)
-        {
-            if (auto *ext = dynamic_cast<HeapExtendedObject*>(curr)) {
-                auto *r = findObject(f, root, ext->right, start_from, counter, self);
-                if (r) return r;
-                auto *l = findObject(f, root, ext->left, start_from, counter, self);
-                if (l) return l;
-            } else {
-                if (counter >= start_from) {
-                    if (auto *simp = dynamic_cast<HeapSimpleObject*>(curr)) {
-                        auto it = simp->fields.find(f);
-                        if (it != simp->fields.end()) {
-                            self = root;
-                            return simp;
-                        }
-                    } else if (auto *comp = dynamic_cast<HeapComprehensionObject*>(curr)) {
-                        auto it = comp->compValues.find(f);
-                        if (it != comp->compValues.end()) {
-                            self = root;
-                            return comp;
-                        }
-                    }
-                }
-                counter++;
-            }
-            return nullptr;
-        }
-
-        typedef std::map<const Identifier*, ObjectField::Hide> IdHideMap;
-
-        /** Auxiliary function.
-         */
-        IdHideMap objectFields(const HeapObject *obj_,
-                               unsigned &counter, unsigned skip,
-                               bool manifesting)
-        {
-            IdHideMap r;
-            if (auto *obj = dynamic_cast<const HeapSimpleObject*>(obj_)) {
-                counter++;
-                if (counter <= skip) return r;
-                for (const auto &f : obj->fields) {
-                    r[f.first] = !manifesting ? ObjectField::VISIBLE : f.second.hide;
-                }
-
-            } else if (auto *obj = dynamic_cast<const HeapExtendedObject*>(obj_)) {
-                r = objectFields(obj->right, counter, skip, manifesting);
-                for (const auto &pair : objectFields(obj->left, counter, skip, manifesting)) {
-                    auto it = r.find(pair.first);
-                    if (it == r.end()) {
-                        // First time it is seen
-                        r[pair.first] = pair.second;
-                    } else if (it->second == ObjectField::INHERIT) {
-                        // Seen before, but with inherited visibility so use new visibility
-                        r[pair.first] = pair.second;
-                    }
-                }
-
-            } else if (auto *obj = dynamic_cast<const HeapComprehensionObject*>(obj_)) {
-                counter++;
-                if (counter <= skip) return r;
-                for (const auto &f : obj->compValues)
-                    r[f.first] = ObjectField::VISIBLE;
-            }
-            return r;
-        }
-
-        /** Auxiliary function.
-         */
-        std::set<const Identifier*> objectFields(const HeapObject *obj_, bool manifesting)
-        {
-            unsigned counter = 0;
-            std::set<const Identifier*> r;
-            for (const auto &pair : objectFields(obj_, counter, 0, manifesting)) {
-                if (pair.second != ObjectField::HIDDEN) r.insert(pair.first);
-            }
-            return r;
-        }
-
-        /** Import another Jsonnet file.
-         *
-         * If the file has already been imported, then use that version.  This maintains
-         * referential transparency in the case of writes to disk during execution.
-         *
-         * \param loc Location of the import statement.
-         * \param file Path to the filename.
-         */
-        AST *import(const LocationRange &loc, const LiteralString *file)
-        {
-            const ImportCacheValue *input = importString(loc, file);
-            Tokens tokens = jsonnet_lex(input->foundHere, input->content.c_str());
-            AST *expr = jsonnet_parse(alloc, tokens);
-            jsonnet_desugar(alloc, expr);
-            jsonnet_static_analysis(expr);
-            return expr;
-        }
-
-        /** Import a file as a string.
-         *
-         * If the file has already been imported, then use that version.  This maintains
-         * referential transparency in the case of writes to disk during execution.
-         *
-         * \param loc Location of the import statement.
-         * \param file Path to the filename.
-         * \param found_here If non-null, used to store the actual path of the file
-         */
-        const ImportCacheValue *importString(const LocationRange &loc, const LiteralString *file)
-        {
-            std::string dir = dir_name(loc.file);
-
-            const String &path = file->value;
-
-            std::pair<std::string, String> key(dir, path);
-            const ImportCacheValue *cached_value = cachedImports[key];
-            if (cached_value != nullptr)
-                return cached_value;
-
-
-            int success = 0;
-            char *found_here_cptr;
-            char *content =
-                importCallback(importCallbackContext, dir.c_str(), encode_utf8(path).c_str(),
-                               &found_here_cptr, &success);
-
-            std::string input(content);
-            ::free(content);
-
-            if (!success) {
-                    std::string msg = "Couldn't open import \"" + encode_utf8(path) + "\": ";
-                    msg += input;
-                    throw makeError(loc, msg);
-            }
-
-            auto *input_ptr = new ImportCacheValue();
-            input_ptr->foundHere = found_here_cptr;
-            input_ptr->content = input;
-            ::free(found_here_cptr);
-            cachedImports[key] = input_ptr;
-            return input_ptr;
-        }
-
-        /** Capture the required variables from the environment. */
-        BindingFrame capture(const std::vector<const Identifier*> &free_vars)
-        {
-            BindingFrame env;
-            for (auto fv : free_vars) {
-                auto *th = stack.lookUpVar(fv);
-                if (th != nullptr) {
-                    env[fv] = th;
-                }
-            }
-            return env;
-        }
-
-        /** Count the number of leaves in the tree.
-         *
-         * \param obj The root of the tree.
-         * \param counter Initialize to 0, returns the number of leaves.
-         */
-        unsigned countLeaves(HeapObject *obj)
-        {
-            if (auto *ext = dynamic_cast<HeapExtendedObject*>(obj)) {
-                return countLeaves(ext->left) + countLeaves(ext->right);
-            } else {
-                return 1;
-            }
-        }
-
-        public:
-
-        /** Create a new interpreter.
-         *
-         * \param loc The location range of the file to be executed.
-         */
-        Interpreter(Allocator *alloc, const ExtMap &ext_vars,
-                    unsigned max_stack, double gc_min_objects, double gc_growth_trigger,
-                    JsonnetImportCallback *import_callback, void *import_callback_context)
-          : heap(gc_min_objects, gc_growth_trigger), stack(max_stack), alloc(alloc),
-            idArrayElement(alloc->makeIdentifier(U"array_element")),
-            idInvariant(alloc->makeIdentifier(U"object_assert")), externalVars(ext_vars),
-            importCallback(import_callback), importCallbackContext(import_callback_context)
-        {
-            scratch = makeNull();
-        }
-
-        /** Clean up the heap, stack, stash, and builtin function ASTs. */
-        ~Interpreter()
-        {
-            for (const auto &pair : cachedImports) {
-                delete pair.second;
-            }
-        }
-
-        const Value &getScratchRegister(void)
-        {
-            return scratch;
-        }
-
-        void setScratchRegister(const Value &v)
-        {
-            scratch = v;
-        }
-
-
-        /** Raise an error if the arguments aren't the expected types. */
-        void validateBuiltinArgs(const LocationRange &loc,
-                                 unsigned long builtin,
-                                 const std::vector<Value> &args,
-                                 const std::vector<Value::Type> params)
-        {
-            if (args.size() == params.size()) {
-                for (unsigned i=0 ; i<args.size() ; ++i) {
-                    if (args[i].t != params[i]) goto bad;
-                }
-                return;
-            }
-            bad:;
-            const String &name = jsonnet_builtin_decl(builtin).name;
-            std::stringstream ss;
-            ss << "Builtin function " + encode_utf8(name) + " expected (";
-            const char *prefix = "";
-            for (auto p : params) {
-                ss << prefix << type_str(p);
-                prefix = ", ";
-            }
-            ss << ") but got (";
-            prefix = "";
-            for (auto a : args) {
-                ss << prefix << type_str(a);
-                prefix = ", ";
-            }
-            ss << ")";
-            throw makeError(loc, ss.str());
-        }
-
-
-        String toString(const LocationRange &loc)
-        {
-            return manifestJson(loc, false, U"");
-        }
-
-
-
-        /** Recursively collect an object's invariants.
-         *
-         * \param curr
-         * \param self
-         * \param offset
-         * \param thunks
-         */
-        void objectInvariants(HeapObject *curr, HeapObject *self,
-                              unsigned &counter, std::vector<HeapThunk*> &thunks)
-        {
-            if (auto *ext = dynamic_cast<HeapExtendedObject*>(curr)) {
-                objectInvariants(ext->right, self, counter, thunks);
-                objectInvariants(ext->left, self, counter, thunks);
-            } else {
+    /** Auxiliary function of objectIndex.
+     *
+     * Traverse the object's tree from right to left, looking for an object
+     * with the given field.  Call with offset initially set to 0.
+     *
+     * \param f The field we're looking for.
+     * \param curr The root object.
+     * \param start_from Step over this many leaves first.
+     * \param counter Return the level of "super" that contained the field.
+     * \param self Return the new root.
+     * \returns The first object with the field, or nullptr if it could not be found.
+     */
+    HeapLeafObject *findObject(const Identifier *f, HeapObject *root, HeapObject *curr,
+                               unsigned start_from, unsigned &counter,
+                               HeapObject *&self)
+    {
+        if (auto *ext = dynamic_cast<HeapExtendedObject*>(curr)) {
+            auto *r = findObject(f, root, ext->right, start_from, counter, self);
+            if (r) return r;
+            auto *l = findObject(f, root, ext->left, start_from, counter, self);
+            if (l) return l;
+        } else {
+            if (counter >= start_from) {
                 if (auto *simp = dynamic_cast<HeapSimpleObject*>(curr)) {
-                    for (AST *assert : simp->asserts) {
-                        auto *el_th = makeHeap<HeapThunk>(idInvariant,
-                                                          self, counter, assert);
-                        el_th->upValues = simp->upValues;
-                        thunks.push_back(el_th);
+                    auto it = simp->fields.find(f);
+                    if (it != simp->fields.end()) {
+                        self = root;
+                        return simp;
+                    }
+                } else if (auto *comp = dynamic_cast<HeapComprehensionObject*>(curr)) {
+                    auto it = comp->compValues.find(f);
+                    if (it != comp->compValues.end()) {
+                        self = root;
+                        return comp;
                     }
                 }
-                counter++;
             }
+            counter++;
+        }
+        return nullptr;
+    }
+
+    typedef std::map<const Identifier*, ObjectField::Hide> IdHideMap;
+
+    /** Auxiliary function.
+     */
+    IdHideMap objectFields(const HeapObject *obj_,
+                           unsigned &counter, unsigned skip,
+                           bool manifesting)
+    {
+        IdHideMap r;
+        if (auto *obj = dynamic_cast<const HeapSimpleObject*>(obj_)) {
+            counter++;
+            if (counter <= skip) return r;
+            for (const auto &f : obj->fields) {
+                r[f.first] = !manifesting ? ObjectField::VISIBLE : f.second.hide;
+            }
+
+        } else if (auto *obj = dynamic_cast<const HeapExtendedObject*>(obj_)) {
+            r = objectFields(obj->right, counter, skip, manifesting);
+            for (const auto &pair : objectFields(obj->left, counter, skip, manifesting)) {
+                auto it = r.find(pair.first);
+                if (it == r.end()) {
+                    // First time it is seen
+                    r[pair.first] = pair.second;
+                } else if (it->second == ObjectField::INHERIT) {
+                    // Seen before, but with inherited visibility so use new visibility
+                    r[pair.first] = pair.second;
+                }
+            }
+
+        } else if (auto *obj = dynamic_cast<const HeapComprehensionObject*>(obj_)) {
+            counter++;
+            if (counter <= skip) return r;
+            for (const auto &f : obj->compValues)
+                r[f.first] = ObjectField::VISIBLE;
+        }
+        return r;
+    }
+
+    /** Auxiliary function.
+     */
+    std::set<const Identifier*> objectFields(const HeapObject *obj_, bool manifesting)
+    {
+        unsigned counter = 0;
+        std::set<const Identifier*> r;
+        for (const auto &pair : objectFields(obj_, counter, 0, manifesting)) {
+            if (pair.second != ObjectField::HIDDEN) r.insert(pair.first);
+        }
+        return r;
+    }
+
+    /** Import another Jsonnet file.
+     *
+     * If the file has already been imported, then use that version.  This maintains
+     * referential transparency in the case of writes to disk during execution.
+     *
+     * \param loc Location of the import statement.
+     * \param file Path to the filename.
+     */
+    AST *import(const LocationRange &loc, const LiteralString *file)
+    {
+        const ImportCacheValue *input = importString(loc, file);
+        Tokens tokens = jsonnet_lex(input->foundHere, input->content.c_str());
+        AST *expr = jsonnet_parse(alloc, tokens);
+        jsonnet_desugar(alloc, expr);
+        jsonnet_static_analysis(expr);
+        return expr;
+    }
+
+    /** Import a file as a string.
+     *
+     * If the file has already been imported, then use that version.  This maintains
+     * referential transparency in the case of writes to disk during execution.
+     *
+     * \param loc Location of the import statement.
+     * \param file Path to the filename.
+     * \param found_here If non-null, used to store the actual path of the file
+     */
+    const ImportCacheValue *importString(const LocationRange &loc, const LiteralString *file)
+    {
+        std::string dir = dir_name(loc.file);
+
+        const String &path = file->value;
+
+        std::pair<std::string, String> key(dir, path);
+        const ImportCacheValue *cached_value = cachedImports[key];
+        if (cached_value != nullptr)
+            return cached_value;
+
+        int success = 0;
+        char *found_here_cptr;
+        char *content =
+            importCallback(importCallbackContext, dir.c_str(), encode_utf8(path).c_str(),
+                           &found_here_cptr, &success);
+
+        std::string input(content);
+        ::free(content);
+
+        if (!success) {
+            std::string msg = "Couldn't open import \"" + encode_utf8(path) + "\": ";
+            msg += input;
+            throw makeError(loc, msg);
         }
 
-        /** Index an object's field.
-         *
-         * \param loc Location where the e.f occured.
-         * \param obj The target
-         * \param f The field
-         */
-        const AST *objectIndex(const LocationRange &loc, HeapObject *obj,
-                               const Identifier *f, unsigned offset)
-        {
-            unsigned found_at = 0;
-            HeapObject *self = nullptr;
-            HeapLeafObject *found = findObject(f, obj, obj, offset, found_at, self);
-            if (found == nullptr) {
-                throw makeError(loc, "Field does not exist: " + encode_utf8(f->name));
-            }
-            if (auto *simp = dynamic_cast<HeapSimpleObject*>(found)) {
-                auto it = simp->fields.find(f);
-                const AST *body = it->second.body;
+        auto *input_ptr = new ImportCacheValue();
+        input_ptr->foundHere = found_here_cptr;
+        input_ptr->content = input;
+        ::free(found_here_cptr);
+        cachedImports[key] = input_ptr;
+        return input_ptr;
+    }
 
-                stack.newCall(loc, simp, self, found_at, simp->upValues);
-                return body;
-            } else {
-                // If a HeapLeafObject is not HeapSimpleObject, it must be HeapComprehensionObject.
-                auto *comp = static_cast<HeapComprehensionObject*>(found);
-                auto it = comp->compValues.find(f);
-                auto *th = it->second;
-                BindingFrame binds = comp->upValues;
-                binds[comp->id] = th;
-                stack.newCall(loc, comp, self, found_at, binds);
-                return comp->value;
+    /** Capture the required variables from the environment. */
+    BindingFrame capture(const std::vector<const Identifier*> &free_vars)
+    {
+        BindingFrame env;
+        for (auto fv : free_vars) {
+            auto *th = stack.lookUpVar(fv);
+            if (th != nullptr) {
+                env[fv] = th;
             }
         }
+        return env;
+    }
 
-        void runInvariants(const LocationRange &loc, HeapObject *self)
-        {
-            if (stack.alreadyExecutingInvariants(self)) return;
-
-            unsigned counter = 0;
-            stack.newFrame(FRAME_INVARIANTS, loc);
-            std::vector<HeapThunk*> &thunks = stack.top().thunks;
-            objectInvariants(self, self, counter, thunks);
-            if (thunks.size() == 0) {
-                stack.pop();
-                return;
-            }
-            HeapThunk *thunk = thunks[0];
-            unsigned initial_stack_size = stack.size();
-            stack.top().elementId = 1;
-            stack.top().self = self;
-            stack.newCall(loc, thunk,
-                          thunk->self, thunk->offset, thunk->upValues);
-            evaluate(thunk->body, initial_stack_size);
+    /** Count the number of leaves in the tree.
+     *
+     * \param obj The root of the tree.
+     * \param counter Initialize to 0, returns the number of leaves.
+     */
+    unsigned countLeaves(HeapObject *obj)
+    {
+        if (auto *ext = dynamic_cast<HeapExtendedObject*>(obj)) {
+            return countLeaves(ext->left) + countLeaves(ext->right);
+        } else {
+            return 1;
         }
+    }
 
-        /** Evaluate the given AST to a value.
-         *
-         * Rather than call itself recursively, this function maintains a separate stack of
-         * partially-evaluated constructs.  First, the AST is handled depending on its type.  If
-         * this cannot be completed without evaluating another AST (e.g. a sub expression) then a
-         * frame is pushed onto the stack containing the partial state, and the code jumps back to
-         * the beginning of this function.  Once there are no more ASTs to evaluate, the code
-         * executes the second part of the function to unwind the stack.  If the stack cannot be
-         * completely unwound without evaluating an AST then it jumps back to the beginning of the
-         * function again.  The process terminates when the AST has been processed and the stack is
-         * the same size it was at the beginning of the call to evaluate.
-         */
-        void evaluate(const AST *ast_, unsigned initial_stack_size)
-        {
-            recurse:
+    public:
 
-            switch (ast_->type) {
-                case AST_APPLY: {
-                    const auto &ast = *static_cast<const Apply*>(ast_);
-                    stack.newFrame(FRAME_APPLY_TARGET, ast_);
-                    ast_ = ast.target;
-                    goto recurse;
-                } break;
+    /** Create a new interpreter.
+     *
+     * \param loc The location range of the file to be executed.
+     */
+    Interpreter(Allocator *alloc, const ExtMap &ext_vars,
+                unsigned max_stack, double gc_min_objects, double gc_growth_trigger,
+                JsonnetImportCallback *import_callback, void *import_callback_context)
+      : heap(gc_min_objects, gc_growth_trigger), stack(max_stack), alloc(alloc),
+        idArrayElement(alloc->makeIdentifier(U"array_element")),
+        idInvariant(alloc->makeIdentifier(U"object_assert")), externalVars(ext_vars),
+        importCallback(import_callback), importCallbackContext(import_callback_context)
+    {
+        scratch = makeNull();
+    }
 
-                case AST_ARRAY: {
-                    const auto &ast = *static_cast<const Array*>(ast_);
-                    HeapObject *self;
-                    unsigned offset;
-                    stack.getSelfBinding(self, offset);
-                    scratch = makeArray({});
-                    auto &elements = static_cast<HeapArray*>(scratch.v.h)->elements;
-                    for (const auto &el : ast.elements) {
-                        auto *el_th = makeHeap<HeapThunk>(idArrayElement, self, offset, el.expr);
-                        el_th->upValues =  capture(el.expr->freeVariables);
-                        elements.push_back(el_th);
-                    }
-                } break;
+    /** Clean up the heap, stack, stash, and builtin function ASTs. */
+    ~Interpreter()
+    {
+        for (const auto &pair : cachedImports) {
+            delete pair.second;
+        }
+    }
 
-                case AST_BINARY: {
-                    const auto &ast = *static_cast<const Binary*>(ast_);
-                    stack.newFrame(FRAME_BINARY_LEFT, ast_);
-                    ast_ = ast.left;
-                    goto recurse;
-                } break;
+    const Value &getScratchRegister(void)
+    {
+        return scratch;
+    }
 
-                case AST_BUILTIN_FUNCTION: {
-                    const auto &ast = *static_cast<const BuiltinFunction*>(ast_);
-                    scratch = makeBuiltin(ast.id, ast.params);
-                } break;
+    void setScratchRegister(const Value &v)
+    {
+        scratch = v;
+    }
 
-                case AST_CONDITIONAL: {
-                    const auto &ast = *static_cast<const Conditional*>(ast_);
-                    stack.newFrame(FRAME_IF, ast_);
-                    ast_ = ast.cond;
-                    goto recurse;
-                } break;
 
-                case AST_ERROR: {
-                    const auto &ast = *static_cast<const Error*>(ast_);
-                    stack.newFrame(FRAME_ERROR, ast_);
-                    ast_ = ast.expr;
-                    goto recurse;
-                } break;
-
-                case AST_FUNCTION: {
-                    const auto &ast = *static_cast<const Function*>(ast_);
-                    auto env = capture(ast.freeVariables);
-                    HeapObject *self;
-                    unsigned offset;
-                    stack.getSelfBinding(self, offset);
-                    Identifiers ids;
-                    ids.reserve(ast.params.size());
-                    for (const auto &p : ast.params)
-                        ids.push_back(p.id);
-                    scratch = makeClosure(env, self, offset, ids, ast.body);
-                } break;
-
-                case AST_IMPORT: {
-                    const auto &ast = *static_cast<const Import*>(ast_);
-                    AST *expr = import(ast.location, ast.file);
-                    ast_ = expr;
-                    stack.newCall(ast.location, nullptr, nullptr, 0, BindingFrame());
-                    goto recurse;
-                } break;
-
-                case AST_IMPORTSTR: {
-                    const auto &ast = *static_cast<const Importstr*>(ast_);
-                    const ImportCacheValue *value = importString(ast.location, ast.file);
-                    scratch = makeString(decode_utf8(value->content));
-                } break;
-
-                case AST_INDEX: {
-                    const auto &ast = *static_cast<const Index*>(ast_);
-                    stack.newFrame(FRAME_INDEX_TARGET, ast_);
-                    ast_ = ast.target;
-                    goto recurse;
-                } break;
-
-                case AST_LOCAL: {
-                    const auto &ast = *static_cast<const Local*>(ast_);
-                    stack.newFrame(FRAME_LOCAL, ast_);
-                    Frame &f = stack.top();
-                    // First build all the thunks and bind them.
-                    HeapObject *self;
-                    unsigned offset;
-                    stack.getSelfBinding(self, offset);
-                    for (const auto &bind : ast.binds) {
-                        // Note that these 2 lines must remain separate to avoid the GC running
-                        // when bindings has a nullptr for key bind.first.
-                        auto *th = makeHeap<HeapThunk>(bind.var, self, offset, bind.body);
-                        f.bindings[bind.var] = th;
-                    }
-                    // Now capture the environment (including the new thunks, to make cycles).
-                    for (const auto &bind : ast.binds) {
-                        auto *thunk = f.bindings[bind.var];
-                        thunk->upValues = capture(bind.body->freeVariables);
-                    }
-                    ast_ = ast.body;
-                    goto recurse;
-                } break;
-
-                case AST_LITERAL_BOOLEAN: {
-                    const auto &ast = *static_cast<const LiteralBoolean*>(ast_);
-                    scratch = makeBoolean(ast.value);
-                } break;
-
-                case AST_LITERAL_NUMBER: {
-                    const auto &ast = *static_cast<const LiteralNumber*>(ast_);
-                    scratch = makeDoubleCheck(ast_->location, ast.value);
-                } break;
-
-                case AST_LITERAL_STRING: {
-                    const auto &ast = *static_cast<const LiteralString*>(ast_);
-                    scratch = makeString(ast.value);
-                } break;
-
-                case AST_LITERAL_NULL: {
-                    scratch = makeNull();
-                } break;
-
-                case AST_DESUGARED_OBJECT: {
-                    const auto &ast = *static_cast<const DesugaredObject*>(ast_);
-                    if (ast.fields.empty()) {
-                        auto env = capture(ast.freeVariables);
-                        std::map<const Identifier *, HeapSimpleObject::Field> fields;
-                        scratch = makeObject<HeapSimpleObject>(env, fields, ast.asserts);
-                    } else {
-                        auto env = capture(ast.freeVariables);
-                        stack.newFrame(FRAME_OBJECT, ast_);
-                        auto fit = ast.fields.begin();
-                        stack.top().fit = fit;
-                        ast_ = fit->name;
-                        goto recurse;
-                    }
-                } break;
-
-                case AST_OBJECT_COMPREHENSION_SIMPLE: {
-                    const auto &ast = *static_cast<const ObjectComprehensionSimple*>(ast_);
-                    stack.newFrame(FRAME_OBJECT_COMP_ARRAY, ast_);
-                    ast_ = ast.array;
-                    goto recurse;
-                } break;
-
-                case AST_SELF: {
-                    scratch.t = Value::OBJECT;
-                    HeapObject *self;
-                    unsigned offset;
-                    stack.getSelfBinding(self, offset);
-                    scratch.v.h = self;
-                } break;
-
-                case AST_SUPER_INDEX: {
-                    const auto &ast = *static_cast<const SuperIndex*>(ast_);
-                    stack.newFrame(FRAME_SUPER_INDEX, ast_);
-                    ast_ = ast.index;
-                    goto recurse;
-                } break;
-
-                case AST_UNARY: {
-                    const auto &ast = *static_cast<const Unary*>(ast_);
-                    stack.newFrame(FRAME_UNARY, ast_);
-                    ast_ = ast.expr;
-                    goto recurse;
-                } break;
-
-                case AST_VAR: {
-                    const auto &ast = *static_cast<const Var*>(ast_);
-                    auto *thunk = stack.lookUpVar(ast.id);
-                    if (thunk == nullptr) {
-                        std::cerr << "INTERNAL ERROR: Could not bind variable: "
-                                  << encode_utf8(ast.id->name) << std::endl;
-                        std::abort();
-                    }
-                    if (thunk->filled) {
-                        scratch = thunk->content;
-                    } else {
-                        stack.newCall(ast.location, thunk,
-                                      thunk->self, thunk->offset, thunk->upValues);
-                        ast_ = thunk->body;
-                        goto recurse;
-                    }
-                } break;
-
-                default:
-                std::cerr << "INTERNAL ERROR: Unknown AST: " << ast_->type << std::endl;
-                std::abort();
+    /** Raise an error if the arguments aren't the expected types. */
+    void validateBuiltinArgs(const LocationRange &loc,
+                             unsigned long builtin,
+                             const std::vector<Value> &args,
+                             const std::vector<Value::Type> params)
+    {
+        if (args.size() == params.size()) {
+            for (unsigned i=0 ; i<args.size() ; ++i) {
+                if (args[i].t != params[i]) goto bad;
             }
+            return;
+        }
+        bad:;
+        const String &name = jsonnet_builtin_decl(builtin).name;
+        std::stringstream ss;
+        ss << "Builtin function " + encode_utf8(name) + " expected (";
+        const char *prefix = "";
+        for (auto p : params) {
+            ss << prefix << type_str(p);
+            prefix = ", ";
+        }
+        ss << ") but got (";
+        prefix = "";
+        for (auto a : args) {
+            ss << prefix << type_str(a);
+            prefix = ", ";
+        }
+        ss << ")";
+        throw makeError(loc, ss.str());
+    }
 
-            // To evaluate another AST, set ast to it, then goto recurse.
-            // To pop, exit the switch or goto popframe
-            // To change the frame and re-enter the switch, goto replaceframe
-            while (stack.size() > initial_stack_size) {
+
+    String toString(const LocationRange &loc)
+    {
+        return manifestJson(loc, false, U"");
+    }
+
+
+
+    /** Recursively collect an object's invariants.
+     *
+     * \param curr
+     * \param self
+     * \param offset
+     * \param thunks
+     */
+    void objectInvariants(HeapObject *curr, HeapObject *self,
+                          unsigned &counter, std::vector<HeapThunk*> &thunks)
+    {
+        if (auto *ext = dynamic_cast<HeapExtendedObject*>(curr)) {
+            objectInvariants(ext->right, self, counter, thunks);
+            objectInvariants(ext->left, self, counter, thunks);
+        } else {
+            if (auto *simp = dynamic_cast<HeapSimpleObject*>(curr)) {
+                for (AST *assert : simp->asserts) {
+                    auto *el_th = makeHeap<HeapThunk>(idInvariant, self, counter, assert);
+                    el_th->upValues = simp->upValues;
+                    thunks.push_back(el_th);
+                }
+            }
+            counter++;
+        }
+    }
+
+    /** Index an object's field.
+     *
+     * \param loc Location where the e.f occured.
+     * \param obj The target
+     * \param f The field
+     */
+    const AST *objectIndex(const LocationRange &loc, HeapObject *obj,
+                           const Identifier *f, unsigned offset)
+    {
+        unsigned found_at = 0;
+        HeapObject *self = nullptr;
+        HeapLeafObject *found = findObject(f, obj, obj, offset, found_at, self);
+        if (found == nullptr) {
+            throw makeError(loc, "Field does not exist: " + encode_utf8(f->name));
+        }
+        if (auto *simp = dynamic_cast<HeapSimpleObject*>(found)) {
+            auto it = simp->fields.find(f);
+            const AST *body = it->second.body;
+
+            stack.newCall(loc, simp, self, found_at, simp->upValues);
+            return body;
+        } else {
+            // If a HeapLeafObject is not HeapSimpleObject, it must be HeapComprehensionObject.
+            auto *comp = static_cast<HeapComprehensionObject*>(found);
+            auto it = comp->compValues.find(f);
+            auto *th = it->second;
+            BindingFrame binds = comp->upValues;
+            binds[comp->id] = th;
+            stack.newCall(loc, comp, self, found_at, binds);
+            return comp->value;
+        }
+    }
+
+    void runInvariants(const LocationRange &loc, HeapObject *self)
+    {
+        if (stack.alreadyExecutingInvariants(self)) return;
+
+        unsigned counter = 0;
+        stack.newFrame(FRAME_INVARIANTS, loc);
+        std::vector<HeapThunk*> &thunks = stack.top().thunks;
+        objectInvariants(self, self, counter, thunks);
+        if (thunks.size() == 0) {
+            stack.pop();
+            return;
+        }
+        HeapThunk *thunk = thunks[0];
+        unsigned initial_stack_size = stack.size();
+        stack.top().elementId = 1;
+        stack.top().self = self;
+        stack.newCall(loc, thunk, thunk->self, thunk->offset, thunk->upValues);
+        evaluate(thunk->body, initial_stack_size);
+    }
+
+    /** Evaluate the given AST to a value.
+     *
+     * Rather than call itself recursively, this function maintains a separate stack of
+     * partially-evaluated constructs.  First, the AST is handled depending on its type.  If
+     * this cannot be completed without evaluating another AST (e.g. a sub expression) then a
+     * frame is pushed onto the stack containing the partial state, and the code jumps back to
+     * the beginning of this function.  Once there are no more ASTs to evaluate, the code
+     * executes the second part of the function to unwind the stack.  If the stack cannot be
+     * completely unwound without evaluating an AST then it jumps back to the beginning of the
+     * function again.  The process terminates when the AST has been processed and the stack is
+     * the same size it was at the beginning of the call to evaluate.
+     */
+    void evaluate(const AST *ast_, unsigned initial_stack_size)
+    {
+        recurse:
+
+        switch (ast_->type) {
+            case AST_APPLY: {
+                const auto &ast = *static_cast<const Apply*>(ast_);
+                stack.newFrame(FRAME_APPLY_TARGET, ast_);
+                ast_ = ast.target;
+                goto recurse;
+            } break;
+
+            case AST_ARRAY: {
+                const auto &ast = *static_cast<const Array*>(ast_);
+                HeapObject *self;
+                unsigned offset;
+                stack.getSelfBinding(self, offset);
+                scratch = makeArray({});
+                auto &elements = static_cast<HeapArray*>(scratch.v.h)->elements;
+                for (const auto &el : ast.elements) {
+                    auto *el_th = makeHeap<HeapThunk>(idArrayElement, self, offset, el.expr);
+                    el_th->upValues =  capture(el.expr->freeVariables);
+                    elements.push_back(el_th);
+                }
+            } break;
+
+            case AST_BINARY: {
+                const auto &ast = *static_cast<const Binary*>(ast_);
+                stack.newFrame(FRAME_BINARY_LEFT, ast_);
+                ast_ = ast.left;
+                goto recurse;
+            } break;
+
+            case AST_BUILTIN_FUNCTION: {
+                const auto &ast = *static_cast<const BuiltinFunction*>(ast_);
+                scratch = makeBuiltin(ast.id, ast.params);
+            } break;
+
+            case AST_CONDITIONAL: {
+                const auto &ast = *static_cast<const Conditional*>(ast_);
+                stack.newFrame(FRAME_IF, ast_);
+                ast_ = ast.cond;
+                goto recurse;
+            } break;
+
+            case AST_ERROR: {
+                const auto &ast = *static_cast<const Error*>(ast_);
+                stack.newFrame(FRAME_ERROR, ast_);
+                ast_ = ast.expr;
+                goto recurse;
+            } break;
+
+            case AST_FUNCTION: {
+                const auto &ast = *static_cast<const Function*>(ast_);
+                auto env = capture(ast.freeVariables);
+                HeapObject *self;
+                unsigned offset;
+                stack.getSelfBinding(self, offset);
+                Identifiers ids;
+                ids.reserve(ast.params.size());
+                for (const auto &p : ast.params)
+                    ids.push_back(p.id);
+                scratch = makeClosure(env, self, offset, ids, ast.body);
+            } break;
+
+            case AST_IMPORT: {
+                const auto &ast = *static_cast<const Import*>(ast_);
+                AST *expr = import(ast.location, ast.file);
+                ast_ = expr;
+                stack.newCall(ast.location, nullptr, nullptr, 0, BindingFrame());
+                goto recurse;
+            } break;
+
+            case AST_IMPORTSTR: {
+                const auto &ast = *static_cast<const Importstr*>(ast_);
+                const ImportCacheValue *value = importString(ast.location, ast.file);
+                scratch = makeString(decode_utf8(value->content));
+            } break;
+
+            case AST_INDEX: {
+                const auto &ast = *static_cast<const Index*>(ast_);
+                stack.newFrame(FRAME_INDEX_TARGET, ast_);
+                ast_ = ast.target;
+                goto recurse;
+            } break;
+
+            case AST_LOCAL: {
+                const auto &ast = *static_cast<const Local*>(ast_);
+                stack.newFrame(FRAME_LOCAL, ast_);
                 Frame &f = stack.top();
-                switch (f.kind) {
-                    case FRAME_APPLY_TARGET: {
-                        const auto &ast = *static_cast<const Apply*>(f.ast);
-                        if (scratch.t != Value::FUNCTION) {
-                            throw makeError(ast.location,
-                                            "Only functions can be called, got "
-                                            + type_str(scratch));
-                        }
-                        auto *func = static_cast<HeapClosure*>(scratch.v.h);
-                        if (ast.args.size() != func->params.size()) {
-                            std::stringstream ss;
-                            ss << "Expected " << func->params.size() <<
-                                  " arguments, got " << ast.args.size() << ".";
-                            throw makeError(ast.location, ss.str());
-                        }
-
-                        // Create thunks for arguments.
-                        for (unsigned i=0 ; i<ast.args.size() ; ++i) {
-                            const auto &arg = ast.args[i];
-                            HeapObject *self;
-                            unsigned offset;
-                            stack.getSelfBinding(self, offset);
-                            auto *thunk =
-                                makeHeap<HeapThunk>(func->params[i], self, offset, arg.expr);
-                            thunk->upValues = capture(arg.expr->freeVariables);
-                            f.thunks.push_back(thunk);
-                        }
-                        // Popping stack frame invalidates the f reference.
-                        std::vector<HeapThunk*> args = f.thunks;
-
-                        stack.pop();
-
-                        if (func->body == nullptr) {
-                            // Built-in function.
-                            // Give nullptr for self because noone looking at this frame will
-                            // attempt to bind to self (it's native code).
-                            stack.newFrame(FRAME_BUILTIN_FORCE_THUNKS, f.ast);
-                            stack.top().thunks = args;
-                            stack.top().val = scratch;
-                            goto replaceframe;
-                        } else {
-                            // User defined function.
-                            BindingFrame bindings = func->upValues;
-                            for (unsigned i=0 ; i<func->params.size() ; ++i)
-                                bindings[func->params[i]] = args[i];
-                            stack.newCall(ast.location, func, func->self, func->offset, bindings);
-                            if (ast.tailstrict) {
-                                stack.top().tailCall = true;
-                                if (args.size() == 0) {
-                                    // No need to force thunks, proceed straight to body.
-                                    ast_ = func->body;
-                                    goto recurse;
-                                } else {
-                                    // The check for args.size() > 0 
-                                    stack.top().thunks = args;
-                                    stack.top().val = scratch;
-                                    goto replaceframe;
-                                }
-                            } else {
-                                ast_ = func->body;
-                                goto recurse;
-                            }
-                        }
-                    } break;
-
-                    case FRAME_BINARY_LEFT: {
-                        const auto &ast = *static_cast<const Binary*>(f.ast);
-                        const Value &lhs = scratch;
-                        if (lhs.t == Value::BOOLEAN) {
-                            // Handle short-cut semantics
-                            switch (ast.op) {
-                                case BOP_AND: {
-                                    if (!lhs.v.b) {
-                                        scratch = makeBoolean(false);
-                                        goto popframe;
-                                    }
-                                } break;
-
-                                case BOP_OR: {
-                                    if (lhs.v.b) {
-                                        scratch = makeBoolean(true);
-                                        goto popframe;
-                                    }
-                                } break;
-
-                                default:;
-                            }
-                        }
-                        stack.top().kind = FRAME_BINARY_RIGHT;
-                        stack.top().val = lhs;
-                        ast_ = ast.right;
-                        goto recurse;
-                    } break;
-
-                    case FRAME_BINARY_RIGHT: {
-                        const auto &ast = *static_cast<const Binary*>(f.ast);
-                        const Value &lhs = stack.top().val;
-                        const Value &rhs = scratch;
-                        if (lhs.t == Value::STRING || rhs.t == Value::STRING) {
-                            if (ast.op == BOP_PLUS) {
-                                // Handle co-ercions for string processing.
-                                stack.top().kind = FRAME_STRING_CONCAT;
-                                stack.top().val2 = rhs;
-                                goto replaceframe;
-                            }
-                        }
-                        // Equality can be used when the types don't match.
-                        switch (ast.op) {
-                            case BOP_MANIFEST_EQUAL:
-                            std::cerr << "INTERNAL ERROR: Equals not desugared" << std::endl;
-                            abort();
-
-                            case BOP_MANIFEST_UNEQUAL:
-                            std::cerr << "INTERNAL ERROR: Notequals not desugared" << std::endl;
-                            abort();
-
-                            default:;
-                        }
-                        // Everything else requires matching types.
-                        if (lhs.t != rhs.t) {
-                            throw makeError(ast.location,
-                                            "Binary operator " + bop_string(ast.op) + " requires "
-                                            "matching types, got " + type_str(lhs) + " and " +
-                                            type_str(rhs) + ".");
-                        }
-                        switch (lhs.t) {
-                            case Value::ARRAY:
-                            if (ast.op == BOP_PLUS) {
-                                auto *arr_l = static_cast<HeapArray*>(lhs.v.h);
-                                auto *arr_r = static_cast<HeapArray*>(rhs.v.h);
-                                std::vector<HeapThunk*> elements;
-                                for (auto *el : arr_l->elements)
-                                    elements.push_back(el);
-                                for (auto *el : arr_r->elements)
-                                    elements.push_back(el);
-                                scratch = makeArray(elements);
-                            } else {
-                                throw makeError(ast.location,
-                                                "Binary operator " + bop_string(ast.op)
-                                                + " does not operate on arrays.");
-                            }
-                            break;
-
-                            case Value::BOOLEAN:
-                            switch (ast.op) {
-                                case BOP_AND:
-                                scratch = makeBoolean(lhs.v.b && rhs.v.b);
-                                break;
-
-                                case BOP_OR:
-                                scratch = makeBoolean(lhs.v.b || rhs.v.b);
-                                break;
-
-                                default:
-                                throw makeError(ast.location,
-                                                "Binary operator " + bop_string(ast.op)
-                                                + " does not operate on booleans.");
-                            }
-                            break;
-
-                            case Value::DOUBLE:
-                            switch (ast.op) {
-                                case BOP_PLUS:
-                                scratch = makeDoubleCheck(ast.location, lhs.v.d + rhs.v.d);
-                                break;
-
-                                case BOP_MINUS:
-                                scratch = makeDoubleCheck(ast.location, lhs.v.d - rhs.v.d);
-                                break;
-
-                                case BOP_MULT:
-                                scratch = makeDoubleCheck(ast.location, lhs.v.d * rhs.v.d);
-                                break;
-
-                                case BOP_DIV:
-                                if (rhs.v.d == 0)
-                                    throw makeError(ast.location, "Division by zero.");
-                                scratch = makeDoubleCheck(ast.location, lhs.v.d / rhs.v.d);
-                                break;
-
-                                // No need to check doubles made from longs
-
-                                case BOP_SHIFT_L: {
-                                    long long_l = lhs.v.d;
-                                    long long_r = rhs.v.d;
-                                    scratch = makeDouble(long_l << long_r);
-                                } break;
-
-                                case BOP_SHIFT_R: {
-                                    long long_l = lhs.v.d;
-                                    long long_r = rhs.v.d;
-                                    scratch = makeDouble(long_l >> long_r);
-                                } break;
-
-                                case BOP_BITWISE_AND: {
-                                    long long_l = lhs.v.d;
-                                    long long_r = rhs.v.d;
-                                    scratch = makeDouble(long_l & long_r);
-                                } break;
-
-                                case BOP_BITWISE_XOR: {
-                                    long long_l = lhs.v.d;
-                                    long long_r = rhs.v.d;
-                                    scratch = makeDouble(long_l ^ long_r);
-                                } break;
-
-                                case BOP_BITWISE_OR: {
-                                    long long_l = lhs.v.d;
-                                    long long_r = rhs.v.d;
-                                    scratch = makeDouble(long_l | long_r);
-                                } break;
-
-                                case BOP_LESS_EQ:
-                                scratch = makeBoolean(lhs.v.d <= rhs.v.d);
-                                break;
-
-                                case BOP_GREATER_EQ:
-                                scratch = makeBoolean(lhs.v.d >= rhs.v.d);
-                                break;
-
-                                case BOP_LESS:
-                                scratch = makeBoolean(lhs.v.d < rhs.v.d);
-                                break;
-
-                                case BOP_GREATER:
-                                scratch = makeBoolean(lhs.v.d > rhs.v.d);
-                                break;
-
-                                default:
-                                throw makeError(ast.location,
-                                                "Binary operator " + bop_string(ast.op)
-                                                + " does not operate on numbers.");
-                            }
-                            break;
-
-                            case Value::FUNCTION:
-                            throw makeError(ast.location, "Binary operator " + bop_string(ast.op) +
-                                                          " does not operate on functions.");
-
-                            case Value::NULL_TYPE:
-                            throw makeError(ast.location, "Binary operator " + bop_string(ast.op) +
-                                                          " does not operate on null.");
-
-                            case Value::OBJECT: {
-                                if (ast.op != BOP_PLUS) {
-                                    throw makeError(ast.location,
-                                                    "Binary operator " + bop_string(ast.op) +
-                                                    " does not operate on objects.");
-                                }
-                                auto *lhs_obj = static_cast<HeapObject*>(lhs.v.h);
-                                auto *rhs_obj = static_cast<HeapObject*>(rhs.v.h);
-                                scratch = makeObject<HeapExtendedObject>(lhs_obj, rhs_obj);
-                            }
-                            break;
-
-                            case Value::STRING: {
-                                const String &lhs_str =
-                                    static_cast<HeapString*>(lhs.v.h)->value;
-                                const String &rhs_str =
-                                    static_cast<HeapString*>(rhs.v.h)->value;
-                                switch (ast.op) {
-                                    case BOP_PLUS:
-                                    scratch = makeString(lhs_str + rhs_str);
-                                    break;
-
-                                    case BOP_LESS_EQ:
-                                    scratch = makeBoolean(lhs_str <= rhs_str);
-                                    break;
-
-                                    case BOP_GREATER_EQ:
-                                    scratch = makeBoolean(lhs_str >= rhs_str);
-                                    break;
-
-                                    case BOP_LESS:
-                                    scratch = makeBoolean(lhs_str < rhs_str);
-                                    break;
-
-                                    case BOP_GREATER:
-                                    scratch = makeBoolean(lhs_str > rhs_str);
-                                    break;
-
-                                    default:
-                                    throw makeError(ast.location,
-                                                    "Binary operator " + bop_string(ast.op)
-                                                    + " does not operate on strings.");
-                                }
-                            }
-                            break;
-                        }
-                    } break;
-
-                    case FRAME_BUILTIN_FILTER: {
-                        const auto &ast = *static_cast<const Apply*>(f.ast);
-                        auto *func = static_cast<HeapClosure*>(f.val.v.h);
-                        auto *arr = static_cast<HeapArray*>(f.val2.v.h);
-                        if (scratch.t != Value::BOOLEAN) {
-                            throw makeError(ast.location,
-                                            "filter function must return boolean, got: "
-                                            + type_str(scratch));
-                        }
-                        if (scratch.v.b) f.thunks.push_back(arr->elements[f.elementId]);
-                        f.elementId++;
-                        // Iterate through arr, calling the function on each.
-                        if (f.elementId == arr->elements.size()) {
-                            scratch = makeArray(f.thunks);
-                        } else {
-                            auto *thunk = arr->elements[f.elementId];
-                            BindingFrame bindings = func->upValues;
-                            bindings[func->params[0]] = thunk;
-                            stack.newCall(ast.location, func, func->self, func->offset, bindings);
-                            ast_ = func->body;
-                            goto recurse;
-                        }
-                    } break;
-
-                    case FRAME_BUILTIN_FORCE_THUNKS: {
-                        const auto &ast = *static_cast<const Apply*>(f.ast);
-                        auto *func = static_cast<HeapClosure*>(f.val.v.h);
-                        if (f.elementId == f.thunks.size()) {
-                            // All thunks forced, now the builtin implementations.
-                            const LocationRange &loc = ast.location;
-                            unsigned builtin = func->builtin;
-                            std::vector<Value> args;
-                            for (auto *th : f.thunks) {
-                                args.push_back(th->content);
-                            }
-                            switch (builtin) {
-                                case 0: { // makeArray
-                                    validateBuiltinArgs(loc, builtin, args,
-                                                        {Value::DOUBLE, Value::FUNCTION});
-                                    long sz = long(args[0].v.d);
-                                    if (sz < 0) {
-                                        std::stringstream ss;
-                                        ss << "makeArray requires size >= 0, got " << sz;
-                                        throw makeError(loc, ss.str());
-                                    }
-                                    auto *func = static_cast<const HeapClosure*>(args[1].v.h);
-                                    std::vector<HeapThunk*> elements;
-                                    if (func->params.size() != 1) {
-                                        std::stringstream ss;
-                                        ss << "makeArray function must take 1 param, got: "
-                                           << func->params.size();
-                                        throw makeError(loc, ss.str());
-                                    }
-                                    elements.resize(sz);
-                                    for (long i=0 ; i<sz ; ++i) {
-                                        auto *th = makeHeap<HeapThunk>(idArrayElement, func->self,
-                                                                       func->offset, func->body);
-                                        // The next line stops the new thunks from being GCed.
-                                        f.thunks.push_back(th);
-                                        th->upValues = func->upValues;
-
-                                        auto *el = makeHeap<HeapThunk>(func->params[0], nullptr,
-                                                                       0, nullptr);
-                                        el->fill(makeDouble(i));  // i guaranteed not to be inf/NaN
-                                        th->upValues[func->params[0]] = el;
-                                        elements[i] = th;
-                                    }
-                                    scratch = makeArray(elements);
-                                } break;
-
-                                case 1:  // pow
-                                validateBuiltinArgs(loc, builtin, args,
-                                                    {Value::DOUBLE, Value::DOUBLE});
-                                scratch = makeDoubleCheck(loc,
-                                                             std::pow(args[0].v.d, args[1].v.d));
-                                break;
-
-                                case 2:  // floor
-                                validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
-                                scratch = makeDoubleCheck(loc, std::floor(args[0].v.d));
-                                break;
-
-                                case 3:  // ceil
-                                validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
-                                scratch = makeDoubleCheck(loc, std::ceil(args[0].v.d));
-                                break;
-
-                                case 4:  // sqrt
-                                validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
-                                scratch = makeDoubleCheck(loc, std::sqrt(args[0].v.d));
-                                break;
-
-                                case 5:  // sin
-                                validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
-                                scratch = makeDoubleCheck(loc, std::sin(args[0].v.d));
-                                break;
-
-                                case 6:  // cos
-                                validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
-                                scratch = makeDoubleCheck(loc, std::cos(args[0].v.d));
-                                break;
-
-                                case 7:  // tan
-                                validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
-                                scratch = makeDoubleCheck(loc, std::tan(args[0].v.d));
-                                break;
-
-                                case 8:  // asin
-                                validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
-                                scratch = makeDoubleCheck(loc, std::asin(args[0].v.d));
-                                break;
-
-                                case 9:  // acos
-                                validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
-                                scratch = makeDoubleCheck(loc, std::acos(args[0].v.d));
-                                break;
-
-                                case 10:  // atan
-                                validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
-                                scratch = makeDoubleCheck(loc, std::atan(args[0].v.d));
-                                break;
-
-                                case 11: {  // type
-                                    switch (args[0].t) {
-                                        case Value::NULL_TYPE:
-                                        scratch = makeString(U"null");
-                                        break;
-
-                                        case Value::BOOLEAN:
-                                        scratch = makeString(U"boolean");
-                                        break;
-
-                                        case Value::DOUBLE:
-                                        scratch = makeString(U"number");
-                                        break;
-
-                                        case Value::ARRAY:
-                                        scratch = makeString(U"array");
-                                        break;
-
-                                        case Value::FUNCTION:
-                                        scratch = makeString(U"function");
-                                        break;
-
-                                        case Value::OBJECT:
-                                        scratch = makeString(U"object");
-                                        break;
-
-                                        case Value::STRING:
-                                        scratch = makeString(U"string");
-                                        break;
-
-                                    }
-                                }
-                                break;
-
-                                case 12: {  // filter
-                                    validateBuiltinArgs(loc, builtin, args,
-                                                        {Value::FUNCTION, Value::ARRAY});
-                                    auto *func = static_cast<HeapClosure*>(args[0].v.h);
-                                    auto *arr = static_cast<HeapArray*>(args[1].v.h);
-                                    if (func->params.size() != 1) {
-                                        throw makeError(loc, "filter function takes 1 parameter.");
-                                    }
-                                    if (arr->elements.size() == 0) {
-                                        scratch = makeArray({});
-                                    } else {
-                                        f.kind = FRAME_BUILTIN_FILTER;
-                                        f.val = args[0];
-                                        f.val2 = args[1];
-                                        f.thunks.clear();
-                                        f.elementId = 0;
-
-                                        auto *thunk = arr->elements[f.elementId];
-                                        BindingFrame bindings = func->upValues;
-                                        bindings[func->params[0]] = thunk;
-                                        stack.newCall(loc, func, func->self, func->offset,
-                                                      bindings);
-                                        ast_ = func->body;
-                                        goto recurse;
-                                    }
-                                } break;
-
-                                case 13: {  // objectHasEx
-                                    validateBuiltinArgs(loc, builtin, args,
-                                                        {Value::OBJECT, Value::STRING,
-                                                         Value::BOOLEAN});
-                                    const auto *obj = static_cast<const HeapObject*>(args[0].v.h);
-                                    const auto *str = static_cast<const HeapString*>(args[1].v.h);
-                                    bool include_hidden = args[2].v.b;
-                                    bool found = false;
-                                    for (const auto &field : objectFields(obj, !include_hidden)) {
-                                        if (field->name == str->value) {
-                                            found = true;
-                                            break;
-                                        }
-                                    }
-                                    scratch = makeBoolean(found);
-                                } break;
-
-                                case 14: {  // length
-                                    if (args.size() != 1) {
-                                        throw makeError(loc, "length takes 1 parameter.");
-                                    }
-                                    HeapEntity *e = args[0].v.h;
-                                    switch (args[0].t) {
-                                        case Value::OBJECT: {
-                                            auto fields =
-                                                objectFields(static_cast<HeapObject*>(e), true);
-                                            scratch = makeDouble(fields.size());
-                                        } break;
-
-                                        case Value::ARRAY:
-                                        scratch = makeDouble(static_cast<HeapArray*>(e)
-                                                             ->elements.size());
-                                        break;
-
-                                        case Value::STRING:
-                                        scratch = makeDouble(static_cast<HeapString*>(e)
-                                                             ->value.length());
-                                        break;
-
-                                        case Value::FUNCTION:
-                                        scratch = makeDouble(static_cast<HeapClosure*>(e)
-                                                             ->params.size());
-                                        break;
-
-                                        default:
-                                        throw makeError(loc,
-                                                        "length operates on strings, objects, "
-                                                        "and arrays, got " + type_str(args[0]));
-                                    }
-                                } break;
-
-                                case 15: {  // objectFieldsEx
-                                    validateBuiltinArgs(loc, builtin, args,
-                                                        {Value::OBJECT, Value::BOOLEAN});
-                                    const auto *obj = static_cast<HeapObject*>(args[0].v.h);
-                                    bool include_hidden = args[1].v.b;
-                                    // Stash in a set first to sort them.
-                                    std::set<String> fields;
-                                    for (const auto &field : objectFields(obj, !include_hidden)) {
-                                        fields.insert(field->name);
-                                    }
-                                    scratch = makeArray({});
-                                    auto &elements = static_cast<HeapArray*>(scratch.v.h)->elements;
-                                    for (const auto &field : fields) {
-                                        auto *th = makeHeap<HeapThunk>(idArrayElement, nullptr,
-                                                                       0, nullptr);
-                                        elements.push_back(th);
-                                        th->fill(makeString(field));
-                                    }
-                                } break;
-
-                                case 16: { // codepoint
-                                    validateBuiltinArgs(loc, builtin, args, {Value::STRING});
-                                    const String &str =
-                                        static_cast<HeapString*>(args[0].v.h)->value;
-                                    if (str.length() != 1) {
-                                        std::stringstream ss;
-                                        ss << "codepoint takes a string of length 1, got length "
-                                           << str.length();
-                                        throw makeError(loc, ss.str());
-                                    }
-                                    char32_t c = static_cast<HeapString*>(args[0].v.h)->value[0];
-                                    scratch = makeDouble((unsigned long)(c));
-                                } break;
-
-                                case 17: { // char
-                                    validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
-                                    long l = long(args[0].v.d);
-                                    if (l < 0) {
-                                        std::stringstream ss;
-                                        ss << "Codepoints must be >= 0, got " << l;
-                                        throw makeError(ast.location, ss.str());
-                                    }
-                                    if (l >= JSONNET_CODEPOINT_MAX) {
-                                        std::stringstream ss;
-                                        ss << "Invalid unicode codepoint, got " << l;
-                                        throw makeError(ast.location, ss.str());
-                                    }
-                                    char32_t c = l;
-                                    scratch = makeString(String(&c, 1));
-                                } break;
-
-                                case 18: {  // log
-                                    validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
-                                    scratch = makeDoubleCheck(loc, std::log(args[0].v.d));
-                                } break;
-
-                                case 19: {  // exp
-                                    validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
-                                    scratch = makeDoubleCheck(loc, std::exp(args[0].v.d));
-                                } break;
-
-                                case 20: {  // mantissa
-                                    validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
-                                    int exp;
-                                    double m = std::frexp(args[0].v.d, &exp);
-                                    scratch = makeDoubleCheck(loc, m);
-                                } break;
-
-                                case 21: {  // exponent
-                                    validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
-                                    int exp;
-                                    std::frexp(args[0].v.d, &exp);
-                                    scratch = makeDoubleCheck(loc, exp);
-                                } break;
-
-                                case 22: {  // modulo
-                                    validateBuiltinArgs(loc, builtin, args,
-                                                        {Value::DOUBLE, Value::DOUBLE});
-                                    double a = args[0].v.d;
-                                    double b = args[1].v.d;
-                                    if (b == 0)
-                                        throw makeError(ast.location, "Division by zero.");
-                                    scratch = makeDoubleCheck(loc, std::fmod(a, b));
-                                } break;
-
-                                case 23: {  // extVar
-                                    validateBuiltinArgs(loc, builtin, args, {Value::STRING});
-                                    const String &var =
-                                        static_cast<HeapString*>(args[0].v.h)->value;
-                                    std::string var8 = encode_utf8(var);
-                                    auto it = externalVars.find(var8);
-                                    if (it == externalVars.end()) {
-                                        std::string msg = "Undefined external variable: " + var8;
-                                        throw makeError(ast.location, msg);
-                                    }
-                                    const VmExt &ext = it->second;
-                                    if (ext.isCode) {
-                                        std::string filename = "<extvar:" + var8 + ">";
-                                        Tokens tokens = jsonnet_lex(filename, ext.data.c_str());
-                                        AST *expr = jsonnet_parse(alloc, tokens);
-                                        jsonnet_desugar(alloc, expr);
-                                        jsonnet_static_analysis(expr);
-                                        ast_ = expr;
-                                        stack.pop();
-                                        goto recurse;
-                                    } else {
-                                        scratch = makeString(decode_utf8(ext.data));
-                                    }
-                                } break;
-
-                                case 24: {  // primitiveEquals
-                                    if (args.size() != 2) {
-                                        throw makeError(loc, "primitiveEquals takes 2 parameters.");
-                                    }
-                                    if (args[0].t != args[1].t) {
-                                        scratch = makeBoolean(false);
-                                        break;
-                                    }
-                                    bool r;
-                                    switch (args[0].t) {
-                                        case Value::BOOLEAN:
-                                        r = args[0].v.b == args[1].v.b;
-                                        break;
-
-                                        case Value::DOUBLE:
-                                        r = args[0].v.d == args[1].v.d;
-                                        break;
-
-                                        case Value::STRING:
-                                        r = static_cast<HeapString*>(args[0].v.h)->value
-                                          == static_cast<HeapString*>(args[1].v.h)->value;
-                                        break;
-
-                                        case Value::NULL_TYPE:
-                                        r = true;
-                                        break;
-
-                                        case Value::FUNCTION:
-                                        throw makeError(loc, "Cannot test equality of functions");
-                                        break;
-
-                                        default:
-                                        throw makeError(loc,
-                                                        "primitiveEquals operates on primitive "
-                                                        "types, got " + type_str(args[0]));
-                                    }
-                                    scratch = makeBoolean(r);
-                                } break;
-
-                                default:
-                                std::cerr << "INTERNAL ERROR: Unrecognized builtin: " << builtin
-                                          << std::endl;
-                                std::abort();
-                            }
-
-                        } else {
-                            HeapThunk *th = f.thunks[f.elementId++];
-                            if (!th->filled) {
-                                stack.newCall(ast.location, th, th->self, th->offset, th->upValues);
-                                ast_ = th->body;
-                                goto recurse;
-                            }
-                        }
-                    } break;
-
-                    case FRAME_CALL: {
-                        if (auto *thunk = dynamic_cast<HeapThunk*>(f.context)) {
-                            // If we called a thunk, cache result.
-                            thunk->fill(scratch);
-                        } else if (auto *closure = dynamic_cast<HeapClosure*>(f.context)) {
-                            if (f.elementId < f.thunks.size()) {
-                                // If tailstrict, force thunks
-                                HeapThunk *th = f.thunks[f.elementId++];
-                                if (!th->filled) {
-                                    stack.newCall(f.location, th,
-                                                  th->self, th->offset, th->upValues);
-                                    ast_ = th->body;
-                                    goto recurse;
-                                }
-                            } else if (f.thunks.size() == 0) {
-                                // Body has now been executed
-                            } else {
-                                // Execute the body
-                                f.thunks.clear();
-                                f.elementId = 0;
-                                ast_ = closure->body;
-                                goto recurse;
-                            }
-                        }
-                        // Result of call is in scratch, just pop.
-                    } break;
-
-                    case FRAME_ERROR: {
-                        const auto &ast = *static_cast<const Error*>(f.ast);
-                        if (scratch.t != Value::STRING)
-                            throw makeError(ast.location, "Error message must be string, got " +
-                                                          type_str(scratch) + ".");
-                        std::string msg = encode_utf8(static_cast<HeapString*>(scratch.v.h)->value);
-                        throw makeError(ast.location, msg);
-                    } break;
-
-                    case FRAME_IF: {
-                        const auto &ast = *static_cast<const Conditional*>(f.ast);
-                        if (scratch.t != Value::BOOLEAN) {
-                            throw makeError(ast.location, "Condition must be boolean, got " +
-                                                          type_str(scratch) + ".");
-                        }
-                        ast_ = scratch.v.b ? ast.branchTrue : ast.branchFalse;
-                        stack.pop();
-                        goto recurse;
-                    } break;
-
-                    case FRAME_SUPER_INDEX: {
-                        const auto &ast = *static_cast<const SuperIndex*>(f.ast);
+                // First build all the thunks and bind them.
+                HeapObject *self;
+                unsigned offset;
+                stack.getSelfBinding(self, offset);
+                for (const auto &bind : ast.binds) {
+                    // Note that these 2 lines must remain separate to avoid the GC running
+                    // when bindings has a nullptr for key bind.first.
+                    auto *th = makeHeap<HeapThunk>(bind.var, self, offset, bind.body);
+                    f.bindings[bind.var] = th;
+                }
+                // Now capture the environment (including the new thunks, to make cycles).
+                for (const auto &bind : ast.binds) {
+                    auto *thunk = f.bindings[bind.var];
+                    thunk->upValues = capture(bind.body->freeVariables);
+                }
+                ast_ = ast.body;
+                goto recurse;
+            } break;
+
+            case AST_LITERAL_BOOLEAN: {
+                const auto &ast = *static_cast<const LiteralBoolean*>(ast_);
+                scratch = makeBoolean(ast.value);
+            } break;
+
+            case AST_LITERAL_NUMBER: {
+                const auto &ast = *static_cast<const LiteralNumber*>(ast_);
+                scratch = makeDoubleCheck(ast_->location, ast.value);
+            } break;
+
+            case AST_LITERAL_STRING: {
+                const auto &ast = *static_cast<const LiteralString*>(ast_);
+                scratch = makeString(ast.value);
+            } break;
+
+            case AST_LITERAL_NULL: {
+                scratch = makeNull();
+            } break;
+
+            case AST_DESUGARED_OBJECT: {
+                const auto &ast = *static_cast<const DesugaredObject*>(ast_);
+                if (ast.fields.empty()) {
+                    auto env = capture(ast.freeVariables);
+                    std::map<const Identifier *, HeapSimpleObject::Field> fields;
+                    scratch = makeObject<HeapSimpleObject>(env, fields, ast.asserts);
+                } else {
+                    auto env = capture(ast.freeVariables);
+                    stack.newFrame(FRAME_OBJECT, ast_);
+                    auto fit = ast.fields.begin();
+                    stack.top().fit = fit;
+                    ast_ = fit->name;
+                    goto recurse;
+                }
+            } break;
+
+            case AST_OBJECT_COMPREHENSION_SIMPLE: {
+                const auto &ast = *static_cast<const ObjectComprehensionSimple*>(ast_);
+                stack.newFrame(FRAME_OBJECT_COMP_ARRAY, ast_);
+                ast_ = ast.array;
+                goto recurse;
+            } break;
+
+            case AST_SELF: {
+                scratch.t = Value::OBJECT;
+                HeapObject *self;
+                unsigned offset;
+                stack.getSelfBinding(self, offset);
+                scratch.v.h = self;
+            } break;
+
+            case AST_SUPER_INDEX: {
+                const auto &ast = *static_cast<const SuperIndex*>(ast_);
+                stack.newFrame(FRAME_SUPER_INDEX, ast_);
+                ast_ = ast.index;
+                goto recurse;
+            } break;
+
+            case AST_UNARY: {
+                const auto &ast = *static_cast<const Unary*>(ast_);
+                stack.newFrame(FRAME_UNARY, ast_);
+                ast_ = ast.expr;
+                goto recurse;
+            } break;
+
+            case AST_VAR: {
+                const auto &ast = *static_cast<const Var*>(ast_);
+                auto *thunk = stack.lookUpVar(ast.id);
+                if (thunk == nullptr) {
+                    std::cerr << "INTERNAL ERROR: Could not bind variable: "
+                              << encode_utf8(ast.id->name) << std::endl;
+                    std::abort();
+                }
+                if (thunk->filled) {
+                    scratch = thunk->content;
+                } else {
+                    stack.newCall(ast.location, thunk, thunk->self, thunk->offset, thunk->upValues);
+                    ast_ = thunk->body;
+                    goto recurse;
+                }
+            } break;
+
+            default:
+            std::cerr << "INTERNAL ERROR: Unknown AST: " << ast_->type << std::endl;
+            std::abort();
+        }
+
+        // To evaluate another AST, set ast to it, then goto recurse.
+        // To pop, exit the switch or goto popframe
+        // To change the frame and re-enter the switch, goto replaceframe
+        while (stack.size() > initial_stack_size) {
+            Frame &f = stack.top();
+            switch (f.kind) {
+                case FRAME_APPLY_TARGET: {
+                    const auto &ast = *static_cast<const Apply*>(f.ast);
+                    if (scratch.t != Value::FUNCTION) {
+                        throw makeError(ast.location,
+                                        "Only functions can be called, got "
+                                        + type_str(scratch));
+                    }
+                    auto *func = static_cast<HeapClosure*>(scratch.v.h);
+                    if (ast.args.size() != func->params.size()) {
+                        std::stringstream ss;
+                        ss << "Expected " << func->params.size() <<
+                              " arguments, got " << ast.args.size() << ".";
+                        throw makeError(ast.location, ss.str());
+                    }
+
+                    // Create thunks for arguments.
+                    for (unsigned i=0 ; i<ast.args.size() ; ++i) {
+                        const auto &arg = ast.args[i];
                         HeapObject *self;
                         unsigned offset;
                         stack.getSelfBinding(self, offset);
-                        offset++;
-                        if (offset >= countLeaves(self)) {
-                            throw makeError(ast.location,
-                                            "Attempt to use super when there is no super class.");
+                        auto *thunk = makeHeap<HeapThunk>(func->params[i], self, offset, arg.expr);
+                        thunk->upValues = capture(arg.expr->freeVariables);
+                        f.thunks.push_back(thunk);
+                    }
+                    // Popping stack frame invalidates the f reference.
+                    std::vector<HeapThunk*> args = f.thunks;
+
+                    stack.pop();
+
+                    if (func->body == nullptr) {
+                        // Built-in function.
+                        // Give nullptr for self because noone looking at this frame will
+                        // attempt to bind to self (it's native code).
+                        stack.newFrame(FRAME_BUILTIN_FORCE_THUNKS, f.ast);
+                        stack.top().thunks = args;
+                        stack.top().val = scratch;
+                        goto replaceframe;
+                    } else {
+                        // User defined function.
+                        BindingFrame bindings = func->upValues;
+                        for (unsigned i=0 ; i<func->params.size() ; ++i)
+                            bindings[func->params[i]] = args[i];
+                        stack.newCall(ast.location, func, func->self, func->offset, bindings);
+                        if (ast.tailstrict) {
+                            stack.top().tailCall = true;
+                            if (args.size() == 0) {
+                                // No need to force thunks, proceed straight to body.
+                                ast_ = func->body;
+                                goto recurse;
+                            } else {
+                                // The check for args.size() > 0
+                                stack.top().thunks = args;
+                                stack.top().val = scratch;
+                                goto replaceframe;
+                            }
+                        } else {
+                            ast_ = func->body;
+                            goto recurse;
                         }
-                        if (scratch.t != Value::STRING) {
+                    }
+                } break;
+
+                case FRAME_BINARY_LEFT: {
+                    const auto &ast = *static_cast<const Binary*>(f.ast);
+                    const Value &lhs = scratch;
+                    if (lhs.t == Value::BOOLEAN) {
+                        // Handle short-cut semantics
+                        switch (ast.op) {
+                            case BOP_AND: {
+                                if (!lhs.v.b) {
+                                    scratch = makeBoolean(false);
+                                    goto popframe;
+                                }
+                            } break;
+
+                            case BOP_OR: {
+                                if (lhs.v.b) {
+                                    scratch = makeBoolean(true);
+                                    goto popframe;
+                                }
+                            } break;
+
+                            default:;
+                        }
+                    }
+                    stack.top().kind = FRAME_BINARY_RIGHT;
+                    stack.top().val = lhs;
+                    ast_ = ast.right;
+                    goto recurse;
+                } break;
+
+                case FRAME_BINARY_RIGHT: {
+                    const auto &ast = *static_cast<const Binary*>(f.ast);
+                    const Value &lhs = stack.top().val;
+                    const Value &rhs = scratch;
+                    if (lhs.t == Value::STRING || rhs.t == Value::STRING) {
+                        if (ast.op == BOP_PLUS) {
+                            // Handle co-ercions for string processing.
+                            stack.top().kind = FRAME_STRING_CONCAT;
+                            stack.top().val2 = rhs;
+                            goto replaceframe;
+                        }
+                    }
+                    // Equality can be used when the types don't match.
+                    switch (ast.op) {
+                        case BOP_MANIFEST_EQUAL:
+                        std::cerr << "INTERNAL ERROR: Equals not desugared" << std::endl;
+                        abort();
+
+                        case BOP_MANIFEST_UNEQUAL:
+                        std::cerr << "INTERNAL ERROR: Notequals not desugared" << std::endl;
+                        abort();
+
+                        default:;
+                    }
+                    // Everything else requires matching types.
+                    if (lhs.t != rhs.t) {
+                        throw makeError(ast.location,
+                                        "Binary operator " + bop_string(ast.op) + " requires "
+                                        "matching types, got " + type_str(lhs) + " and " +
+                                        type_str(rhs) + ".");
+                    }
+                    switch (lhs.t) {
+                        case Value::ARRAY:
+                        if (ast.op == BOP_PLUS) {
+                            auto *arr_l = static_cast<HeapArray*>(lhs.v.h);
+                            auto *arr_r = static_cast<HeapArray*>(rhs.v.h);
+                            std::vector<HeapThunk*> elements;
+                            for (auto *el : arr_l->elements)
+                                elements.push_back(el);
+                            for (auto *el : arr_r->elements)
+                                elements.push_back(el);
+                            scratch = makeArray(elements);
+                        } else {
                             throw makeError(ast.location,
-                                            "Super index must be string, got "
-                                            + type_str(scratch) + ".");
+                                            "Binary operator " + bop_string(ast.op)
+                                            + " does not operate on arrays.");
+                        }
+                        break;
+
+                        case Value::BOOLEAN:
+                        switch (ast.op) {
+                            case BOP_AND:
+                            scratch = makeBoolean(lhs.v.b && rhs.v.b);
+                            break;
+
+                            case BOP_OR:
+                            scratch = makeBoolean(lhs.v.b || rhs.v.b);
+                            break;
+
+                            default:
+                            throw makeError(ast.location,
+                                            "Binary operator " + bop_string(ast.op)
+                                            + " does not operate on booleans.");
+                        }
+                        break;
+
+                        case Value::DOUBLE:
+                        switch (ast.op) {
+                            case BOP_PLUS:
+                            scratch = makeDoubleCheck(ast.location, lhs.v.d + rhs.v.d);
+                            break;
+
+                            case BOP_MINUS:
+                            scratch = makeDoubleCheck(ast.location, lhs.v.d - rhs.v.d);
+                            break;
+
+                            case BOP_MULT:
+                            scratch = makeDoubleCheck(ast.location, lhs.v.d * rhs.v.d);
+                            break;
+
+                            case BOP_DIV:
+                            if (rhs.v.d == 0)
+                                throw makeError(ast.location, "Division by zero.");
+                            scratch = makeDoubleCheck(ast.location, lhs.v.d / rhs.v.d);
+                            break;
+
+                            // No need to check doubles made from longs
+
+                            case BOP_SHIFT_L: {
+                                long long_l = lhs.v.d;
+                                long long_r = rhs.v.d;
+                                scratch = makeDouble(long_l << long_r);
+                            } break;
+
+                            case BOP_SHIFT_R: {
+                                long long_l = lhs.v.d;
+                                long long_r = rhs.v.d;
+                                scratch = makeDouble(long_l >> long_r);
+                            } break;
+
+                            case BOP_BITWISE_AND: {
+                                long long_l = lhs.v.d;
+                                long long_r = rhs.v.d;
+                                scratch = makeDouble(long_l & long_r);
+                            } break;
+
+                            case BOP_BITWISE_XOR: {
+                                long long_l = lhs.v.d;
+                                long long_r = rhs.v.d;
+                                scratch = makeDouble(long_l ^ long_r);
+                            } break;
+
+                            case BOP_BITWISE_OR: {
+                                long long_l = lhs.v.d;
+                                long long_r = rhs.v.d;
+                                scratch = makeDouble(long_l | long_r);
+                            } break;
+
+                            case BOP_LESS_EQ:
+                            scratch = makeBoolean(lhs.v.d <= rhs.v.d);
+                            break;
+
+                            case BOP_GREATER_EQ:
+                            scratch = makeBoolean(lhs.v.d >= rhs.v.d);
+                            break;
+
+                            case BOP_LESS:
+                            scratch = makeBoolean(lhs.v.d < rhs.v.d);
+                            break;
+
+                            case BOP_GREATER:
+                            scratch = makeBoolean(lhs.v.d > rhs.v.d);
+                            break;
+
+                            default:
+                            throw makeError(ast.location,
+                                            "Binary operator " + bop_string(ast.op)
+                                            + " does not operate on numbers.");
+                        }
+                        break;
+
+                        case Value::FUNCTION:
+                        throw makeError(ast.location, "Binary operator " + bop_string(ast.op) +
+                                                      " does not operate on functions.");
+
+                        case Value::NULL_TYPE:
+                        throw makeError(ast.location, "Binary operator " + bop_string(ast.op) +
+                                                      " does not operate on null.");
+
+                        case Value::OBJECT: {
+                            if (ast.op != BOP_PLUS) {
+                                throw makeError(ast.location,
+                                                "Binary operator " + bop_string(ast.op) +
+                                                " does not operate on objects.");
+                            }
+                            auto *lhs_obj = static_cast<HeapObject*>(lhs.v.h);
+                            auto *rhs_obj = static_cast<HeapObject*>(rhs.v.h);
+                            scratch = makeObject<HeapExtendedObject>(lhs_obj, rhs_obj);
+                        }
+                        break;
+
+                        case Value::STRING: {
+                            const String &lhs_str =
+                                static_cast<HeapString*>(lhs.v.h)->value;
+                            const String &rhs_str =
+                                static_cast<HeapString*>(rhs.v.h)->value;
+                            switch (ast.op) {
+                                case BOP_PLUS:
+                                scratch = makeString(lhs_str + rhs_str);
+                                break;
+
+                                case BOP_LESS_EQ:
+                                scratch = makeBoolean(lhs_str <= rhs_str);
+                                break;
+
+                                case BOP_GREATER_EQ:
+                                scratch = makeBoolean(lhs_str >= rhs_str);
+                                break;
+
+                                case BOP_LESS:
+                                scratch = makeBoolean(lhs_str < rhs_str);
+                                break;
+
+                                case BOP_GREATER:
+                                scratch = makeBoolean(lhs_str > rhs_str);
+                                break;
+
+                                default:
+                                throw makeError(ast.location,
+                                                "Binary operator " + bop_string(ast.op)
+                                                + " does not operate on strings.");
+                            }
+                        }
+                        break;
+                    }
+                } break;
+
+                case FRAME_BUILTIN_FILTER: {
+                    const auto &ast = *static_cast<const Apply*>(f.ast);
+                    auto *func = static_cast<HeapClosure*>(f.val.v.h);
+                    auto *arr = static_cast<HeapArray*>(f.val2.v.h);
+                    if (scratch.t != Value::BOOLEAN) {
+                        throw makeError(ast.location,
+                                        "filter function must return boolean, got: "
+                                        + type_str(scratch));
+                    }
+                    if (scratch.v.b) f.thunks.push_back(arr->elements[f.elementId]);
+                    f.elementId++;
+                    // Iterate through arr, calling the function on each.
+                    if (f.elementId == arr->elements.size()) {
+                        scratch = makeArray(f.thunks);
+                    } else {
+                        auto *thunk = arr->elements[f.elementId];
+                        BindingFrame bindings = func->upValues;
+                        bindings[func->params[0]] = thunk;
+                        stack.newCall(ast.location, func, func->self, func->offset, bindings);
+                        ast_ = func->body;
+                        goto recurse;
+                    }
+                } break;
+
+                case FRAME_BUILTIN_FORCE_THUNKS: {
+                    const auto &ast = *static_cast<const Apply*>(f.ast);
+                    auto *func = static_cast<HeapClosure*>(f.val.v.h);
+                    if (f.elementId == f.thunks.size()) {
+                        // All thunks forced, now the builtin implementations.
+                        const LocationRange &loc = ast.location;
+                        unsigned builtin = func->builtin;
+                        std::vector<Value> args;
+                        for (auto *th : f.thunks) {
+                            args.push_back(th->content);
+                        }
+                        switch (builtin) {
+                            case 0: { // makeArray
+                                validateBuiltinArgs(loc, builtin, args,
+                                                    {Value::DOUBLE, Value::FUNCTION});
+                                long sz = long(args[0].v.d);
+                                if (sz < 0) {
+                                    std::stringstream ss;
+                                    ss << "makeArray requires size >= 0, got " << sz;
+                                    throw makeError(loc, ss.str());
+                                }
+                                auto *func = static_cast<const HeapClosure*>(args[1].v.h);
+                                std::vector<HeapThunk*> elements;
+                                if (func->params.size() != 1) {
+                                    std::stringstream ss;
+                                    ss << "makeArray function must take 1 param, got: "
+                                       << func->params.size();
+                                    throw makeError(loc, ss.str());
+                                }
+                                elements.resize(sz);
+                                for (long i=0 ; i<sz ; ++i) {
+                                    auto *th = makeHeap<HeapThunk>(idArrayElement, func->self,
+                                                                   func->offset, func->body);
+                                    // The next line stops the new thunks from being GCed.
+                                    f.thunks.push_back(th);
+                                    th->upValues = func->upValues;
+
+                                    auto *el = makeHeap<HeapThunk>(func->params[0], nullptr,
+                                                                   0, nullptr);
+                                    el->fill(makeDouble(i));  // i guaranteed not to be inf/NaN
+                                    th->upValues[func->params[0]] = el;
+                                    elements[i] = th;
+                                }
+                                scratch = makeArray(elements);
+                            } break;
+
+                            case 1:  // pow
+                            validateBuiltinArgs(loc, builtin, args,
+                                                {Value::DOUBLE, Value::DOUBLE});
+                            scratch = makeDoubleCheck(loc, std::pow(args[0].v.d, args[1].v.d));
+                            break;
+
+                            case 2:  // floor
+                            validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
+                            scratch = makeDoubleCheck(loc, std::floor(args[0].v.d));
+                            break;
+
+                            case 3:  // ceil
+                            validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
+                            scratch = makeDoubleCheck(loc, std::ceil(args[0].v.d));
+                            break;
+
+                            case 4:  // sqrt
+                            validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
+                            scratch = makeDoubleCheck(loc, std::sqrt(args[0].v.d));
+                            break;
+
+                            case 5:  // sin
+                            validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
+                            scratch = makeDoubleCheck(loc, std::sin(args[0].v.d));
+                            break;
+
+                            case 6:  // cos
+                            validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
+                            scratch = makeDoubleCheck(loc, std::cos(args[0].v.d));
+                            break;
+
+                            case 7:  // tan
+                            validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
+                            scratch = makeDoubleCheck(loc, std::tan(args[0].v.d));
+                            break;
+
+                            case 8:  // asin
+                            validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
+                            scratch = makeDoubleCheck(loc, std::asin(args[0].v.d));
+                            break;
+
+                            case 9:  // acos
+                            validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
+                            scratch = makeDoubleCheck(loc, std::acos(args[0].v.d));
+                            break;
+
+                            case 10:  // atan
+                            validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
+                            scratch = makeDoubleCheck(loc, std::atan(args[0].v.d));
+                            break;
+
+                            case 11: {  // type
+                                switch (args[0].t) {
+                                    case Value::NULL_TYPE:
+                                    scratch = makeString(U"null");
+                                    break;
+
+                                    case Value::BOOLEAN:
+                                    scratch = makeString(U"boolean");
+                                    break;
+
+                                    case Value::DOUBLE:
+                                    scratch = makeString(U"number");
+                                    break;
+
+                                    case Value::ARRAY:
+                                    scratch = makeString(U"array");
+                                    break;
+
+                                    case Value::FUNCTION:
+                                    scratch = makeString(U"function");
+                                    break;
+
+                                    case Value::OBJECT:
+                                    scratch = makeString(U"object");
+                                    break;
+
+                                    case Value::STRING:
+                                    scratch = makeString(U"string");
+                                    break;
+
+                                }
+                            }
+                            break;
+
+                            case 12: {  // filter
+                                validateBuiltinArgs(loc, builtin, args,
+                                                    {Value::FUNCTION, Value::ARRAY});
+                                auto *func = static_cast<HeapClosure*>(args[0].v.h);
+                                auto *arr = static_cast<HeapArray*>(args[1].v.h);
+                                if (func->params.size() != 1) {
+                                    throw makeError(loc, "filter function takes 1 parameter.");
+                                }
+                                if (arr->elements.size() == 0) {
+                                    scratch = makeArray({});
+                                } else {
+                                    f.kind = FRAME_BUILTIN_FILTER;
+                                    f.val = args[0];
+                                    f.val2 = args[1];
+                                    f.thunks.clear();
+                                    f.elementId = 0;
+
+                                    auto *thunk = arr->elements[f.elementId];
+                                    BindingFrame bindings = func->upValues;
+                                    bindings[func->params[0]] = thunk;
+                                    stack.newCall(loc, func, func->self, func->offset, bindings);
+                                    ast_ = func->body;
+                                    goto recurse;
+                                }
+                            } break;
+
+                            case 13: {  // objectHasEx
+                                validateBuiltinArgs(loc, builtin, args,
+                                                    {Value::OBJECT, Value::STRING,
+                                                     Value::BOOLEAN});
+                                const auto *obj = static_cast<const HeapObject*>(args[0].v.h);
+                                const auto *str = static_cast<const HeapString*>(args[1].v.h);
+                                bool include_hidden = args[2].v.b;
+                                bool found = false;
+                                for (const auto &field : objectFields(obj, !include_hidden)) {
+                                    if (field->name == str->value) {
+                                        found = true;
+                                        break;
+                                    }
+                                }
+                                scratch = makeBoolean(found);
+                            } break;
+
+                            case 14: {  // length
+                                if (args.size() != 1) {
+                                    throw makeError(loc, "length takes 1 parameter.");
+                                }
+                                HeapEntity *e = args[0].v.h;
+                                switch (args[0].t) {
+                                    case Value::OBJECT: {
+                                        auto fields =
+                                            objectFields(static_cast<HeapObject*>(e), true);
+                                        scratch = makeDouble(fields.size());
+                                    } break;
+
+                                    case Value::ARRAY:
+                                    scratch = makeDouble(static_cast<HeapArray*>(e)
+                                                         ->elements.size());
+                                    break;
+
+                                    case Value::STRING:
+                                    scratch = makeDouble(static_cast<HeapString*>(e)
+                                                         ->value.length());
+                                    break;
+
+                                    case Value::FUNCTION:
+                                    scratch = makeDouble(static_cast<HeapClosure*>(e)
+                                                         ->params.size());
+                                    break;
+
+                                    default:
+                                    throw makeError(loc,
+                                                    "length operates on strings, objects, "
+                                                    "and arrays, got " + type_str(args[0]));
+                                }
+                            } break;
+
+                            case 15: {  // objectFieldsEx
+                                validateBuiltinArgs(loc, builtin, args,
+                                                    {Value::OBJECT, Value::BOOLEAN});
+                                const auto *obj = static_cast<HeapObject*>(args[0].v.h);
+                                bool include_hidden = args[1].v.b;
+                                // Stash in a set first to sort them.
+                                std::set<String> fields;
+                                for (const auto &field : objectFields(obj, !include_hidden)) {
+                                    fields.insert(field->name);
+                                }
+                                scratch = makeArray({});
+                                auto &elements = static_cast<HeapArray*>(scratch.v.h)->elements;
+                                for (const auto &field : fields) {
+                                    auto *th = makeHeap<HeapThunk>(idArrayElement, nullptr,
+                                                                   0, nullptr);
+                                    elements.push_back(th);
+                                    th->fill(makeString(field));
+                                }
+                            } break;
+
+                            case 16: { // codepoint
+                                validateBuiltinArgs(loc, builtin, args, {Value::STRING});
+                                const String &str =
+                                    static_cast<HeapString*>(args[0].v.h)->value;
+                                if (str.length() != 1) {
+                                    std::stringstream ss;
+                                    ss << "codepoint takes a string of length 1, got length "
+                                       << str.length();
+                                    throw makeError(loc, ss.str());
+                                }
+                                char32_t c = static_cast<HeapString*>(args[0].v.h)->value[0];
+                                scratch = makeDouble((unsigned long)(c));
+                            } break;
+
+                            case 17: { // char
+                                validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
+                                long l = long(args[0].v.d);
+                                if (l < 0) {
+                                    std::stringstream ss;
+                                    ss << "Codepoints must be >= 0, got " << l;
+                                    throw makeError(ast.location, ss.str());
+                                }
+                                if (l >= JSONNET_CODEPOINT_MAX) {
+                                    std::stringstream ss;
+                                    ss << "Invalid unicode codepoint, got " << l;
+                                    throw makeError(ast.location, ss.str());
+                                }
+                                char32_t c = l;
+                                scratch = makeString(String(&c, 1));
+                            } break;
+
+                            case 18: {  // log
+                                validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
+                                scratch = makeDoubleCheck(loc, std::log(args[0].v.d));
+                            } break;
+
+                            case 19: {  // exp
+                                validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
+                                scratch = makeDoubleCheck(loc, std::exp(args[0].v.d));
+                            } break;
+
+                            case 20: {  // mantissa
+                                validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
+                                int exp;
+                                double m = std::frexp(args[0].v.d, &exp);
+                                scratch = makeDoubleCheck(loc, m);
+                            } break;
+
+                            case 21: {  // exponent
+                                validateBuiltinArgs(loc, builtin, args, {Value::DOUBLE});
+                                int exp;
+                                std::frexp(args[0].v.d, &exp);
+                                scratch = makeDoubleCheck(loc, exp);
+                            } break;
+
+                            case 22: {  // modulo
+                                validateBuiltinArgs(loc, builtin, args,
+                                                    {Value::DOUBLE, Value::DOUBLE});
+                                double a = args[0].v.d;
+                                double b = args[1].v.d;
+                                if (b == 0)
+                                    throw makeError(ast.location, "Division by zero.");
+                                scratch = makeDoubleCheck(loc, std::fmod(a, b));
+                            } break;
+
+                            case 23: {  // extVar
+                                validateBuiltinArgs(loc, builtin, args, {Value::STRING});
+                                const String &var =
+                                    static_cast<HeapString*>(args[0].v.h)->value;
+                                std::string var8 = encode_utf8(var);
+                                auto it = externalVars.find(var8);
+                                if (it == externalVars.end()) {
+                                    std::string msg = "Undefined external variable: " + var8;
+                                    throw makeError(ast.location, msg);
+                                }
+                                const VmExt &ext = it->second;
+                                if (ext.isCode) {
+                                    std::string filename = "<extvar:" + var8 + ">";
+                                    Tokens tokens = jsonnet_lex(filename, ext.data.c_str());
+                                    AST *expr = jsonnet_parse(alloc, tokens);
+                                    jsonnet_desugar(alloc, expr);
+                                    jsonnet_static_analysis(expr);
+                                    ast_ = expr;
+                                    stack.pop();
+                                    goto recurse;
+                                } else {
+                                    scratch = makeString(decode_utf8(ext.data));
+                                }
+                            } break;
+
+                            case 24: {  // primitiveEquals
+                                if (args.size() != 2) {
+                                    throw makeError(loc, "primitiveEquals takes 2 parameters.");
+                                }
+                                if (args[0].t != args[1].t) {
+                                    scratch = makeBoolean(false);
+                                    break;
+                                }
+                                bool r;
+                                switch (args[0].t) {
+                                    case Value::BOOLEAN:
+                                    r = args[0].v.b == args[1].v.b;
+                                    break;
+
+                                    case Value::DOUBLE:
+                                    r = args[0].v.d == args[1].v.d;
+                                    break;
+
+                                    case Value::STRING:
+                                    r = static_cast<HeapString*>(args[0].v.h)->value
+                                      == static_cast<HeapString*>(args[1].v.h)->value;
+                                    break;
+
+                                    case Value::NULL_TYPE:
+                                    r = true;
+                                    break;
+
+                                    case Value::FUNCTION:
+                                    throw makeError(loc, "Cannot test equality of functions");
+                                    break;
+
+                                    default:
+                                    throw makeError(loc,
+                                                    "primitiveEquals operates on primitive "
+                                                    "types, got " + type_str(args[0]));
+                                }
+                                scratch = makeBoolean(r);
+                            } break;
+
+                            default:
+                            std::cerr << "INTERNAL ERROR: Unrecognized builtin: " << builtin
+                                      << std::endl;
+                            std::abort();
                         }
 
+                    } else {
+                        HeapThunk *th = f.thunks[f.elementId++];
+                        if (!th->filled) {
+                            stack.newCall(ast.location, th, th->self, th->offset, th->upValues);
+                            ast_ = th->body;
+                            goto recurse;
+                        }
+                    }
+                } break;
+
+                case FRAME_CALL: {
+                    if (auto *thunk = dynamic_cast<HeapThunk*>(f.context)) {
+                        // If we called a thunk, cache result.
+                        thunk->fill(scratch);
+                    } else if (auto *closure = dynamic_cast<HeapClosure*>(f.context)) {
+                        if (f.elementId < f.thunks.size()) {
+                            // If tailstrict, force thunks
+                            HeapThunk *th = f.thunks[f.elementId++];
+                            if (!th->filled) {
+                                stack.newCall(f.location, th,
+                                              th->self, th->offset, th->upValues);
+                                ast_ = th->body;
+                                goto recurse;
+                            }
+                        } else if (f.thunks.size() == 0) {
+                            // Body has now been executed
+                        } else {
+                            // Execute the body
+                            f.thunks.clear();
+                            f.elementId = 0;
+                            ast_ = closure->body;
+                            goto recurse;
+                        }
+                    }
+                    // Result of call is in scratch, just pop.
+                } break;
+
+                case FRAME_ERROR: {
+                    const auto &ast = *static_cast<const Error*>(f.ast);
+                    if (scratch.t != Value::STRING)
+                        throw makeError(ast.location, "Error message must be string, got " +
+                                                      type_str(scratch) + ".");
+                    std::string msg = encode_utf8(static_cast<HeapString*>(scratch.v.h)->value);
+                    throw makeError(ast.location, msg);
+                } break;
+
+                case FRAME_IF: {
+                    const auto &ast = *static_cast<const Conditional*>(f.ast);
+                    if (scratch.t != Value::BOOLEAN) {
+                        throw makeError(ast.location, "Condition must be boolean, got " +
+                                                      type_str(scratch) + ".");
+                    }
+                    ast_ = scratch.v.b ? ast.branchTrue : ast.branchFalse;
+                    stack.pop();
+                    goto recurse;
+                } break;
+
+                case FRAME_SUPER_INDEX: {
+                    const auto &ast = *static_cast<const SuperIndex*>(f.ast);
+                    HeapObject *self;
+                    unsigned offset;
+                    stack.getSelfBinding(self, offset);
+                    offset++;
+                    if (offset >= countLeaves(self)) {
+                        throw makeError(ast.location,
+                                        "Attempt to use super when there is no super class.");
+                    }
+                    if (scratch.t != Value::STRING) {
+                        throw makeError(ast.location,
+                                        "Super index must be string, got "
+                                        + type_str(scratch) + ".");
+                    }
+
+                    const String &index_name =
+                        static_cast<HeapString*>(scratch.v.h)->value;
+                    auto *fid = alloc->makeIdentifier(index_name);
+                    stack.pop();
+                    ast_ = objectIndex(ast.location, self, fid, offset);
+                    goto recurse;
+                } break;
+
+                case FRAME_INDEX_INDEX: {
+                    const auto &ast = *static_cast<const Index*>(f.ast);
+                    const Value &target = f.val;
+                    if (target.t == Value::ARRAY) {
+                        const auto *array = static_cast<HeapArray*>(target.v.h);
+                        if (scratch.t != Value::DOUBLE) {
+                            throw makeError(ast.location, "Array index must be number, got "
+                                                          + type_str(scratch) + ".");
+                        }
+                        long i = long(scratch.v.d);
+                        long sz = array->elements.size();
+                        if (i < 0 || i >= sz) {
+                            std::stringstream ss;
+                            ss << "Array bounds error: " << i
+                               << " not within [0, " << sz << ")";
+                            throw makeError(ast.location, ss.str());
+                        }
+                        auto *thunk = array->elements[i];
+                        if (thunk->filled) {
+                            scratch = thunk->content;
+                        } else {
+                            stack.pop();
+                            stack.newCall(ast.location, thunk,
+                                          thunk->self, thunk->offset, thunk->upValues);
+                            ast_ = thunk->body;
+                            goto recurse;
+                        }
+                    } else if (target.t == Value::OBJECT) {
+                        auto *obj = static_cast<HeapObject*>(target.v.h);
+                        assert(obj != nullptr);
+                        if (scratch.t != Value::STRING) {
+                            throw makeError(ast.location,
+                                            "Object index must be string, got "
+                                            + type_str(scratch) + ".");
+                        }
                         const String &index_name =
                             static_cast<HeapString*>(scratch.v.h)->value;
                         auto *fid = alloc->makeIdentifier(index_name);
                         stack.pop();
-                        ast_ = objectIndex(ast.location, self, fid, offset);
+                        ast_ = objectIndex(ast.location, obj, fid, 0);
                         goto recurse;
-                    } break;
+                    } else if (target.t == Value::STRING) {
+                        auto *obj = static_cast<HeapString*>(target.v.h);
+                        assert(obj != nullptr);
+                        if (scratch.t != Value::DOUBLE) {
+                            throw makeError(ast.location,
+                                            "String index must be a number, got "
+                                            + type_str(scratch) + ".");
+                        }
+                        long sz = obj->value.length();
+                        long i = (long)scratch.v.d;
+                        if (i < 0 || i >= sz) {
+                            std::stringstream ss;
+                            ss << "String bounds error: " << i
+                               << " not within [0, " << sz << ")";
+                            throw makeError(ast.location, ss.str());
+                        }
+                        char32_t ch[] = {obj->value[i], U'\0'};
+                        scratch = makeString(ch);
+                    } else {
+                        std::cerr << "INTERNAL ERROR: Not object / array / string." << std::endl;
+                        abort();
+                    }
+                } break;
 
-                    case FRAME_INDEX_INDEX: {
-                        const auto &ast = *static_cast<const Index*>(f.ast);
-                        const Value &target = f.val;
-                        if (target.t == Value::ARRAY) {
-                            const auto *array = static_cast<HeapArray*>(target.v.h);
-                            if (scratch.t != Value::DOUBLE) {
-                                throw makeError(ast.location, "Array index must be number, got "
-                                                              + type_str(scratch) + ".");
-                            }
-                            long i = long(scratch.v.d);
-                            long sz = array->elements.size();
-                            if (i < 0 || i >= sz) {
-                                std::stringstream ss;
-                                ss << "Array bounds error: " << i
-                                   << " not within [0, " << sz << ")";
-                                throw makeError(ast.location, ss.str());
-                            }
-                            auto *thunk = array->elements[i];
-                            if (thunk->filled) {
-                                scratch = thunk->content;
-                            } else {
-                                stack.pop();
+                case FRAME_INDEX_TARGET: {
+                    const auto &ast = *static_cast<const Index*>(f.ast);
+                    if (scratch.t != Value::ARRAY
+                        && scratch.t != Value::OBJECT
+                        && scratch.t != Value::STRING) {
+                        throw makeError(ast.location,
+                                        "Can only index objects, strings, and arrays, got "
+                                        + type_str(scratch) + ".");
+                    }
+                    f.val = scratch;
+                    f.kind = FRAME_INDEX_INDEX;
+                    if (scratch.t == Value::OBJECT) {
+                        auto *self = static_cast<HeapObject*>(scratch.v.h);
+                        if (!stack.alreadyExecutingInvariants(self)) {
+                            stack.newFrame(FRAME_INVARIANTS, ast.location);
+                            Frame &f2 = stack.top();
+                            f2.self = self;
+                            unsigned counter = 0;
+                            objectInvariants(self, self, counter, f2.thunks);
+                            if (f2.thunks.size() > 0) {
+                                auto *thunk = f2.thunks[0];
+                                f2.elementId = 1;
                                 stack.newCall(ast.location, thunk,
                                               thunk->self, thunk->offset, thunk->upValues);
                                 ast_ = thunk->body;
                                 goto recurse;
                             }
-                        } else if (target.t == Value::OBJECT) {
-                            auto *obj = static_cast<HeapObject*>(target.v.h);
-                            assert(obj != nullptr);
-                            if (scratch.t != Value::STRING) {
-                                throw makeError(ast.location,
-                                                "Object index must be string, got "
-                                                + type_str(scratch) + ".");
-                            }
-                            const String &index_name =
-                                static_cast<HeapString*>(scratch.v.h)->value;
-                            auto *fid = alloc->makeIdentifier(index_name);
-                            stack.pop();
-                            ast_ = objectIndex(ast.location, obj, fid, 0);
-                            goto recurse;
-                        } else if (target.t == Value::STRING) {
-                            auto *obj = static_cast<HeapString*>(target.v.h);
-                            assert(obj != nullptr);
-                            if (scratch.t != Value::DOUBLE) {
-                                throw makeError(ast.location,
-                                                "String index must be a number, got "
-                                                + type_str(scratch) + ".");
-                            }
-                            long sz = obj->value.length();
-                            long i = (long)scratch.v.d;
-                            if (i < 0 || i >= sz) {
-                                std::stringstream ss;
-                                ss << "String bounds error: " << i
-                                   << " not within [0, " << sz << ")";
-                                throw makeError(ast.location, ss.str());
-                            }
-                            char32_t ch[] = {obj->value[i], U'\0'};
-                            scratch = makeString(ch);
-                        } else {
-                            std::cerr << "INTERNAL ERROR: Not object / array / string."
-                                      << std::endl;
-                            abort();
                         }
-                    } break;
+                    }
+                    ast_ = ast.index;
+                    goto recurse;
+                } break;
 
-                    case FRAME_INDEX_TARGET: {
-                        const auto &ast = *static_cast<const Index*>(f.ast);
-                        if (scratch.t != Value::ARRAY
-                            && scratch.t != Value::OBJECT
-                            && scratch.t != Value::STRING) {
-                            throw makeError(ast.location,
-                                            "Can only index objects, strings, and arrays, got "
-                                            + type_str(scratch) + ".");
+                case FRAME_INVARIANTS: {
+                    if (f.elementId >= f.thunks.size()) {
+                        if (stack.size() == initial_stack_size + 1) {
+                            // Just pop, evaluate was invoked by runInvariants.
+                            break;
                         }
-                        f.val = scratch;
-                        f.kind = FRAME_INDEX_INDEX;
-                        if (scratch.t == Value::OBJECT) {
-                            auto *self = static_cast<HeapObject*>(scratch.v.h);
-                            if (!stack.alreadyExecutingInvariants(self)) {
-                                stack.newFrame(FRAME_INVARIANTS, ast.location);
-                                Frame &f2 = stack.top();
-                                f2.self = self;
-                                unsigned counter = 0;
-                                objectInvariants(self, self, counter, f2.thunks);
-                                if (f2.thunks.size() > 0) {
-                                    auto *thunk = f2.thunks[0];
-                                    f2.elementId = 1;
-                                    stack.newCall(ast.location, thunk,
-                                                  thunk->self, thunk->offset, thunk->upValues);
-                                    ast_ = thunk->body;
-                                    goto recurse;
-                                }
-                            }
-                        }
+                        stack.pop();
+                        Frame &f2 = stack.top();
+                        const auto &ast = *static_cast<const Index*>(f2.ast);
                         ast_ = ast.index;
                         goto recurse;
-                    } break;
+                    }
+                    auto *thunk = f.thunks[f.elementId++];
+                    stack.newCall(f.location, thunk,
+                                  thunk->self, thunk->offset, thunk->upValues);
+                    ast_ = thunk->body;
+                    goto recurse;
+                } break;
 
-                    case FRAME_INVARIANTS: {
-                        if (f.elementId >= f.thunks.size()) {
-                            if (stack.size() == initial_stack_size + 1) {
-                                // Just pop, evaluate was invoked by runInvariants.
-                                break;
-                            }
-                            stack.pop();
-                            Frame &f2 = stack.top();
-                            const auto &ast = *static_cast<const Index*>(f2.ast);
-                            ast_ = ast.index;
-                            goto recurse;
-                        }
-                        auto *thunk = f.thunks[f.elementId++];
-                        stack.newCall(f.location, thunk,
-                                      thunk->self, thunk->offset, thunk->upValues);
-                        ast_ = thunk->body;
-                        goto recurse;
-                    } break;
+                case FRAME_LOCAL: {
+                    // Result of execution is in scratch already.
+                } break;
 
-                    case FRAME_LOCAL: {
-                        // Result of execution is in scratch already.
-                    } break;
-
-                    case FRAME_OBJECT: {
-                        const auto &ast = *static_cast<const DesugaredObject*>(f.ast);
-                        if (scratch.t != Value::NULL_TYPE) {
-                            if (scratch.t != Value::STRING) {
-                                throw makeError(ast.location, "Field name was not a string.");
-                            }
-                            const auto &fname = static_cast<const HeapString*>(scratch.v.h)->value;
-                            const Identifier *fid = alloc->makeIdentifier(fname);
-                            if (f.objectFields.find(fid) != f.objectFields.end()) {
-                                std::string msg = "Duplicate field name: \""
-                                                  + encode_utf8(fname) + "\"";
-                                throw makeError(ast.location, msg);
-                            }
-                            f.objectFields[fid].hide = f.fit->hide;
-                            f.objectFields[fid].body = f.fit->body;
-                        }
-                        f.fit++;
-                        if (f.fit != ast.fields.end()) {
-                            ast_ = f.fit->name;
-                            goto recurse;
-                        } else {
-                            auto env = capture(ast.freeVariables);
-                            scratch = makeObject<HeapSimpleObject>(env, f.objectFields,
-                                                                   ast.asserts);
-                        }
-                    } break;
-
-                    case FRAME_OBJECT_COMP_ARRAY: {
-                        const auto &ast = *static_cast<const ObjectComprehensionSimple*>(f.ast);
-                        const Value &arr_v = scratch;
-                        if (scratch.t != Value::ARRAY) {
-                            throw makeError(ast.location,
-                                            "Object comprehension needs array, got "
-                                            + type_str(arr_v));
-                        }
-                        const auto *arr = static_cast<const HeapArray*>(arr_v.v.h);
-                        if (arr->elements.size() == 0) {
-                            // Degenerate case.  Just create the object now.
-                            scratch = makeObject<HeapComprehensionObject>(BindingFrame{}, ast.value,
-                                                                          ast.id, BindingFrame{});
-                        } else {
-                            f.kind = FRAME_OBJECT_COMP_ELEMENT;
-                            f.val = scratch;
-                            f.bindings[ast.id] = arr->elements[0];
-                            f.elementId = 0;
-                            ast_ = ast.field;
-                            goto recurse;
-                        }
-                    } break;
-
-                    case FRAME_OBJECT_COMP_ELEMENT: {
-                        const auto &ast = *static_cast<const ObjectComprehensionSimple*>(f.ast);
-                        const auto *arr = static_cast<const HeapArray*>(f.val.v.h);
+                case FRAME_OBJECT: {
+                    const auto &ast = *static_cast<const DesugaredObject*>(f.ast);
+                    if (scratch.t != Value::NULL_TYPE) {
                         if (scratch.t != Value::STRING) {
-                            std::stringstream ss;
-                            ss << "field must be string, got: " << type_str(scratch);
-                            throw makeError(ast.location, ss.str());
+                            throw makeError(ast.location, "Field name was not a string.");
                         }
                         const auto &fname = static_cast<const HeapString*>(scratch.v.h)->value;
                         const Identifier *fid = alloc->makeIdentifier(fname);
-                        if (f.elements.find(fid) != f.elements.end()) {
+                        if (f.objectFields.find(fid) != f.objectFields.end()) {
+                            std::string msg = "Duplicate field name: \""
+                                              + encode_utf8(fname) + "\"";
+                            throw makeError(ast.location, msg);
+                        }
+                        f.objectFields[fid].hide = f.fit->hide;
+                        f.objectFields[fid].body = f.fit->body;
+                    }
+                    f.fit++;
+                    if (f.fit != ast.fields.end()) {
+                        ast_ = f.fit->name;
+                        goto recurse;
+                    } else {
+                        auto env = capture(ast.freeVariables);
+                        scratch = makeObject<HeapSimpleObject>(env, f.objectFields, ast.asserts);
+                    }
+                } break;
+
+                case FRAME_OBJECT_COMP_ARRAY: {
+                    const auto &ast = *static_cast<const ObjectComprehensionSimple*>(f.ast);
+                    const Value &arr_v = scratch;
+                    if (scratch.t != Value::ARRAY) {
+                        throw makeError(ast.location,
+                                        "Object comprehension needs array, got "
+                                        + type_str(arr_v));
+                    }
+                    const auto *arr = static_cast<const HeapArray*>(arr_v.v.h);
+                    if (arr->elements.size() == 0) {
+                        // Degenerate case.  Just create the object now.
+                        scratch = makeObject<HeapComprehensionObject>(BindingFrame{}, ast.value,
+                                                                      ast.id, BindingFrame{});
+                    } else {
+                        f.kind = FRAME_OBJECT_COMP_ELEMENT;
+                        f.val = scratch;
+                        f.bindings[ast.id] = arr->elements[0];
+                        f.elementId = 0;
+                        ast_ = ast.field;
+                        goto recurse;
+                    }
+                } break;
+
+                case FRAME_OBJECT_COMP_ELEMENT: {
+                    const auto &ast = *static_cast<const ObjectComprehensionSimple*>(f.ast);
+                    const auto *arr = static_cast<const HeapArray*>(f.val.v.h);
+                    if (scratch.t != Value::STRING) {
+                        std::stringstream ss;
+                        ss << "field must be string, got: " << type_str(scratch);
+                        throw makeError(ast.location, ss.str());
+                    }
+                    const auto &fname = static_cast<const HeapString*>(scratch.v.h)->value;
+                    const Identifier *fid = alloc->makeIdentifier(fname);
+                    if (f.elements.find(fid) != f.elements.end()) {
+                        throw makeError(ast.location,
+                                        "Duplicate field name: \"" + encode_utf8(fname) + "\"");
+                    }
+                    f.elements[fid] = arr->elements[f.elementId];
+                    f.elementId++;
+
+                    if (f.elementId == arr->elements.size()) {
+                        auto env = capture(ast.freeVariables);
+                        scratch = makeObject<HeapComprehensionObject>(env, ast.value,
+                                                                      ast.id, f.elements);
+                    } else {
+                        f.bindings[ast.id] = arr->elements[f.elementId];
+                        ast_ = ast.field;
+                        goto recurse;
+                    }
+                } break;
+
+                case FRAME_STRING_CONCAT: {
+                    const auto &ast = *static_cast<const Binary*>(f.ast);
+                    const Value &lhs = stack.top().val;
+                    const Value &rhs = stack.top().val2;
+                    String output;
+                    if (lhs.t == Value::STRING) {
+                        output.append(static_cast<const HeapString*>(lhs.v.h)->value);
+                    } else {
+                        scratch = lhs;
+                        output.append(toString(ast.left->location));
+                    }
+                    if (rhs.t == Value::STRING) {
+                        output.append(static_cast<const HeapString*>(rhs.v.h)->value);
+                    } else {
+                        scratch = rhs;
+                        output.append(toString(ast.right->location));
+                    }
+                    scratch = makeString(output);
+                } break;
+
+                case FRAME_UNARY: {
+                    const auto &ast = *static_cast<const Unary*>(f.ast);
+                    switch (scratch.t) {
+
+                        case Value::BOOLEAN:
+                        if (ast.op == UOP_NOT) {
+                            scratch = makeBoolean(!scratch.v.b);
+                        } else {
                             throw makeError(ast.location,
-                                            "Duplicate field name: \"" + encode_utf8(fname) + "\"");
+                                            "Unary operator " + uop_string(ast.op)
+                                            + " does not operate on booleans.");
                         }
-                        f.elements[fid] = arr->elements[f.elementId];
-                        f.elementId++;
+                        break;
 
-                        if (f.elementId == arr->elements.size()) {
-                            auto env = capture(ast.freeVariables);
-                            scratch = makeObject<HeapComprehensionObject>(env, ast.value,
-                                                                          ast.id, f.elements);
-                        } else {
-                            f.bindings[ast.id] = arr->elements[f.elementId];
-                            ast_ = ast.field;
-                            goto recurse;
-                        }
-                    } break;
-
-                    case FRAME_STRING_CONCAT: {
-                        const auto &ast = *static_cast<const Binary*>(f.ast);
-                        const Value &lhs = stack.top().val;
-                        const Value &rhs = stack.top().val2;
-                        String output;
-                        if (lhs.t == Value::STRING) {
-                            output.append(static_cast<const HeapString*>(lhs.v.h)->value);
-                        } else {
-                            scratch = lhs;
-                            output.append(toString(ast.left->location));
-                        }
-                        if (rhs.t == Value::STRING) {
-                            output.append(static_cast<const HeapString*>(rhs.v.h)->value);
-                        } else {
-                            scratch = rhs;
-                            output.append(toString(ast.right->location));
-                        }
-                        scratch = makeString(output);
-                    } break;
-
-                    case FRAME_UNARY: {
-                        const auto &ast = *static_cast<const Unary*>(f.ast);
-                        switch (scratch.t) {
-
-                            case Value::BOOLEAN:
-                            if (ast.op == UOP_NOT) {
-                                scratch = makeBoolean(!scratch.v.b);
-                            } else {
-                                throw makeError(ast.location,
-                                                "Unary operator " + uop_string(ast.op)
-                                                + " does not operate on booleans.");
-                            }
+                        case Value::DOUBLE:
+                        switch (ast.op) {
+                            case UOP_PLUS:
                             break;
 
-                            case Value::DOUBLE:
-                            switch (ast.op) {
-                                case UOP_PLUS:
-                                break;
+                            case UOP_MINUS:
+                            scratch = makeDouble(-scratch.v.d);
+                            break;
 
-                                case UOP_MINUS:
-                                scratch = makeDouble(-scratch.v.d);
-                                break;
-
-                                case UOP_BITWISE_NOT:
-                                scratch = makeDouble(~(long)(scratch.v.d));
-                                break;
-
-                                default:
-                                throw makeError(ast.location,
-                                                "Unary operator " + uop_string(ast.op)
-                                                + " does not operate on numbers.");
-                            }
+                            case UOP_BITWISE_NOT:
+                            scratch = makeDouble(~(long)(scratch.v.d));
                             break;
 
                             default:
-                                throw makeError(ast.location,
-                                                "Unary operator " + uop_string(ast.op) +
-                                                " does not operate on type " + type_str(scratch));
+                            throw makeError(ast.location,
+                                            "Unary operator " + uop_string(ast.op)
+                                            + " does not operate on numbers.");
                         }
-                    } break;
+                        break;
 
-                    default:
-                    std::cerr << "INTERNAL ERROR: Unknown FrameKind:  " << f.kind << std::endl;
-                    std::abort();
-                }
-
-                popframe:;
-
-                stack.pop();
-
-                replaceframe:;
-            }
-        }
-
-        /** Manifest the scratch value by evaluating any remaining fields, and then convert to JSON.
-         *
-         * This can trigger a garbage collection cycle.  Be sure to stash any objects that aren't
-         * reachable via the stack or heap.
-         *
-         * \param multiline If true, will print objects and arrays in an indented fashion.
-         */
-        String manifestJson(const LocationRange &loc, bool multiline, const String &indent)
-        {
-            // Printing fields means evaluating and binding them, which can trigger
-            // garbage collection.
-
-            StringStream ss;
-            switch (scratch.t) {
-                case Value::ARRAY: {
-                    HeapArray *arr = static_cast<HeapArray*>(scratch.v.h);
-                    if (arr->elements.size() == 0) {
-                        ss << U"[ ]";
-                    } else {
-                        const char32_t *prefix = multiline ? U"[\n" : U"[";
-                        String indent2 = multiline ? indent + U"   " : indent;
-                        for (auto *thunk : arr->elements) {
-                            LocationRange tloc = thunk->body == nullptr
-                                               ? loc
-                                               : thunk->body->location;
-                            if (thunk->filled) {
-                                stack.newCall(loc, thunk, nullptr, 0, BindingFrame{});
-                                // Keep arr alive when scratch is overwritten
-                                stack.top().val = scratch;
-                                scratch = thunk->content;
-                            } else {
-                                stack.newCall(loc, thunk,
-                                              thunk->self, thunk->offset, thunk->upValues);
-                                // Keep arr alive when scratch is overwritten
-                                stack.top().val = scratch;
-                                evaluate(thunk->body, stack.size());
-                            }
-                            auto element = manifestJson(tloc, multiline, indent2);
-                            // Restore scratch
-                            scratch = stack.top().val;
-                            stack.pop();
-                            ss << prefix << indent2 << element;
-                            prefix = multiline ? U",\n" : U", ";
-                        }
-                        ss << (multiline ? U"\n" : U"") << indent << U"]";
+                        default:
+                            throw makeError(ast.location,
+                                            "Unary operator " + uop_string(ast.op) +
+                                            " does not operate on type " + type_str(scratch));
                     }
-                }
-                break;
+                } break;
 
-                case Value::BOOLEAN:
-                ss << (scratch.v.b ? U"true" : U"false");
-                break;
-
-                case Value::DOUBLE:
-                ss << decode_utf8(jsonnet_unparse_number(scratch.v.d));
-                break;
-
-                case Value::FUNCTION:
-                throw makeError(loc, "Couldn't manifest function in JSON output.");
-
-                case Value::NULL_TYPE:
-                ss << U"null";
-                break;
-
-                case Value::OBJECT: {
-                    auto *obj = static_cast<HeapObject*>(scratch.v.h);
-                    runInvariants(loc, obj);
-                    // Using std::map has the useful side-effect of ordering the fields
-                    // alphabetically.
-                    std::map<String, const Identifier*> fields;
-                    for (const auto &f : objectFields(obj, true)) {
-                        fields[f->name] = f;
-                    }
-                    if (fields.size() == 0) {
-                        ss << U"{ }";
-                    } else {
-                        String indent2 = multiline ? indent + U"   " : indent;
-                        const char32_t *prefix = multiline ? U"{\n" : U"{";
-                        for (const auto &f : fields) {
-                            // pushes FRAME_CALL
-                            const AST *body = objectIndex(loc, obj, f.second, 0);
-                            stack.top().val = scratch;
-                            evaluate(body, stack.size());
-                            auto vstr = manifestJson(body->location, multiline, indent2);
-                            // Reset scratch so that the object we're manifesting doesn't
-                            // get GC'd.
-                            scratch = stack.top().val;
-                            stack.pop();
-                            ss << prefix << indent2 << U"\"" << f.first << U"\": " << vstr;
-                            prefix = multiline ? U",\n" : U", ";
-                        }
-                        ss << (multiline ? U"\n" : U"") << indent << U"}";
-                    }
-                }
-                break;
-
-                case Value::STRING: {
-                    const String &str = static_cast<HeapString*>(scratch.v.h)->value;
-                    ss << jsonnet_string_unparse(str, false);
-                }
-                break;
+                default:
+                std::cerr << "INTERNAL ERROR: Unknown FrameKind:  " << f.kind << std::endl;
+                std::abort();
             }
-            return ss.str();
+
+            popframe:;
+
+            stack.pop();
+
+            replaceframe:;
         }
+    }
 
-        String manifestString(const LocationRange &loc)
-        {
-            if (scratch.t != Value::STRING) {
-                std::stringstream ss;
-                ss << "Expected string result, got: " << type_str(scratch.t);
-                throw makeError(loc, ss.str());
-            }
-            return static_cast<HeapString*>(scratch.v.h)->value;
-        }
+    /** Manifest the scratch value by evaluating any remaining fields, and then convert to JSON.
+     *
+     * This can trigger a garbage collection cycle.  Be sure to stash any objects that aren't
+     * reachable via the stack or heap.
+     *
+     * \param multiline If true, will print objects and arrays in an indented fashion.
+     */
+    String manifestJson(const LocationRange &loc, bool multiline, const String &indent)
+    {
+        // Printing fields means evaluating and binding them, which can trigger
+        // garbage collection.
 
-        StrMap manifestMulti(bool string)
-        {
-            StrMap r;
-            LocationRange loc("During manifestation");
-            if (scratch.t != Value::OBJECT) {
-                std::stringstream ss;
-                ss << "Multi mode: Top-level object was a " << type_str(scratch.t) << ", "
-                   << "should be an object whose keys are filenames and values hold "
-                   << "the JSON for that file.";
-                throw makeError(loc, ss.str());
-            }
-            auto *obj = static_cast<HeapObject*>(scratch.v.h);
-            runInvariants(loc, obj);
-            std::map<String, const Identifier*> fields;
-            for (const auto &f : objectFields(obj, true)) {
-                fields[f->name] = f;
-            }
-            for (const auto &f : fields) {
-                // pushes FRAME_CALL
-                const AST *body = objectIndex(loc, obj, f.second, 0);
-                stack.top().val = scratch;
-                evaluate(body, stack.size());
-                auto vstr = string ? manifestString(body->location)
-                                   : manifestJson(body->location, true, U"");
-                // Reset scratch so that the object we're manifesting doesn't
-                // get GC'd.
-                scratch = stack.top().val;
-                stack.pop();
-                r[encode_utf8(f.first)] = encode_utf8(vstr);
-            }
-            return r;
-        }
-
-        std::vector<std::string> manifestStream(void)
-        {
-            std::vector<std::string> r;
-            LocationRange loc("During manifestation");
-            if (scratch.t != Value::ARRAY) {
-                std::stringstream ss;
-                ss << "Stream mode: Top-level object was a " << type_str(scratch.t) << ", "
-                   << "should be an array whose elements hold "
-                   << "the JSON for each document in the stream.";
-                throw makeError(loc, ss.str());
-            }
-            auto *arr = static_cast<HeapArray*>(scratch.v.h);
-            for (auto *thunk : arr->elements) {
-                LocationRange tloc = thunk->body == nullptr
-                                   ? loc
-                                   : thunk->body->location;
-                if (thunk->filled) {
-                    stack.newCall(loc, thunk, nullptr, 0, BindingFrame{});
-                    // Keep arr alive when scratch is overwritten
-                    stack.top().val = scratch;
-                    scratch = thunk->content;
+        StringStream ss;
+        switch (scratch.t) {
+            case Value::ARRAY: {
+                HeapArray *arr = static_cast<HeapArray*>(scratch.v.h);
+                if (arr->elements.size() == 0) {
+                    ss << U"[ ]";
                 } else {
-                    stack.newCall(loc, thunk,
-                                  thunk->self, thunk->offset, thunk->upValues);
-                    // Keep arr alive when scratch is overwritten
-                    stack.top().val = scratch;
-                    evaluate(thunk->body, stack.size());
+                    const char32_t *prefix = multiline ? U"[\n" : U"[";
+                    String indent2 = multiline ? indent + U"   " : indent;
+                    for (auto *thunk : arr->elements) {
+                        LocationRange tloc = thunk->body == nullptr
+                                           ? loc
+                                           : thunk->body->location;
+                        if (thunk->filled) {
+                            stack.newCall(loc, thunk, nullptr, 0, BindingFrame{});
+                            // Keep arr alive when scratch is overwritten
+                            stack.top().val = scratch;
+                            scratch = thunk->content;
+                        } else {
+                            stack.newCall(loc, thunk, thunk->self, thunk->offset, thunk->upValues);
+                            // Keep arr alive when scratch is overwritten
+                            stack.top().val = scratch;
+                            evaluate(thunk->body, stack.size());
+                        }
+                        auto element = manifestJson(tloc, multiline, indent2);
+                        // Restore scratch
+                        scratch = stack.top().val;
+                        stack.pop();
+                        ss << prefix << indent2 << element;
+                        prefix = multiline ? U",\n" : U", ";
+                    }
+                    ss << (multiline ? U"\n" : U"") << indent << U"]";
                 }
-                String element = manifestJson(tloc, true, U"");
-                scratch = stack.top().val;
-                stack.pop();
-                r.push_back(encode_utf8(element));
             }
-            return r;
+            break;
+
+            case Value::BOOLEAN:
+            ss << (scratch.v.b ? U"true" : U"false");
+            break;
+
+            case Value::DOUBLE:
+            ss << decode_utf8(jsonnet_unparse_number(scratch.v.d));
+            break;
+
+            case Value::FUNCTION:
+            throw makeError(loc, "Couldn't manifest function in JSON output.");
+
+            case Value::NULL_TYPE:
+            ss << U"null";
+            break;
+
+            case Value::OBJECT: {
+                auto *obj = static_cast<HeapObject*>(scratch.v.h);
+                runInvariants(loc, obj);
+                // Using std::map has the useful side-effect of ordering the fields
+                // alphabetically.
+                std::map<String, const Identifier*> fields;
+                for (const auto &f : objectFields(obj, true)) {
+                    fields[f->name] = f;
+                }
+                if (fields.size() == 0) {
+                    ss << U"{ }";
+                } else {
+                    String indent2 = multiline ? indent + U"   " : indent;
+                    const char32_t *prefix = multiline ? U"{\n" : U"{";
+                    for (const auto &f : fields) {
+                        // pushes FRAME_CALL
+                        const AST *body = objectIndex(loc, obj, f.second, 0);
+                        stack.top().val = scratch;
+                        evaluate(body, stack.size());
+                        auto vstr = manifestJson(body->location, multiline, indent2);
+                        // Reset scratch so that the object we're manifesting doesn't
+                        // get GC'd.
+                        scratch = stack.top().val;
+                        stack.pop();
+                        ss << prefix << indent2 << U"\"" << f.first << U"\": " << vstr;
+                        prefix = multiline ? U",\n" : U", ";
+                    }
+                    ss << (multiline ? U"\n" : U"") << indent << U"}";
+                }
+            }
+            break;
+
+            case Value::STRING: {
+                const String &str = static_cast<HeapString*>(scratch.v.h)->value;
+                ss << jsonnet_string_unparse(str, false);
+            }
+            break;
         }
+        return ss.str();
+    }
 
-    };
+    String manifestString(const LocationRange &loc)
+    {
+        if (scratch.t != Value::STRING) {
+            std::stringstream ss;
+            ss << "Expected string result, got: " << type_str(scratch.t);
+            throw makeError(loc, ss.str());
+        }
+        return static_cast<HeapString*>(scratch.v.h)->value;
+    }
 
-}
+    StrMap manifestMulti(bool string)
+    {
+        StrMap r;
+        LocationRange loc("During manifestation");
+        if (scratch.t != Value::OBJECT) {
+            std::stringstream ss;
+            ss << "Multi mode: Top-level object was a " << type_str(scratch.t) << ", "
+               << "should be an object whose keys are filenames and values hold "
+               << "the JSON for that file.";
+            throw makeError(loc, ss.str());
+        }
+        auto *obj = static_cast<HeapObject*>(scratch.v.h);
+        runInvariants(loc, obj);
+        std::map<String, const Identifier*> fields;
+        for (const auto &f : objectFields(obj, true)) {
+            fields[f->name] = f;
+        }
+        for (const auto &f : fields) {
+            // pushes FRAME_CALL
+            const AST *body = objectIndex(loc, obj, f.second, 0);
+            stack.top().val = scratch;
+            evaluate(body, stack.size());
+            auto vstr = string ? manifestString(body->location)
+                               : manifestJson(body->location, true, U"");
+            // Reset scratch so that the object we're manifesting doesn't
+            // get GC'd.
+            scratch = stack.top().val;
+            stack.pop();
+            r[encode_utf8(f.first)] = encode_utf8(vstr);
+        }
+        return r;
+    }
+
+    std::vector<std::string> manifestStream(void)
+    {
+        std::vector<std::string> r;
+        LocationRange loc("During manifestation");
+        if (scratch.t != Value::ARRAY) {
+            std::stringstream ss;
+            ss << "Stream mode: Top-level object was a " << type_str(scratch.t) << ", "
+               << "should be an array whose elements hold "
+               << "the JSON for each document in the stream.";
+            throw makeError(loc, ss.str());
+        }
+        auto *arr = static_cast<HeapArray*>(scratch.v.h);
+        for (auto *thunk : arr->elements) {
+            LocationRange tloc = thunk->body == nullptr
+                               ? loc
+                               : thunk->body->location;
+            if (thunk->filled) {
+                stack.newCall(loc, thunk, nullptr, 0, BindingFrame{});
+                // Keep arr alive when scratch is overwritten
+                stack.top().val = scratch;
+                scratch = thunk->content;
+            } else {
+                stack.newCall(loc, thunk, thunk->self, thunk->offset, thunk->upValues);
+                // Keep arr alive when scratch is overwritten
+                stack.top().val = scratch;
+                evaluate(thunk->body, stack.size());
+            }
+            String element = manifestJson(tloc, true, U"");
+            scratch = stack.top().val;
+            stack.pop();
+            r.push_back(encode_utf8(element));
+        }
+        return r;
+    }
+
+};
+
+}  // namespace
 
 std::string jsonnet_vm_execute(Allocator *alloc, const AST *ast,
                                const ExtMap &ext_vars,


### PR DESCRIPTION
As discussed offline, this change drops the indent within namespaces. This allows us to save
on horizontal whitespace and makes the code a bit easier to follow.