### PR TITLE
Add fmt test for toplevel binary expression

### DIFF
--- a/test_suite/binary.jsonnet
+++ b/test_suite/binary.jsonnet
@@ -1,0 +1,2 @@
+true &&
+true

--- a/test_suite/binary.jsonnet.fmt.golden
+++ b/test_suite/binary.jsonnet.fmt.golden
@@ -1,0 +1,2 @@
+true &&
+true


### PR DESCRIPTION
Github closed #279 when I rebased, but here's a test for you. I made it a separate test since the bug in #266 would only show up if the first AST processed was a Binary AST; the other ASTs would have initialized/modified the column.