### PR TITLE
Add instructions for building with Clang.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 # User-servicable parts:
 ################################################################################
 
-# C/C++ compiler -- clang also works
+# C/C++ compiler; to use Clang, build with `make CC=clang CXX=clang++`
 CXX ?= g++
 CC ?= gcc
 

--- a/README.md
+++ b/README.md
@@ -37,14 +37,24 @@ To run the output binary, run:
 
 Bazel builds are also supported.
 [Install Bazel](https://www.bazel.io/versions/master/docs/install.html) if it is
-not installed already. Then, run the following command to build:
+not installed already. Then, run the following command to build with GCC:
 
 ```
 bazel build -c opt //cmd:jsonnet
 ```
 
-This builds the `jsonnet` target defined in [cmd/BUILD](./cmd/BUILD) To run the
-output binary, run:
+To build with Clang, use one of these two options:
+
+```
+env CC=clang CXX=clang++ bazel build -c opt //cmd:jsonnet
+
+# OR
+
+bazel build -c opt --action_env=CC=clang --action_env=CXX=clang++ //cmd:jsonnet
+```
+
+This builds the `jsonnet` target defined in [`cmd/BUILD`](./cmd/BUILD). To
+launch the output binary, run:
 
 ```
 bazel-bin/cmd/jsonnet

--- a/README.md
+++ b/README.md
@@ -9,15 +9,22 @@ Visit our [discussion forum](https://groups.google.com/forum/#!forum/jsonnet).
 
 ## Building Jsonnet
 
-The GCC C++ (g++) compiler is required to build Jsonnet. Clang is also
-supported.
+You can use either GCC or Clang to build Jsonnet. Note that on recent versions
+of macOS, `/usr/bin/gcc` and `/usr/bin/g++` are actually Clang, so there is no
+difference.
 
 ### Makefile
 
-To build jsonnet with g++, run:
+To build Jsonnet with GCC, run:
 
 ```
 make
+```
+
+To build Jsonnet with Clang, run:
+
+```
+make CC=clang CXX=clang++
 ```
 
 To run the output binary, run:


### PR DESCRIPTION
This addresses the basic request behind issue #348 to bring Clang to parity with GCC.

This PR does not make Clang default, because that would be a behavior change.