### PR TITLE
Fix the bazel python build

### DIFF
--- a/python/BUILD
+++ b/python/BUILD
@@ -1,26 +1,23 @@
-# TODO(dcunnin): Re-enable the following by fixing this error:
-# ERROR: /home/dcunnin/jsonnet/python/BUILD:1:1: no such package '@default_python//': Failed to locate Python headers:
+cc_binary(
+    name = "_jsonnet.so",
+    srcs = ["_jsonnet.c"],
+    linkshared = 1,
+    deps = [
+        "//core:libjsonnet",
+        "@default_python//:headers",
+    ],
+)
 
-# cc_binary(
-#     name = "_jsonnet.so",
-#     srcs = ["_jsonnet.c"],
-#     linkshared = 1,
-#     deps = [
-#         "//core:libjsonnet",
-#         "@default_python//:headers",
-#     ],
-# )
+py_library(
+    name = "_jsonnet",
+    data = [":_jsonnet.so"],
+    imports = ["."],
+    visibility = ["//visibility:public"],
+)
 
-# py_library(
-#     name = "_jsonnet",
-#     data = [":_jsonnet.so"],
-#     imports = ["."],
-#     visibility = ["//visibility:public"],
-# )
-
-# py_test(
-#     name = "_jsonnet_test",
-#     srcs = ["_jsonnet_test.py"],
-#     data = ["test.jsonnet"],
-#     deps = [":_jsonnet"],
-# )
+py_test(
+    name = "_jsonnet_test",
+    srcs = ["_jsonnet_test.py"],
+    data = ["test.jsonnet"],
+    deps = [":_jsonnet"],
+)

--- a/tools/build_defs/python_repo.bzl
+++ b/tools/build_defs/python_repo.bzl
@@ -29,7 +29,7 @@ def _python_interpreter(repository_ctx):
     realpath = rctx.which(rctx.attr.path)
   rctx.symlink(realpath, "bin/python")
   include_path = rctx.execute([
-      realpath, "-c", 'import sysconfig; print(sysconfig.get_path("include"))',
+      realpath, "-c", "import distutils.sysconfig; print(distutils.sysconfig.get_python_inc())",
   ])
   if include_path.return_code != 0:
     fail("Failed to locate Python headers:\n" + include_path.stderr)


### PR DESCRIPTION
For some reason `sysconfig.get_path("include")` incorrectly returns /usr/local/include/python2.7 on Debian (and probably Ubuntu) systems. Fortunately, `distutils.sysconfig.get_python_inc()` seems to do the right thing across platforms.