### PR TITLE
Add a builtin trace function.

### DIFF
--- a/core/desugarer.cpp
+++ b/core/desugarer.cpp
@@ -63,7 +63,7 @@ BuiltinDecl jsonnet_builtin_decl(unsigned long builtin)
         case 24: return {U"primitiveEquals", {U"a", U"b"}};
         case 25: return {U"native", {U"name"}};
         case 26: return {U"md5", {U"str"}};
-        case 27: return {U"trace", {U"str", U"obj"}};
+        case 27: return {U"trace", {U"str", U"rest"}};
         default:
             std::cerr << "INTERNAL ERROR: Unrecognized builtin function: " << builtin << std::endl;
             std::abort();

--- a/core/desugarer.cpp
+++ b/core/desugarer.cpp
@@ -32,7 +32,7 @@ struct BuiltinDecl {
     std::vector<UString> params;
 };
 
-static unsigned long max_builtin = 26;
+static unsigned long max_builtin = 27;
 BuiltinDecl jsonnet_builtin_decl(unsigned long builtin)
 {
     switch (builtin) {
@@ -63,6 +63,7 @@ BuiltinDecl jsonnet_builtin_decl(unsigned long builtin)
         case 24: return {U"primitiveEquals", {U"a", U"b"}};
         case 25: return {U"native", {U"name"}};
         case 26: return {U"md5", {U"str"}};
+        case 27: return {U"trace", {U"str", U"obj"}};
         default:
             std::cerr << "INTERNAL ERROR: Unrecognized builtin function: " << builtin << std::endl;
             std::abort();

--- a/core/state.h
+++ b/core/state.h
@@ -43,9 +43,7 @@ struct Value {
         ARRAY = 0x10,
         FUNCTION = 0x11,
         OBJECT = 0x12,
-        STRING = 0x13,
-
-        ANY = 0xFF00
+        STRING = 0x13
     };
     Type t;
     union {
@@ -70,7 +68,6 @@ std::string type_str(Value::Type t)
         case Value::FUNCTION: return "function";
         case Value::OBJECT: return "object";
         case Value::STRING: return "string";
-        case Value::ANY: return "valuetype";
         default:
             std::cerr << "INTERNAL ERROR: Unknown type: " << t << std::endl;
             std::abort();

--- a/core/state.h
+++ b/core/state.h
@@ -43,7 +43,9 @@ struct Value {
         ARRAY = 0x10,
         FUNCTION = 0x11,
         OBJECT = 0x12,
-        STRING = 0x13
+        STRING = 0x13,
+
+        ANY = 0xFF00
     };
     Type t;
     union {
@@ -68,6 +70,7 @@ std::string type_str(Value::Type t)
         case Value::FUNCTION: return "function";
         case Value::OBJECT: return "object";
         case Value::STRING: return "string";
+        case Value::ANY: return "valuetype";
         default:
             std::cerr << "INTERNAL ERROR: Unknown type: " << t << std::endl;
             std::abort();

--- a/core/vm.cpp
+++ b/core/vm.cpp
@@ -1301,15 +1301,10 @@ class Interpreter {
 
     const AST *builtinTrace(const LocationRange &loc, const std::vector<Value> &args)
     {
-        // TODO: This error handling is really bad. Ideally there should be a
-        // Value::OBJECT_OR_ARRAY enum and the validateBuiltinArgs should know how
-        // how to check the type.
-        // TODO: This error handling will only suggest to use an array for the trace
-        // call even though objects are also allowed.
         validateBuiltinArgs(loc, "trace", args, {Value::STRING, Value::OBJECT});
 
         std::string str = encode_utf8(static_cast<HeapString *>(args[0].v.h)->value);
-        std::cerr << "TRACE " << loc.file << ":" << loc.begin.line << " " <<  str
+        std::cerr << "TRACE: " << loc.file << ":" << loc.begin.line << " " <<  str
             << std::endl;
 
         auto *obj = static_cast<HeapObject *>(args[1].v.h);

--- a/core/vm.cpp
+++ b/core/vm.cpp
@@ -1298,7 +1298,6 @@ class Interpreter {
             ss << "Builtin function trace expected string as first parameter but "
                << "got " << type_str(args[0].t);
             throw makeError(loc, ss.str());
-
         }
 
         std::string str = encode_utf8(static_cast<HeapString *>(args[0].v.h)->value);

--- a/doc/docs/stdlib.html
+++ b/doc/docs/stdlib.html
@@ -632,5 +632,5 @@ local conditionalReturn(cond, in1, in2) =
         std.trace('cond is true returning ' + std.toString(n1), in1)
     else
         std.trace('cond is false returning ' + std.toString(in2), in2);
-}</code></p>
+</code></p>
 

--- a/doc/docs/stdlib.html
+++ b/doc/docs/stdlib.html
@@ -622,15 +622,30 @@ href="https://tools.ietf.org/html/rfc7396">RFC7396</a></p>
 
 <h4 id="trace">std.trace(str, rest)</h4>
 
-<p> <code>trace</code> outputs the string to std::cerr in its first argument, before
-returning the second argument as its result </p>
+<p><code>trace</code> outputs the given string <code>str</code> to stderr and
+returns <code>rest</code> as the result.<p>
+<em>Available since version 0.11.0</em>
 
 <p>Example:<br />
 <code>
 local conditionalReturn(cond, in1, in2) =
     if (cond) then
-        std.trace('cond is true returning ' + std.toString(n1), in1)
+        std.trace('cond is true returning ' + std.toString(in1), in1)
     else
         std.trace('cond is false returning ' + std.toString(in2), in2);
+
+
+{
+    a: conditionalReturn(true, { b: true }, { c: false }),
+}
 </code></p>
 
+<p>Prints:</p>
+<p><code>
+TRACE: test.jsonnet:3 cond is true returning {"b": true}
+{
+   "a": {
+      "b": true
+   }
+}
+</code></p>

--- a/doc/docs/stdlib.html
+++ b/doc/docs/stdlib.html
@@ -618,3 +618,19 @@ words, it consumes the output of std.base64().</p>
 <p>Applies <code>patch</code> to <code>target</code> according to <a
 href="https://tools.ietf.org/html/rfc7396">RFC7396</a></p>
 
+<h3 id="Debugging">Debugging</h3>
+
+<h4 id="trace">std.trace(str, rest)</h4>
+
+<p> <code>trace</code> outputs the string to std::cerr in its first argument, before
+returning the second argument as its result </p>
+
+<p>Example:<br />
+<code>
+local conditionalReturn(cond, in1, in2) =
+    if (cond) then
+        std.trace('cond is true returning ' + std.toString(n1), in1)
+    else
+        std.trace('cond is false returning ' + std.toString(in2), in2);
+}</code></p>
+

--- a/test_suite/error.trace_one_param.jsonnet
+++ b/test_suite/error.trace_one_param.jsonnet
@@ -1,0 +1,20 @@
+/*
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+local v = std.trace('');
+{
+  a: v,
+}

--- a/test_suite/error.trace_one_param.jsonnet.golden
+++ b/test_suite/error.trace_one_param.jsonnet.golden
@@ -1,4 +1,4 @@
-RUNTIME ERROR: function parameter obj not bound in call.
+RUNTIME ERROR: function parameter rest not bound in call.
 	error.trace_one_param.jsonnet:17:11-24	thunk <v>
 	error.trace_one_param.jsonnet:19:6	object <anonymous>
 	During manifestation	

--- a/test_suite/error.trace_one_param.jsonnet.golden
+++ b/test_suite/error.trace_one_param.jsonnet.golden
@@ -1,0 +1,4 @@
+RUNTIME ERROR: function parameter obj not bound in call.
+	error.trace_one_param.jsonnet:17:11-24	thunk <v>
+	error.trace_one_param.jsonnet:19:6	object <anonymous>
+	During manifestation	

--- a/test_suite/error.trace_three_param.jsonnet
+++ b/test_suite/error.trace_three_param.jsonnet
@@ -1,0 +1,20 @@
+/*
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+local v = std.trace('', {}, '');
+{
+  a: v,
+}

--- a/test_suite/error.trace_three_param.jsonnet.golden
+++ b/test_suite/error.trace_three_param.jsonnet.golden
@@ -1,0 +1,4 @@
+RUNTIME ERROR: too many args, function has 2 parameter(s)
+	error.trace_three_param.jsonnet:17:11-32	thunk <v>
+	error.trace_three_param.jsonnet:19:6	object <anonymous>
+	During manifestation	

--- a/test_suite/error.trace_two_param.jsonnet
+++ b/test_suite/error.trace_two_param.jsonnet
@@ -1,0 +1,20 @@
+/*
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+local v = std.trace(3, {});
+{
+  a: v,
+}

--- a/test_suite/error.trace_two_param.jsonnet.golden
+++ b/test_suite/error.trace_two_param.jsonnet.golden
@@ -1,0 +1,4 @@
+RUNTIME ERROR: Builtin function trace expected string as first parameter but got number
+	error.trace_two_param.jsonnet:17:11-27	thunk <v>
+	error.trace_two_param.jsonnet:19:6	object <anonymous>
+	During manifestation	

--- a/test_suite/error.trace_zero_param.jsonnet
+++ b/test_suite/error.trace_zero_param.jsonnet
@@ -1,0 +1,20 @@
+/*
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+local v = std.trace();
+{
+  a: v,
+}

--- a/test_suite/error.trace_zero_param.jsonnet.golden
+++ b/test_suite/error.trace_zero_param.jsonnet.golden
@@ -1,0 +1,4 @@
+RUNTIME ERROR: function parameter str not bound in call.
+	error.trace_zero_param.jsonnet:17:11-22	thunk <v>
+	error.trace_zero_param.jsonnet:19:6	object <anonymous>
+	During manifestation	

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -567,5 +567,8 @@ std.assertEqual(std.asciiLower('!@#$%&*()asdfghFGHJKL09876 '), '!@#$%&*()asdfghf
 
 std.assertEqual(std.deepJoin(['a', ['b', 'c', [[], 'd', ['e'], 'f', 'g'], [], []], 'h']),
                 'abcdefgh') &&
+std.assertEqual(std.trace('', {}), {}) &&
+std.assertEqual(std.trace('', { a: {} }), { a: {} }) &&
+std.assertEqual(std.trace('Some Trace Message', { a: {} }), { a: {} }) &&
 
 true

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -567,8 +567,16 @@ std.assertEqual(std.asciiLower('!@#$%&*()asdfghFGHJKL09876 '), '!@#$%&*()asdfghf
 
 std.assertEqual(std.deepJoin(['a', ['b', 'c', [[], 'd', ['e'], 'f', 'g'], [], []], 'h']),
                 'abcdefgh') &&
+std.assertEqual(std.trace('', null), null) &&
+std.assertEqual(std.trace('', true), true) &&
+std.assertEqual(std.trace('', 77), 77) &&
+std.assertEqual(std.trace('', 77.88), 77.88) &&
+std.assertEqual(std.trace('', 'word'), 'word') &&
+std.assertEqual(std.foldl(std.trace('', function(acc, i) acc + i), [1, 2, 3], 0), 6) &&
 std.assertEqual(std.trace('', {}), {}) &&
 std.assertEqual(std.trace('', { a: {} }), { a: {} }) &&
+std.assertEqual(std.trace('', []), []) &&
+std.assertEqual(std.trace('', [{ a: 'b' }, { a: 'b' }]), [{ a: 'b' }, { a: 'b' }]) &&
 std.assertEqual(std.trace('Some Trace Message', { a: {} }), { a: {} }) &&
 
 true

--- a/test_suite/stdlib.jsonnet.golden
+++ b/test_suite/stdlib.jsonnet.golden
@@ -1,0 +1,4 @@
+TRACE stdlib.jsonnet:570 
+TRACE stdlib.jsonnet:571 
+TRACE stdlib.jsonnet:572 Some Trace Message
+true

--- a/test_suite/stdlib.jsonnet.golden
+++ b/test_suite/stdlib.jsonnet.golden
@@ -1,4 +1,12 @@
 TRACE: stdlib.jsonnet:570 
 TRACE: stdlib.jsonnet:571 
-TRACE: stdlib.jsonnet:572 Some Trace Message
+TRACE: stdlib.jsonnet:572 
+TRACE: stdlib.jsonnet:573 
+TRACE: stdlib.jsonnet:574 
+TRACE: stdlib.jsonnet:575 
+TRACE: stdlib.jsonnet:576 
+TRACE: stdlib.jsonnet:577 
+TRACE: stdlib.jsonnet:578 
+TRACE: stdlib.jsonnet:579 
+TRACE: stdlib.jsonnet:580 Some Trace Message
 true

--- a/test_suite/stdlib.jsonnet.golden
+++ b/test_suite/stdlib.jsonnet.golden
@@ -1,4 +1,4 @@
-TRACE stdlib.jsonnet:570 
-TRACE stdlib.jsonnet:571 
-TRACE stdlib.jsonnet:572 Some Trace Message
+TRACE: stdlib.jsonnet:570 
+TRACE: stdlib.jsonnet:571 
+TRACE: stdlib.jsonnet:572 Some Trace Message
 true


### PR DESCRIPTION
Prints the first argument to std err with line number
Returns the second argument which is expected to be an object.

ISSUE: #130 
