### PR TITLE
Use /bin/bash shebang since these scripts require it

### DIFF
--- a/tools/build_defs/jsonnet_dev/build_jekyll_tree.sh
+++ b/tools/build_defs/jsonnet_dev/build_jekyll_tree.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_defs/jsonnet_dev/build_jsonnet_srcs_zip.sh
+++ b/tools/build_defs/jsonnet_dev/build_jsonnet_srcs_zip.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
These scripts break when /bin/sh is a symlink to /bin/dash, which is the default in some linux distributions.