### PR TITLE
Balance square-brackets in grammar spec

### DIFF
--- a/doc/ref/spec.html
+++ b/doc/ref/spec.html
@@ -295,7 +295,7 @@ div.rules {
           <td>|</td>
           <td>
             <code>[</code>
-            [ <i>expr</i> { <code>,</code> <i>expr</i> } [ <code>,</code> ]
+            [ <i>expr</i> { <code>,</code> <i>expr</i> } [ <code>,</code> ] ]
             <code>]</code>
           </td>
         </tr> 
@@ -346,7 +346,7 @@ div.rules {
             <i>expr</i>
             <code>[</code>
             <code>:</code> [ <i>expr</i>
-            [ <code>:</code> [ <i>expr</i> ] ] ] ]
+            [ <code>:</code> [ <i>expr</i> ] ] ]
             <code>]</code>
           </td>
         </tr>

--- a/doc/ref/spec.html
+++ b/doc/ref/spec.html
@@ -548,7 +548,7 @@ div.rules {
             <code>]</code>
             <code>:</code>
             <i>expr</i>
-            [ { <code>,</code> <i>objlocal</i> } [ <code>,</code> ] ]
+            [ { <code>,</code> <i>objlocal</i> } ] [ <code>,</code> ] 
             <i>forspec</i> <i>compspec</i>
           </td>
         </tr>


### PR DESCRIPTION
Looks like one closing bracket ran away from the `array` definition to go hang out with the `object index (general2)` definition

Also the comma separating the comprehensions in the `objinside` should be outside the `objlocal`s square brackets, since you don't need any objlocals in order to put a `,` between the `[x]: y` and the for comprehension expressions