### PR TITLE
backwards incompatible: make std.join more strict about types

### DIFF
--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -163,6 +163,8 @@ limitations under the License.
                 running
             else if arr[i] == null then
                 aux(arr, i + 1, first, running) tailstrict
+            else if std.type(arr[i]) != std.type(sep) then
+                error "expected %s but arr[%d] was %s " % [std.type(sep), i, std.type(arr[i])]
             else if first then
                 aux(arr, i + 1, false, running + arr[i]) tailstrict
             else

--- a/test_suite/error.equality_function.jsonnet.golden
+++ b/test_suite/error.equality_function.jsonnet.golden
@@ -1,3 +1,3 @@
 RUNTIME ERROR: Cannot test equality of functions
-	std.jsonnet:1012:17-42	function <anonymous>
+	std.jsonnet:1014:17-42	function <anonymous>
 	error.equality_function.jsonnet:17:1-33	

--- a/test_suite/error.inside_equals_array.jsonnet.golden
+++ b/test_suite/error.inside_equals_array.jsonnet.golden
@@ -1,7 +1,7 @@
 RUNTIME ERROR: foobar
 	error.inside_equals_array.jsonnet:18:18-32	thunk <array_element>
-	std.jsonnet:992:41-45	thunk <b>
-	std.jsonnet:992:33-45	function <anonymous>
-	std.jsonnet:992:33-45	function <aux>
-	std.jsonnet:995:29-45	function <anonymous>
-	std.jsonnet:996:21-33	
+	std.jsonnet:994:41-45	thunk <b>
+	std.jsonnet:994:33-45	function <anonymous>
+	std.jsonnet:994:33-45	function <aux>
+	std.jsonnet:997:29-45	function <anonymous>
+	std.jsonnet:998:21-33	

--- a/test_suite/error.inside_equals_object.jsonnet.golden
+++ b/test_suite/error.inside_equals_object.jsonnet.golden
@@ -1,7 +1,7 @@
 RUNTIME ERROR: foobar
 	error.inside_equals_object.jsonnet:18:22-36	object <b>
-	std.jsonnet:1006:62-66	thunk <b>
-	std.jsonnet:1006:54-66	function <anonymous>
-	std.jsonnet:1006:54-66	function <aux>
-	std.jsonnet:1009:29-45	function <anonymous>
-	std.jsonnet:1010:21-33	
+	std.jsonnet:1008:62-66	thunk <b>
+	std.jsonnet:1008:54-66	function <anonymous>
+	std.jsonnet:1008:54-66	function <aux>
+	std.jsonnet:1011:29-45	function <anonymous>
+	std.jsonnet:1012:21-33	

--- a/test_suite/error.invariant.equality.jsonnet.golden
+++ b/test_suite/error.invariant.equality.jsonnet.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: Object assertion failed.
 	error.invariant.equality.jsonnet:17:10-15	thunk <object_assert>
-	std.jsonnet:1006:54-58	thunk <a>
-	std.jsonnet:1006:54-66	function <anonymous>
-	std.jsonnet:1006:54-66	function <anonymous>
-	std.jsonnet:1010:21-33	
+	std.jsonnet:1008:54-58	thunk <a>
+	std.jsonnet:1008:54-66	function <anonymous>
+	std.jsonnet:1008:54-66	function <anonymous>
+	std.jsonnet:1012:21-33	

--- a/test_suite/error.obj_assert.fail1.jsonnet.golden
+++ b/test_suite/error.obj_assert.fail1.jsonnet.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: Object assertion failed.
 	error.obj_assert.fail1.jsonnet:20:23-29	thunk <object_assert>
-	std.jsonnet:1006:54-58	thunk <a>
-	std.jsonnet:1006:54-66	function <anonymous>
-	std.jsonnet:1006:54-66	function <anonymous>
-	std.jsonnet:1010:21-33	
+	std.jsonnet:1008:54-58	thunk <a>
+	std.jsonnet:1008:54-66	function <anonymous>
+	std.jsonnet:1008:54-66	function <anonymous>
+	std.jsonnet:1012:21-33	

--- a/test_suite/error.obj_assert.fail2.jsonnet.golden
+++ b/test_suite/error.obj_assert.fail2.jsonnet.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: foo was not equal to bar
 	error.obj_assert.fail2.jsonnet:20:32-65	thunk <object_assert>
-	std.jsonnet:1006:54-58	thunk <a>
-	std.jsonnet:1006:54-66	function <anonymous>
-	std.jsonnet:1006:54-66	function <anonymous>
-	std.jsonnet:1010:21-33	
+	std.jsonnet:1008:54-58	thunk <a>
+	std.jsonnet:1008:54-66	function <anonymous>
+	std.jsonnet:1008:54-66	function <anonymous>
+	std.jsonnet:1012:21-33	

--- a/test_suite/error.sanity.jsonnet.golden
+++ b/test_suite/error.sanity.jsonnet.golden
@@ -1,3 +1,3 @@
 RUNTIME ERROR: Assertion failed. 1 != 2
-	std.jsonnet:649:13-56	function <anonymous>
+	std.jsonnet:651:13-56	function <anonymous>
 	error.sanity.jsonnet:17:1-22	

--- a/test_suite/error.std_join_types1.jsonnet
+++ b/test_suite/error.std_join_types1.jsonnet
@@ -1,0 +1,17 @@
+/*
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+std.join("", ["foo", []])

--- a/test_suite/error.std_join_types1.jsonnet.golden
+++ b/test_suite/error.std_join_types1.jsonnet.golden
@@ -1,0 +1,5 @@
+RUNTIME ERROR: expected string but arr[1] was array 
+	std.jsonnet:167:17-95	function <aux>
+	std.jsonnet:169:17-57	function <aux>
+	std.jsonnet:175:13-34	function <anonymous>
+	error.std_join_types1.jsonnet:17:1-26	

--- a/test_suite/error.std_join_types2.jsonnet
+++ b/test_suite/error.std_join_types2.jsonnet
@@ -1,0 +1,17 @@
+/*
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+std.join(["sep"], ["foo", []])

--- a/test_suite/error.std_join_types2.jsonnet.golden
+++ b/test_suite/error.std_join_types2.jsonnet.golden
@@ -1,0 +1,4 @@
+RUNTIME ERROR: expected array but arr[0] was string 
+	std.jsonnet:167:17-95	function <aux>
+	std.jsonnet:177:13-34	function <anonymous>
+	error.std_join_types2.jsonnet:17:1-31	


### PR DESCRIPTION
@sbarzowski intention is to match https://github.com/google/go-jsonnet/pull/146/files behavior