### PR TITLE
Fix substring length calculation when doubling quotes

### DIFF
--- a/cmd/jsonnet.cpp
+++ b/cmd/jsonnet.cpp
@@ -232,7 +232,7 @@ bool get_var_file(const std::string &var_file, const std::string &imp, std::stri
     for (b = 0; (e = path.find("'", b)) != std::string::npos; b = e + 1) {
         val.append(path.substr(b, e - b + 1)).push_back('\'');
     }
-    val.append(path.substr(b, e - b)).push_back('\'');
+    val.append(path.substr(b)).push_back('\'');
 
     return true;
 }


### PR DESCRIPTION
Extraction of the final substring when escaping quotes was only working
as a side-effect of std::string::npos being a big number, not due to
correct code.