### PR TITLE
Fix a 404 hyperlink in tutorial.html

### DIFF
--- a/doc/learning/tutorial.html
+++ b/doc/learning/tutorial.html
@@ -206,7 +206,7 @@ layout: default
       <p>
         Like Python, functions have positional parameters, named parameters, and default arguments.
         Closures are also supported.  The examples below should demonstrate the syntax.  Many
-        functions are already defined in the <a href=/ref/std.html>standard library</a>.
+        functions are already defined in the <a href=/ref/stdlib.html>standard library</a>.
       </p>
       <p>
         Try writing a function <code>is_even</code> that uses the modulo operator <code>%</code> and


### PR DESCRIPTION
I found a 404 hyperlink in Jsonnet - The Data Templating Language. I hope it will be fixed with this PR.