### PR TITLE
Updated documentation with new defaults

### DIFF
--- a/cmd/jsonnet.cpp
+++ b/cmd/jsonnet.cpp
@@ -133,14 +133,14 @@ void usage(std::ostream &o)
     o << "  -o / --output-file <file> Write to the output file rather than stdout\n";
     o << "  -i / --in-place         Update the Jsonnet file(s) in place.\n";
     o << "  --test                  Exit with failure if reformatting changed the file(s).\n";
-    o << "  -n / --indent <n>       Number of spaces to indent by (default 0, means no change)\n";
+    o << "  -n / --indent <n>       Number of spaces to indent by (default 2, 0 means no change)\n";
     o << "  --max-blank-lines <n>   Max vertical spacing, 0 means no change (default 2)\n";
-    o << "  --string-style <d|s|l>  Enforce double, single quotes or 'leave' (the default)\n";
-    o << "  --comment-style <h|s|l> # (h)  // (s)  or 'leave' (default) never changes she-bang\n";
+    o << "  --string-style <d|s|l>  Enforce double, single (default) quotes or 'leave'\n";
+    o << "  --comment-style <h|s|l> # (h), // (s)(default), or 'leave'; never changes she-bang\n";
     o << "  --[no-]pretty-field-names Use syntax sugar for fields and indexing (on by default)\n";
     o << "  --[no-]pad-arrays       [ 1, 2, 3 ] instead of [1, 2, 3]\n";
     o << "  --[no-]pad-objects      { x: 1, x: 2 } instead of {x: 1, y: 2} (on by default)\n";
-    o << "  --[no-]sort-imports     Sorting of imports (off by default)\n";
+    o << "  --[no-]sort-imports     Sorting of imports (on by default)\n";
     o << "  --debug-desugaring      Unparse the desugared AST without executing it\n";
     o << "  --version               Print version\n";
     o << "\n";

--- a/doc/implementation/commandline.html
+++ b/doc/implementation/commandline.html
@@ -62,10 +62,10 @@ and &lt;option&gt; can be:
   -o / --output-file &lt;file&gt; Write to the output file rather than stdout
   -i / --in-place         Update the Jsonnet file in place.  Same as -o &lt;filename&gt;
   --test                  Exit with failure if reformatting changed the file.
-  -n / --indent &lt;n&gt;       Number of spaces to indent by (default 0, means no change)
+  -n / --indent &lt;n&gt;       Number of spaces to indent by (default 2, 0 means no change)
   --max-blank-lines &lt;n&gt;   Max vertical spacing, 0 means no change (default 2)
-  --string-style &lt;d|s|l&gt;  Enforce double, single quotes or 'leave' (the default)
-  --comment-style &lt;h|s|l&gt; # (h)  // (s)  or 'leave' (default) never changes she-bang
+  --string-style &lt;d|s|l&gt;  Enforce double, single (default) quotes or 'leave'
+  --comment-style &lt;h|s|l&gt; # (h), // (s)(default), or 'leave'; never changes she-bang
   --[no-]pretty-field-names Use syntax sugar for fields and indexing (on by default)
   --[no-]pad-arrays       [ 1, 2, 3 ] instead of [1, 2, 3]
   --[no-]pad-objects      { x: 1, x: 2 } instead of {x: 1, y: 2} (on by default)

--- a/test_cmd/eval.golden.stderr.cpp
+++ b/test_cmd/eval.golden.stderr.cpp
@@ -54,14 +54,14 @@ Available fmt options:
   -o / --output-file <file> Write to the output file rather than stdout
   -i / --in-place         Update the Jsonnet file(s) in place.
   --test                  Exit with failure if reformatting changed the file(s).
-  -n / --indent <n>       Number of spaces to indent by (default 0, means no change)
+  -n / --indent <n>       Number of spaces to indent by (default 2, 0 means no change)
   --max-blank-lines <n>   Max vertical spacing, 0 means no change (default 2)
-  --string-style <d|s|l>  Enforce double, single quotes or 'leave' (the default)
-  --comment-style <h|s|l> # (h)  // (s)  or 'leave' (default) never changes she-bang
+  --string-style <d|s|l>  Enforce double, single (default) quotes or 'leave'
+  --comment-style <h|s|l> # (h), // (s)(default), or 'leave'; never changes she-bang
   --[no-]pretty-field-names Use syntax sugar for fields and indexing (on by default)
   --[no-]pad-arrays       [ 1, 2, 3 ] instead of [1, 2, 3]
   --[no-]pad-objects      { x: 1, x: 2 } instead of {x: 1, y: 2} (on by default)
-  --[no-]sort-imports     Sorting of imports (off by default)
+  --[no-]sort-imports     Sorting of imports (on by default)
   --debug-desugaring      Unparse the desugared AST without executing it
   --version               Print version
 

--- a/test_cmd/help.golden.stdout.cpp
+++ b/test_cmd/help.golden.stdout.cpp
@@ -52,14 +52,14 @@ Available fmt options:
   -o / --output-file <file> Write to the output file rather than stdout
   -i / --in-place         Update the Jsonnet file(s) in place.
   --test                  Exit with failure if reformatting changed the file(s).
-  -n / --indent <n>       Number of spaces to indent by (default 0, means no change)
+  -n / --indent <n>       Number of spaces to indent by (default 2, 0 means no change)
   --max-blank-lines <n>   Max vertical spacing, 0 means no change (default 2)
-  --string-style <d|s|l>  Enforce double, single quotes or 'leave' (the default)
-  --comment-style <h|s|l> # (h)  // (s)  or 'leave' (default) never changes she-bang
+  --string-style <d|s|l>  Enforce double, single (default) quotes or 'leave'
+  --comment-style <h|s|l> # (h), // (s)(default), or 'leave'; never changes she-bang
   --[no-]pretty-field-names Use syntax sugar for fields and indexing (on by default)
   --[no-]pad-arrays       [ 1, 2, 3 ] instead of [1, 2, 3]
   --[no-]pad-objects      { x: 1, x: 2 } instead of {x: 1, y: 2} (on by default)
-  --[no-]sort-imports     Sorting of imports (off by default)
+  --[no-]sort-imports     Sorting of imports (on by default)
   --debug-desugaring      Unparse the desugared AST without executing it
   --version               Print version
 

--- a/test_cmd/no_args.golden.stderr.cpp
+++ b/test_cmd/no_args.golden.stderr.cpp
@@ -54,14 +54,14 @@ Available fmt options:
   -o / --output-file <file> Write to the output file rather than stdout
   -i / --in-place         Update the Jsonnet file(s) in place.
   --test                  Exit with failure if reformatting changed the file(s).
-  -n / --indent <n>       Number of spaces to indent by (default 0, means no change)
+  -n / --indent <n>       Number of spaces to indent by (default 2, 0 means no change)
   --max-blank-lines <n>   Max vertical spacing, 0 means no change (default 2)
-  --string-style <d|s|l>  Enforce double, single quotes or 'leave' (the default)
-  --comment-style <h|s|l> # (h)  // (s)  or 'leave' (default) never changes she-bang
+  --string-style <d|s|l>  Enforce double, single (default) quotes or 'leave'
+  --comment-style <h|s|l> # (h), // (s)(default), or 'leave'; never changes she-bang
   --[no-]pretty-field-names Use syntax sugar for fields and indexing (on by default)
   --[no-]pad-arrays       [ 1, 2, 3 ] instead of [1, 2, 3]
   --[no-]pad-objects      { x: 1, x: 2 } instead of {x: 1, y: 2} (on by default)
-  --[no-]sort-imports     Sorting of imports (off by default)
+  --[no-]sort-imports     Sorting of imports (on by default)
   --debug-desugaring      Unparse the desugared AST without executing it
   --version               Print version
 


### PR DESCRIPTION
This updates the help docs to reflect the default changes in commit 0f1addef9137f2f27cd0d5dfdd33aaebba8efce9.

In reference to #441, I think these default changes may mean a "major" version bump is required.