### PR TITLE
Fix pagination in the 3rd page of the case study

### DIFF
--- a/doc/case_studies/casestudy_fractal.3.html
+++ b/doc/case_studies/casestudy_fractal.3.html
@@ -4,8 +4,8 @@ layout: default
 
 <h1 id=top>
 
-<p class=jump_to_page_top>Pages <a href="case_studies/casestudy_fractal.1.html">1</a>, <a
-href="case_studies/casestudy_fractal.2.html">2</a>, 3</p>
+<p class=jump_to_page_top>Pages <a href="/case_studies/casestudy_fractal.1.html">1</a>, <a
+href="/case_studies/casestudy_fractal.2.html">2</a>, 3</p>
 
 Case Study: Fractal Cloud Application
 
@@ -205,5 +205,5 @@ involved.</p>
 UNIX make), we were able to build an operations methodology where many aspects of the service can be
 controlled centrally by editing a single Jsonnet file and issuing make -j update commands.</p>
 
-<p class=jump_to_page>Pages <a href="case_studies/casestudy_fractal.1.html">1</a>, <a
-href="case_studies/casestudy_fractal.2.html">2</a>, 3</p>
+<p class=jump_to_page>Pages <a href="/case_studies/casestudy_fractal.1.html">1</a>, <a
+href="/case_studies/casestudy_fractal.2.html">2</a>, 3</p>


### PR DESCRIPTION
The page enumeration was broken in the third page because there was a leading slash missing in the hyperlinks, and they raised 404 errors when trying to move backwards.