### PR TITLE
Remove unnecessary check

### DIFF
--- a/core/vm.cpp
+++ b/core/vm.cpp
@@ -718,9 +718,7 @@ class Interpreter {
         BindingFrame env;
         for (auto fv : free_vars) {
             auto *th = stack.lookUpVar(fv);
-            if (th != nullptr) {
-                env[fv] = th;
-            }
+            env[fv] = th;
         }
         return env;
     }


### PR DESCRIPTION
Variables should always be available in the stack.