### PR TITLE
Use directly static_cast, rather than probing with dynamic_cast

### DIFF
--- a/core/ast.h
+++ b/core/ast.h
@@ -30,6 +30,7 @@ limitations under the License.
 
 enum ASTType {
     AST_APPLY,
+    AST_APPLY_BRACE,
     AST_ARRAY,
     AST_ARRAY_COMPREHENSION,
     AST_ARRAY_COMPREHENSION_SIMPLE,
@@ -64,6 +65,7 @@ static inline std::string ASTTypeToString(ASTType type)
 {
     switch (type) {
         case AST_APPLY: return "AST_APPLY";
+        case AST_APPLY_BRACE: return "AST_APPLY_BRACE";
         case AST_ARRAY: return "AST_ARRAY";
         case AST_ARRAY_COMPREHENSION: return "AST_ARRAY_COMPREHENSION";
         case AST_ARRAY_COMPREHENSION_SIMPLE: return "AST_ARRAY_COMPREHENSION_SIMPLE";
@@ -126,7 +128,8 @@ struct AST {
     virtual ~AST(void) {}
 };
 
-typedef std::vector<AST *> ASTs;
+#include <list>
+typedef std::list<AST *> ASTs;
 
 /** Either an arg in a function apply, or a param in a closure / other function definition.
  *
@@ -214,7 +217,7 @@ struct ApplyBrace : public AST {
     AST *left;
     AST *right;  // This is always an object or object comprehension.
     ApplyBrace(const LocationRange &lr, const Fodder &open_fodder, AST *left, AST *right)
-        : AST(lr, AST_BINARY, open_fodder), left(left), right(right)
+        : AST(lr, AST_APPLY_BRACE, open_fodder), left(left), right(right)
     {
     }
 };

--- a/core/ast.h
+++ b/core/ast.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <cstdlib>
 
 #include <iostream>
+#include <list>
 #include <map>
 #include <string>
 #include <vector>
@@ -128,7 +129,6 @@ struct AST {
     virtual ~AST(void) {}
 };
 
-#include <list>
 typedef std::list<AST *> ASTs;
 
 /** Either an arg in a function apply, or a param in a closure / other function definition.

--- a/core/parser.cpp
+++ b/core/parser.cpp
@@ -201,10 +201,10 @@ class Parser {
         // parseArgs returns f(x) with x as an expression.  Convert it here.
         for (auto &p : params) {
             if (p.id == nullptr) {
-                auto *pv = dynamic_cast<Var *>(p.expr);
-                if (pv == nullptr) {
+                if (p.expr->type != AST_VAR) {
                     throw StaticError(p.expr->location, "Could not parse parameter here.");
                 }
+                auto *pv = static_cast<Var *>(p.expr);
                 p.id = pv->id;
                 p.idFodder = pv->openFodder;
                 p.expr = nullptr;
@@ -811,7 +811,8 @@ class Parser {
             case Token::IMPORT: {
                 pop();
                 AST *body = parse(MAX_PRECEDENCE);
-                if (auto *lit = dynamic_cast<LiteralString *>(body)) {
+                if (body->type == AST_LITERAL_STRING) {
+                    auto *lit = static_cast<LiteralString *>(body);
                     if (lit->tokenKind == LiteralString::BLOCK) {
                         throw StaticError(lit->location,
                                           "Cannot use text blocks in import statements.");
@@ -827,7 +828,8 @@ class Parser {
             case Token::IMPORTSTR: {
                 pop();
                 AST *body = parse(MAX_PRECEDENCE);
-                if (auto *lit = dynamic_cast<LiteralString *>(body)) {
+                if (body->type == AST_LITERAL_STRING) {
+                    auto *lit = static_cast<LiteralString *>(body);
                     if (lit->tokenKind == LiteralString::BLOCK) {
                         throw StaticError(lit->location,
                                           "Cannot use text blocks in import statements.");

--- a/core/pass.cpp
+++ b/core/pass.cpp
@@ -282,70 +282,50 @@ void CompilerPass::visit(Unary *ast)
     expr(ast->expr);
 }
 
+#define VISIT(var,astType,astClass) \
+   case astType: { \
+     assert(dynamic_cast<astClass *>(var)); \
+     auto *ast = static_cast<astClass *>(var); \
+     visit(ast); \
+   } break
+
 void CompilerPass::visitExpr(AST *&ast_)
 {
-    if (auto *ast = dynamic_cast<Apply *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<ApplyBrace *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<Array *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<ArrayComprehension *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<Assert *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<Binary *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<BuiltinFunction *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<Conditional *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<Dollar *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<Error *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<Function *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<Import *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<Importstr *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<InSuper *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<Index *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<Local *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<LiteralBoolean *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<LiteralNumber *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<LiteralString *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<LiteralNull *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<Object *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<DesugaredObject *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<ObjectComprehension *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<ObjectComprehensionSimple *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<Parens *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<Self *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<SuperIndex *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<Unary *>(ast_)) {
-        visit(ast);
-    } else if (auto *ast = dynamic_cast<Var *>(ast_)) {
-        visit(ast);
-
-    } else {
-        std::cerr << "INTERNAL ERROR: Unknown AST: " << ast_ << std::endl;
-        std::abort();
+    switch(ast_->type) {
+        VISIT(ast_, AST_APPLY, Apply);
+        VISIT(ast_, AST_APPLY_BRACE, ApplyBrace);
+        VISIT(ast_, AST_ARRAY, Array);
+        VISIT(ast_, AST_ARRAY_COMPREHENSION, ArrayComprehension);
+        // VISIT(ast_, AST_ARRAY_COMPREHENSION, ArrayComprehensionSimple);
+        VISIT(ast_, AST_ASSERT, Assert);
+        VISIT(ast_, AST_BINARY, Binary);
+        VISIT(ast_, AST_BUILTIN_FUNCTION, BuiltinFunction);
+        VISIT(ast_, AST_CONDITIONAL, Conditional);
+        VISIT(ast_, AST_DESUGARED_OBJECT, DesugaredObject);
+        VISIT(ast_, AST_DOLLAR, Dollar);
+        VISIT(ast_, AST_ERROR, Error);
+        VISIT(ast_, AST_FUNCTION, Function);
+        VISIT(ast_, AST_IMPORT, Import);
+        VISIT(ast_, AST_IMPORTSTR, Importstr);
+        VISIT(ast_, AST_INDEX, Index);
+        VISIT(ast_, AST_IN_SUPER, InSuper);
+        VISIT(ast_, AST_LITERAL_BOOLEAN, LiteralBoolean);
+        VISIT(ast_, AST_LITERAL_NULL, LiteralNull);
+        VISIT(ast_, AST_LITERAL_NUMBER, LiteralNumber);
+        VISIT(ast_, AST_LITERAL_STRING, LiteralString);
+        VISIT(ast_, AST_LOCAL, Local);
+        VISIT(ast_, AST_OBJECT, Object);
+        VISIT(ast_, AST_OBJECT_COMPREHENSION, ObjectComprehension);
+        VISIT(ast_, AST_OBJECT_COMPREHENSION_SIMPLE, ObjectComprehensionSimple);
+        VISIT(ast_, AST_PARENS, Parens);
+        VISIT(ast_, AST_SELF, Self);
+        VISIT(ast_, AST_SUPER_INDEX, SuperIndex);
+        VISIT(ast_, AST_UNARY, Unary);
+        VISIT(ast_, AST_VAR, Var);
+        default:
+            std::cerr << "INTERNAL ERROR: Unknown AST: " << ast_ << std::endl;
+            std::abort();
+            break;
     }
 }
 
@@ -362,70 +342,50 @@ class ClonePass : public CompilerPass {
     virtual void expr(AST *&ast);
 };
 
+#define CLONE(var,astType,astClass) \
+   case astType: { \
+     assert(dynamic_cast<astClass *>(var)); \
+     auto *ast = static_cast<astClass *>(var); \
+     var = alloc.clone(ast); \
+   } break
+
 void ClonePass::expr(AST *&ast_)
 {
-    if (auto *ast = dynamic_cast<Apply *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<ApplyBrace *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<Array *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<ArrayComprehension *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<Assert *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<Binary *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<BuiltinFunction *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<Conditional *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<Dollar *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<Error *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<Function *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<Import *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<Importstr *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<InSuper *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<Index *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<Local *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<LiteralBoolean *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<LiteralNumber *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<LiteralString *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<LiteralNull *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<Object *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<DesugaredObject *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<ObjectComprehension *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<ObjectComprehensionSimple *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<Parens *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<Self *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<SuperIndex *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<Unary *>(ast_)) {
-        ast_ = alloc.clone(ast);
-    } else if (auto *ast = dynamic_cast<Var *>(ast_)) {
-        ast_ = alloc.clone(ast);
-
-    } else {
-        std::cerr << "INTERNAL ERROR: Unknown AST: " << ast_ << std::endl;
-        std::abort();
+    switch(ast_->type) {
+        CLONE(ast_, AST_APPLY, Apply);
+        CLONE(ast_, AST_APPLY_BRACE, ApplyBrace);
+        CLONE(ast_, AST_ARRAY, Array);
+        CLONE(ast_, AST_ARRAY_COMPREHENSION, ArrayComprehension);
+        // CLONE(ast_, AST_ARRAY_COMPREHENSION, ArrayComprehensionSimple);
+        CLONE(ast_, AST_ASSERT, Assert);
+        CLONE(ast_, AST_BINARY, Binary);
+        CLONE(ast_, AST_BUILTIN_FUNCTION, BuiltinFunction);
+        CLONE(ast_, AST_CONDITIONAL, Conditional);
+        CLONE(ast_, AST_DESUGARED_OBJECT, DesugaredObject);
+        CLONE(ast_, AST_DOLLAR, Dollar);
+        CLONE(ast_, AST_ERROR, Error);
+        CLONE(ast_, AST_FUNCTION, Function);
+        CLONE(ast_, AST_IMPORT, Import);
+        CLONE(ast_, AST_IMPORTSTR, Importstr);
+        CLONE(ast_, AST_INDEX, Index);
+        CLONE(ast_, AST_IN_SUPER, InSuper);
+        CLONE(ast_, AST_LITERAL_BOOLEAN, LiteralBoolean);
+        CLONE(ast_, AST_LITERAL_NULL, LiteralNull);
+        CLONE(ast_, AST_LITERAL_NUMBER, LiteralNumber);
+        CLONE(ast_, AST_LITERAL_STRING, LiteralString);
+        CLONE(ast_, AST_LOCAL, Local);
+        CLONE(ast_, AST_OBJECT, Object);
+        CLONE(ast_, AST_OBJECT_COMPREHENSION, ObjectComprehension);
+        CLONE(ast_, AST_OBJECT_COMPREHENSION_SIMPLE, ObjectComprehensionSimple);
+        CLONE(ast_, AST_PARENS, Parens);
+        CLONE(ast_, AST_SELF, Self);
+        CLONE(ast_, AST_SUPER_INDEX, SuperIndex);
+        CLONE(ast_, AST_UNARY, Unary);
+        CLONE(ast_, AST_VAR, Var);
+        default:
+            std::cerr << "INTERNAL ERROR: Unknown AST: " << ast_ << std::endl;
+            std::abort();
+            break;
     }
 
     CompilerPass::expr(ast_);

--- a/core/state.h
+++ b/core/state.h
@@ -170,10 +170,10 @@ struct HeapSimpleObject : public HeapLeafObject {
      *
      * These are evaluated in the captured environment with self and super bound.
      */
-    std::vector<AST *> asserts;
+    ASTs asserts;
 
     HeapSimpleObject(const BindingFrame &up_values,
-                     const std::map<const Identifier *, Field> fields, std::vector<AST *> asserts)
+                     const std::map<const Identifier *, Field> fields, ASTs asserts)
         : upValues(up_values), fields(fields), asserts(asserts)
     {
     }

--- a/core/static_analysis.cpp
+++ b/core/static_analysis.cpp
@@ -39,31 +39,49 @@ static IdSet static_analysis(AST *ast_, bool in_object, const IdSet &vars)
 {
     IdSet r;
 
-    if (auto *ast = dynamic_cast<const Apply *>(ast_)) {
+    switch (ast_->type) {
+    case AST_APPLY: {
+        assert(dynamic_cast<Apply *>(ast_));
+        auto* ast = static_cast<Apply *>(ast_);
         append(r, static_analysis(ast->target, in_object, vars));
         for (const auto &arg : ast->args)
             append(r, static_analysis(arg.expr, in_object, vars));
-
-    } else if (auto *ast = dynamic_cast<const Array *>(ast_)) {
+    } break;
+    case AST_APPLY_BRACE: {
+        assert(dynamic_cast<ApplyBrace *>(ast_));
+        // Nothing to do.
+    } break;
+    case AST_ARRAY: {
+        assert(dynamic_cast<Array *>(ast_));
+        auto* ast = static_cast<Array *>(ast_);
         for (auto &el : ast->elements)
             append(r, static_analysis(el.expr, in_object, vars));
-
-    } else if (auto *ast = dynamic_cast<const Binary *>(ast_)) {
+    } break;
+    case AST_BINARY: {
+        assert(dynamic_cast<Binary *>(ast_));
+        auto* ast = static_cast<Binary *>(ast_);
         append(r, static_analysis(ast->left, in_object, vars));
         append(r, static_analysis(ast->right, in_object, vars));
-
-    } else if (dynamic_cast<const BuiltinFunction *>(ast_)) {
+    } break;
+    case AST_BUILTIN_FUNCTION: {
+        assert(dynamic_cast<BuiltinFunction *>(ast_));
         // Nothing to do.
-
-    } else if (auto *ast = dynamic_cast<const Conditional *>(ast_)) {
+    } break;
+    case AST_CONDITIONAL: {
+        assert(dynamic_cast<Conditional *>(ast_));
+        auto* ast = static_cast<Conditional *>(ast_);
         append(r, static_analysis(ast->cond, in_object, vars));
         append(r, static_analysis(ast->branchTrue, in_object, vars));
         append(r, static_analysis(ast->branchFalse, in_object, vars));
-
-    } else if (auto *ast = dynamic_cast<const Error *>(ast_)) {
+    } break;
+    case AST_ERROR: {
+        assert(dynamic_cast<Error *>(ast_));
+        auto* ast = static_cast<Error *>(ast_);
         append(r, static_analysis(ast->expr, in_object, vars));
-
-    } else if (auto *ast = dynamic_cast<const Function *>(ast_)) {
+    } break;
+    case AST_FUNCTION: {
+        assert(dynamic_cast<Function *>(ast_));
+        auto* ast = static_cast<Function *>(ast_);
         auto new_vars = vars;
         IdSet params;
         for (const auto &p : ast->params) {
@@ -83,23 +101,31 @@ static IdSet static_analysis(AST *ast_, bool in_object, const IdSet &vars)
         for (const auto &p : ast->params)
             fv.erase(p.id);
         append(r, fv);
-
-    } else if (dynamic_cast<const Import *>(ast_)) {
+    } break;
+    case AST_IMPORT: {
+        assert(dynamic_cast<Import *>(ast_));
         // Nothing to do.
-
-    } else if (dynamic_cast<const Importstr *>(ast_)) {
+    } break;
+    case AST_IMPORTSTR: {
+        assert(dynamic_cast<Importstr *>(ast_));
         // Nothing to do.
-
-    } else if (auto *ast = dynamic_cast<const InSuper *>(ast_)) {
+    } break;
+    case AST_IN_SUPER: {
+        assert(dynamic_cast<const InSuper *>(ast_));
+        auto* ast = static_cast<const InSuper *>(ast_);
         if (!in_object)
             throw StaticError(ast_->location, "Can't use super outside of an object.");
         append(r, static_analysis(ast->element, in_object, vars));
-
-    } else if (auto *ast = dynamic_cast<const Index *>(ast_)) {
+    } break;
+    case AST_INDEX: {
+        assert(dynamic_cast<const Index *>(ast_));
+        auto* ast = static_cast<const Index *>(ast_);
         append(r, static_analysis(ast->target, in_object, vars));
         append(r, static_analysis(ast->index, in_object, vars));
-
-    } else if (auto *ast = dynamic_cast<const Local *>(ast_)) {
+    } break;
+    case AST_LOCAL: {
+        assert(dynamic_cast<const Local *>(ast_));
+        auto* ast = static_cast<const Local *>(ast_);
         IdSet ast_vars;
         for (const auto &bind : ast->binds) {
             ast_vars.insert(bind.var);
@@ -117,20 +143,26 @@ static IdSet static_analysis(AST *ast_, bool in_object, const IdSet &vars)
             fvs.erase(bind.var);
 
         append(r, fvs);
-
-    } else if (dynamic_cast<const LiteralBoolean *>(ast_)) {
+    } break;
+    case AST_LITERAL_BOOLEAN: {
+        assert(dynamic_cast<const LiteralBoolean *>(ast_));
         // Nothing to do.
-
-    } else if (dynamic_cast<const LiteralNumber *>(ast_)) {
+    } break;
+    case AST_LITERAL_NUMBER: {
+        assert(dynamic_cast<const LiteralNumber *>(ast_));
         // Nothing to do.
-
-    } else if (dynamic_cast<const LiteralString *>(ast_)) {
+    } break;
+    case AST_LITERAL_STRING: {
+        assert(dynamic_cast<const LiteralString *>(ast_));
         // Nothing to do.
-
-    } else if (dynamic_cast<const LiteralNull *>(ast_)) {
+    } break;
+    case AST_LITERAL_NULL: {
+        assert(dynamic_cast<const LiteralNull *>(ast_));
         // Nothing to do.
-
-    } else if (auto *ast = dynamic_cast<DesugaredObject *>(ast_)) {
+    } break;
+    case AST_DESUGARED_OBJECT: {
+        assert(dynamic_cast<DesugaredObject *>(ast_));
+        auto* ast = static_cast<DesugaredObject *>(ast_);
         for (auto &field : ast->fields) {
             append(r, static_analysis(field.name, in_object, vars));
             append(r, static_analysis(field.body, true, vars));
@@ -138,36 +170,46 @@ static IdSet static_analysis(AST *ast_, bool in_object, const IdSet &vars)
         for (AST *assert : ast->asserts) {
             append(r, static_analysis(assert, true, vars));
         }
-
-    } else if (auto *ast = dynamic_cast<ObjectComprehensionSimple *>(ast_)) {
+    } break;
+    case AST_OBJECT_COMPREHENSION_SIMPLE: {
+        assert(dynamic_cast<ObjectComprehensionSimple *>(ast_));
+        auto* ast = static_cast<ObjectComprehensionSimple *>(ast_);
         auto new_vars = vars;
         new_vars.insert(ast->id);
         append(r, static_analysis(ast->field, false, new_vars));
         append(r, static_analysis(ast->value, true, new_vars));
         r.erase(ast->id);
         append(r, static_analysis(ast->array, in_object, vars));
-
-    } else if (dynamic_cast<const Self *>(ast_)) {
+    } break;
+    case AST_SELF: {
+        assert(dynamic_cast<const Self *>(ast_));
         if (!in_object)
             throw StaticError(ast_->location, "Can't use self outside of an object.");
-
-    } else if (auto *ast = dynamic_cast<const SuperIndex *>(ast_)) {
+    } break;
+    case AST_SUPER_INDEX: {
+        assert(dynamic_cast<const SuperIndex *>(ast_));
+        auto* ast = static_cast<const SuperIndex *>(ast_);
         if (!in_object)
             throw StaticError(ast_->location, "Can't use super outside of an object.");
         append(r, static_analysis(ast->index, in_object, vars));
-
-    } else if (auto *ast = dynamic_cast<const Unary *>(ast_)) {
+    } break;
+    case AST_UNARY: {
+        assert(dynamic_cast<const Unary *>(ast_));
+        auto* ast = static_cast<const Unary *>(ast_);
         append(r, static_analysis(ast->expr, in_object, vars));
-
-    } else if (auto *ast = dynamic_cast<const Var *>(ast_)) {
+    } break;
+    case AST_VAR: {
+        assert(dynamic_cast<const Var *>(ast_));
+        auto* ast = static_cast<const Var *>(ast_);
         if (vars.find(ast->id) == vars.end()) {
             throw StaticError(ast->location, "Unknown variable: " + encode_utf8(ast->id->name));
         }
         r.insert(ast->id);
-
-    } else {
+    } break;
+    default:
         std::cerr << "INTERNAL ERROR: Unknown AST: " << ast_ << std::endl;
         std::abort();
+        break;
     }
 
     for (auto *id : r)


### PR DESCRIPTION
Instead of probing and dynamic_cast-ing one, by one, use a switch over the stored AST node type, and then static_cast. This change speeds up ~2x times the evalution of  
https://github.com/ksonnet/ksonnet-lib/blob/master/examples/readme/hello-nginx.jsonnet

In addition:
- Added AST_APPLY_BRACE, as previously it was piggybacking on AST_BINARY
- Changed ASTs from std::vector<> to std::list<> as elements are not read by index, but one by one, and avoid reallocations. fwd_list might be even a better choice.