### PR TITLE
Fix spelling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ libjsonnet.so: $(LIB_OBJ)
 libjsonnet++.so: $(LIB_CPP_OBJ)
 	$(CXX) $(LDFLAGS) $(LIB_CPP_OBJ) $(SHARED_LDFLAGS) -o $@
 
-# Javascript build of C binding
+# JavaScript build of C binding
 JS_EXPORTED_FUNCTIONS = 'EXPORTED_FUNCTIONS=["_jsonnet_make", "_jsonnet_evaluate_snippet", "_jsonnet_realloc", "_jsonnet_destroy"]'
 
 libjsonnet.js: $(LIB_SRC) $(ALL_HEADERS)

--- a/doc/_includes/nav.html
+++ b/doc/_includes/nav.html
@@ -31,7 +31,7 @@
             <a href="/implementation/commandline.html">Cmdline Tool</a>
             <a href="/implementation/bindings.html">Libraries</a>
             <a href="/implementation/cpp.html">C++ Internals</a>
-            <a href="/implementation/javascript.html">Javascript</a>
+            <a href="/implementation/javascript.html">JavaScript</a>
             <a href="/implementation/tests.html">Tests</a>
         </div>
     </li>

--- a/doc/case_studies/casestudy_fractal.1.html
+++ b/doc/case_studies/casestudy_fractal.1.html
@@ -49,7 +49,7 @@ fault-tolerant.</p>
 <img src="/img/fractal_architecture.png">
 
 <p>The Application Server hosts static content (CSS) and Jinja'd HTML.  The <a
-href="{{ page.srcroot }}/fractal/appserv/templates/page.html">HTML</a> contains Javascript that issues AJAX
+href="{{ page.srcroot }}/fractal/appserv/templates/page.html">HTML</a> contains JavaScript that issues AJAX
 requests to 1) the Tile Generating Service and 2) the Application Server (to fetch / amend the
 discoveries list).  The Application Server therefore does not communicate directly with the fractal
 Tile Generating Service, but it needs to know the host:port endpoint in order to embed it in the

--- a/doc/docs/demo.html
+++ b/doc/docs/demo.html
@@ -7,7 +7,7 @@ layout: default
 
 <h1 id="online_demo">Jsonnet Online Demo</h1>
 
-<p> This Javascript <a href="/implementation/javascript.html">build</a> of Jsonnet runs in your browser.
+<p> This JavaScript <a href="/implementation/javascript.html">build</a> of Jsonnet runs in your browser.
 There is no filesystem, so <code>import</code> will not find any files.  In most browsers, the textboxes can
 be made larger by dragging their bottom right corner.</p>
 

--- a/doc/docs/tutorial.html
+++ b/doc/docs/tutorial.html
@@ -93,7 +93,7 @@ syntax of Python.  I.e., it can be embedded in the middle of an expression.</p>
 
 <p>The example below illustrates some of these features.  Note that equality returns false if the
 two values have different types, as is the case in most dynamically typed scripting languages (but
-not Javascript).  Note also the <code>|||</code> syntax for text blocks.  This strips the leading
+not JavaScript).  Note also the <code>|||</code> syntax for text blocks.  This strips the leading
 whitespace but preserves the newlines in the string literal.  Just like any other string, one can
 use the string formatting operator <code>%</code>.</p>
 
@@ -207,7 +207,7 @@ definitions are really just syntax sugar for closures that are assigned to a fie
 <p>Finally, you may have noticed that two colons are used instead of one.  This marks the field as
 being <dfn>hidden</dfn>, i.e. it will not appear in the JSON output.  The field can still be
 accessed by Jsonnet code, so it is not like the private/protected modifier that some languages have.
-Hidden fields are convenient for functions, which cannot be manifestated in the JSON output.  It has
+Hidden fields are convenient for functions, which cannot be manifested in the JSON output.  It has
 other uses too, as we will see in the later section on object orientation.</p>
 
 <h3 id="locals">Local Variables</h3>

--- a/doc/implementation/index.html
+++ b/doc/implementation/index.html
@@ -8,6 +8,6 @@ layout: default
 <li> <a href="/implementation/commandline.html">Cmdline Tool</a> </li>
 <li> <a href="/implementation/bindings.html">Libraries</a> </li>
 <li> <a href="/implementation/cpp.html">C++ Internals</a> </li>
-<li> <a href="/implementation/javascript.html">Javascript</a> </li>
+<li> <a href="/implementation/javascript.html">JavaScript</a> </li>
 <li> <a href="/implementation/tests.html">Tests</a> </li>
 </ul>

--- a/doc/implementation/javascript.html
+++ b/doc/implementation/javascript.html
@@ -2,12 +2,12 @@
 layout: default
 ---
 
-<h1 id="javascript_implementation">Javascript Implementation</h1>
+<h1 id="javascript_implementation">JavaScript Implementation</h1>
 
 <p> The C++ implementation can be compiled with <a
-href="http://kripken.github.io/emscripten-site/">emscripten</a> to produce a Javascript
+href="http://kripken.github.io/emscripten-site/">emscripten</a> to produce a JavaScript
 implementation of Jsonnet.  This is how we implement our <a href="/docs/demo.html">Jsonnet demo</a>.  It
-is not the fastest possible Javascript implementation of Jsonnet, but it is easy to build, and is
+is not the fastest possible JavaScript implementation of Jsonnet, but it is easy to build, and is
 sufficient for many purposes.</p>
 
 <p>To compile it, first <a

--- a/examples/bar_menu.11.jsonnet
+++ b/examples/bar_menu.11.jsonnet
@@ -33,7 +33,7 @@ limitations under the License.
 
         [if brunch then "Bloody Mary"]: {
             ingredients: [
-                { kind: "Vokda", qty: 1.5 },
+                { kind: "Vodka", qty: 1.5 },
                 { kind: "Tomato Juice", qty: 3 },
                 { kind: "Lemon Juice", qty: 1.5 },
                 { kind: "Worcestershire Sauce", qty: 0.25 },

--- a/examples/bar_menu.11.jsonnet.golden
+++ b/examples/bar_menu.11.jsonnet.golden
@@ -14,7 +14,7 @@
       "Bloody Mary": {
          "garnish": "Celery salt & pepper",
          "ingredients": [
-            { "kind": "Vokda", "qty": 1.5 },
+            { "kind": "Vodka", "qty": 1.5 },
             { "kind": "Tomato Juice", "qty": 3 },
             { "kind": "Lemon Juice", "qty": 1.5 },
             { "kind": "Worcestershire Sauce", "qty": 0.25 },


### PR DESCRIPTION
There is one obvious typo (Vokda) one word that takes it too far ("manifestated" -> "manifested") and spell checkers complain about "Javascript" and suggest "JavaScript". Apparently it's the official way of writing it (Wikipedia confirms it).