### PR TITLE
Fix operational semantics of object comprehension when field expressi…

### DIFF
--- a/doc/language/spec.html
+++ b/doc/language/spec.html
@@ -1408,12 +1408,14 @@ o = \object{\assert{e_1} \ldots \assert{e_m}, f_1\mathop{h_1}e''_1 \ldots f_p\ma
 <div class="sequent-rule"> \[\rule{object-comp} {
 e_{arr} ↓ [ e_1 \ldots e_n ]
 \\
-\{ (f_1, e'_1) \ldots (f_m, e'_m) \} =
-\{ (v, e_{body}[e_i/x]) \ | \ i ∈\{1\ldots n\} ∧ e_{field}[e_i/x] ↓ v ≠ \null \}
+∀i∈\{1 \ldots n\}: e_{field}[e_i/x] ↓ f_i
 \\
-∀i,j∈\{1\ldots m\}: f_i = f_j ⇒ i = j
+∀i,j∈\{1\ldots n\}: f_i = f_j ≠ \null ⇒ i = j
 \\
-o = \object{f_1: e'_1 \ldots f_m: e'_m}
+\{ (f'_1, e'_1) \ldots (f'_m, e'_m) \} =
+\{ (f_i, e_{body}[e_i/x]) \ | \ i ∈\{1\ldots n\} ∧ f_i ≠ \null \}
+\\
+o = \object{f'_1: e'_1 \ldots f'_m: e'_m}
 } {
 \ocomp{e_{field}}{e_{body}}{x}{e_{arr}} ↓ o
 } \] </div>


### PR DESCRIPTION
All fields now get evaluated to some f_i, i.e. cannot be stuck (throw errors)
We do dup checking (ignoring nulls) before anything else, that avoids the set assignment implicitly de-duping the fields and neutering the dup check.
