### PR TITLE
Use a more common spelling: Pre-Procesor -> preprocessor

### DIFF
--- a/doc/language/comparisons.html
+++ b/doc/language/comparisons.html
@@ -34,7 +34,7 @@ JSON.</p>
 generating (they think it is simply plain text), they cannot help the programmer avoid creating
 errors in the underlying representation.</p>
 
-<p> By analogy, the C Pre-Processor has no understanding of C syntax.  C Pre-Processor macros can
+<p> By analogy, the C preprocessor has no understanding of C syntax.  C preprocessor macros can
 break that syntax if they are used wrongly.  The net result of this is that problems with the use of
 these macros must be debugged by examining the output of the evaluation (i.e. the generated C code).
 Errors cannot be presented at the level at which the programmer is actually working.  For this


### PR DESCRIPTION
https://en.wikipedia.org/wiki/C_preprocessor
http://www.dictionary.com/browse/preprocessor?s=t