### PR TITLE
Fix typo in TEMPLATE

### DIFF
--- a/case_studies/fractal/credentials.libsonnet.TEMPLATE
+++ b/case_studies/fractal/credentials.libsonnet.TEMPLATE
@@ -2,5 +2,5 @@
     project: "XXXXXXXX",  // GCP project name (e.g. verbing-noun-123)
     cassandraUserPass: "XXXXXXXX",  // Any valid Cassandra password (e.g. numbers, letters, capitals)
     cassandraRootPass: "XXXXXXXX",  // Any other valid Cassandra password (e.g. numbers, letters, capitals)
-    dnsSuffix: "",  // Change to differentiate one deployment of Fractal from another.
+    dnsPrefix: "",  // Change to differentiate one deployment of Fractal from another.
 }


### PR DESCRIPTION
`credentials.dnsPrefix` is referenced in `service.jsonnet` but not defined