### PR TITLE
Use Mac-friendly ANSI-escapes in test output

### DIFF
--- a/test_cmd/cmd_tests.source
+++ b/test_cmd/cmd_tests.source
@@ -36,7 +36,7 @@ check_file() {
     if [ "$(< $RESULT_FILENAME)" != "$(< $GOLDEN_FILENAME)" ] ; then
         FAILED=$((FAILED + 1))
         if [ -z "$SUMMARY_ONLY" ]; then
-            echo -e "\e[31;1mFAIL\e[0m \e[1m(stdout mismatch)\e[0m: \e[36m$TEST\e[0m"
+            printf -e "\033[31;1mFAIL\033[0m \033[1m(stdout mismatch)\033[0m: \033[36m$TEST\033[0m\n"
             echo "Result output:"
             cat "$RESULT_FILENAME"
             echo "Expected output:"
@@ -46,7 +46,7 @@ check_file() {
             git --no-pager diff --color --no-index "$GOLDEN_FILENAME" "$RESULT_FILENAME"
             # The output is often quite long, let's repeat the filename once more
             # to avoid wasting time on looking for it
-            echo -e "\nTEST ABOVE: \e[36m$TEST\033[0m"
+            printf -e "\nTEST ABOVE: \033[36m$TEST\033[0m\n"
             separator
         fi
         return 1
@@ -69,7 +69,7 @@ do_test() {
         GOLDEN_STDERR="${GOLDEN_STDERR}.${IMPLEMENTATION}"
     fi
 
-    OUT_DIR="out/${TEST}" 
+    OUT_DIR="out/${TEST}"
     STDOUT="${OUT_DIR}/stdout"
     STDERR="${OUT_DIR}/stderr"
 
@@ -94,7 +94,7 @@ do_test() {
     if [ "$TEST_EXIT_CODE" -ne "$EXPECTED_EXIT_CODE" ] ; then
         FAILED=$((FAILED + 1))
         if [ -z "$SUMMARY_ONLY" ]; then
-            echo -e "\e[31;1mFAIL\e[0m \e[1m(exit code)\e[0m: \e[36m$TEST\e[0m"
+            printf "\033[31;1mFAIL\033[0m \033[1m(exit code)\033[0m: \033[36m$TEST\033[0m\n"
             echo "This run's stdout:"
             cat "$STDOUT"
             echo "This run's stderr:"
@@ -108,7 +108,7 @@ do_test() {
     if ! check_file "${TEST}" "${STDOUT}" "${GOLDEN_STDOUT}"; then
         return 1
     fi
-    
+
     if ! check_file "${TEST}" "${STDERR}" "${GOLDEN_STDERR}"; then
         return 1
     fi

--- a/test_suite/tests.source
+++ b/test_suite/tests.source
@@ -62,14 +62,15 @@ test_eval() {
         return 0
     fi
 
-    TEST_OUTPUT="$($JSONNET_CMD "$JSONNET_FILE" 2>&1)"
+    TEST_CMD="$JSONNET_CMD $JSONNET_FILE"
+    TEST_OUTPUT="$($TEST_CMD 2>&1)"
     TEST_EXIT_CODE="$?"
     EXECUTED=$((EXECUTED + 1))
 
     if [ "$TEST_EXIT_CODE" -ne "$EXPECTED_EXIT_CODE" ] ; then
         FAILED=$((FAILED + 1))
         if [ -z "$SUMMARY_ONLY" ]; then
-            echo -e "\e[31;1mFAIL\e[0m \e[1m(exit code)\e[0m: \e[36m$JSONNET_CMD $JSONNET_FILE\e[0m"
+            printf "\033[31;1mFAIL\033[0m \033[1m(exit code)\033[0m: \033[36m$TEST_CMD\033[0m\n"
             echo "This run's output:"
             echo "$TEST_OUTPUT"
             echo "Actual exit code $TEST_EXIT_CODE, expected $EXPECTED_EXIT_CODE"
@@ -83,7 +84,7 @@ test_eval() {
         if [[ ! "$TEST_OUTPUT" =~ $GOLDEN_OUTPUT ]] ; then
             FAILED=$((FAILED + 1))
             if [ -z "$SUMMARY_ONLY" ]; then
-                echo -e "\e[31;1mFAIL\e[0m \e[1m(regex mismatch)\e[0m: \e[36m$JSONNET_FILE\e[0m"
+                printf "\033[31;1mFAIL\033[0m \033[1m(regex mismatch)\033[0m: \033[36m$TEST_CMD\033[0m\n"
                 echo "This run's output:"
                 echo "$TEST_OUTPUT"
                 separator
@@ -96,7 +97,7 @@ test_eval() {
         if [ "$TEST_OUTPUT" != "$GOLDEN_OUTPUT" ] ; then
             FAILED=$((FAILED + 1))
             if [ -z "$SUMMARY_ONLY" ]; then
-                echo -e "\e[31;1mFAIL\e[0m \e[1m(output mismatch)\e[0m: \e[36m$JSONNET_FILE\e[0m"
+                printf "\033[31;1mFAIL\033[0m \033[1m(output mismatch)\033[0m: \033[36m$TEST_CMD\033[0m\n"
                 echo "This run's output:"
                 echo "$TEST_OUTPUT"
                 echo "Expected:"
@@ -110,7 +111,7 @@ test_eval() {
                 git --no-pager diff --no-index "$TEST_GOLDEN_FILE" "$TEST_OUTPUT_FILE"
                 # The output is often quite long, let's repeat the filename once more
                 # to avoid wasting time on looking for it
-                echo -e "\nTEST FILE ABOVE: \e[36m$JSONNET_FILE\033[0m"
+                printf "\nTEST FILE ABOVE: \033[36m$TEST_CMD\033[0m\n"
                 separator
             fi
             return 1
@@ -123,5 +124,5 @@ test_eval() {
         ;;
     esac
 
-    $($VERBOSE) && echo -e "\e[32mSUCCESS\e[0m: \e[36m$JSONNET_FILE\e[0m"
+    $($VERBOSE) && printf "\033[32mSUCCESS\033[0m: \033[36m$JSONNET_FILE\033[0m\n"
 }


### PR DESCRIPTION
(Also include jsonnet cmd in output messages.)

macOS's `echo` is behind the times and doesn't support ANSI escapes. Its `printf` does, but only via `\033`, not `\e`.