### PR TITLE
add extVarOrNull and extVarOrEmpty

### DIFF
--- a/core/desugarer.cpp
+++ b/core/desugarer.cpp
@@ -31,7 +31,7 @@ struct BuiltinDecl {
     std::vector<String> params;
 };
 
-static unsigned long max_builtin = 25;
+static unsigned long max_builtin = 26;
 BuiltinDecl jsonnet_builtin_decl(unsigned long builtin)
 {
     switch (builtin) {
@@ -61,6 +61,7 @@ BuiltinDecl jsonnet_builtin_decl(unsigned long builtin)
         case 23: return {U"extVar", {U"x"}};
         case 24: return {U"primitiveEquals", {U"a", U"b"}};
         case 25: return {U"native", {U"name"}};
+        case 26: return {U"extVarOrNull", {U"x"}};
         default:
         std::cerr << "INTERNAL ERROR: Unrecognized builtin function: " << builtin << std::endl;
         std::abort();

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1004,4 +1004,7 @@ in range])
         local arr = std.split(f, "/");
         std.join("/", std.makeArray(std.length(arr)-1, function(i)arr[i]) + [r]),
 
+    extVarOrEmpty(v)::
+        local val = std.extVarOrNull(v);
+        if std.type(val) == "null" then {} else val,
 }


### PR DESCRIPTION
Hi Jsonnet folks,

I'm trying to add two functions: extVarOrNull and extVarOrEmpty, which returns Null or Empty when the var is not defined in ext-code or ext-str.

Here is my use case:

{
  local a = 4,
  local b = std.extVarOrNull("a"),
  "c": if b == null then a else b
}

$ jsonnet a.jsonnet 
{
   "c": 4
}

$ jsonnet a.jsonnet --ext-code "a=5"
{
   "c": 5
}