### PR TITLE
avoid trailing spaces in manifestJsonEx output

### DIFF
--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -726,16 +726,16 @@ limitations under the License.
                 error "Tried to manifest function at " + path
             else if std.type(v) == "array" then
                 local range = std.range(0, std.length(v) - 1);
-                local lines = ["[\n" + cindent] 
-                              + std.join([",\n" + cindent],
-                                         [[indent + aux(v[i], path + [i], cindent + indent)] for i
+                local lines = ["[\n"]
+                              + std.join([",\n"],
+                                         [[cindent + indent + aux(v[i], path + [i], cindent + indent)] for i
 in range])                
                               + ["\n" + cindent + "]"];
                 std.join("", lines)
             else if std.type(v) == "object" then
-                local lines = ["{\n" + cindent] 
-                              + std.join([",\n" + cindent],
-                                         [[indent + "\"" + k + "\": "
+                local lines = ["{\n"]
+                              + std.join([",\n"],
+                                         [[cindent + indent + "\"" + k + "\": "
                                            + aux(v[k], path + [k], cindent + indent)]
                                           for k in std.objectFields(v)])
                               + ["\n" + cindent + "}"];

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -341,8 +341,16 @@ std.assertEqual(std.splitLimit("/foo/", "/", 1), ["", "foo/"]) &&
 std.assertEqual(std.manifestJsonEx({
     x: [1, 2, 3, true, false, null, "string\nstring"],
     y: { a: 1, b: 2, c: [1, 2] },
+    emptyArray: [],
+    emptyObject: {},
 }, "    ") + "\n", |||
     {
+        "emptyArray": [
+
+        ],
+        "emptyObject": {
+
+        },
         "x": [
             1,
             2,


### PR DESCRIPTION
This PR avoids trailing spaces in manifestJsonEx output when the input value is an empty array or object. Apart from the aesthetic benefit, one major benefit is making the output eligible for the literal block syntax in yaml, which forbids trailing spaces.