### PR TITLE
Tweak spec for text blocks to allow leading blanks

### DIFF
--- a/doc/ref/spec.html
+++ b/doc/ref/spec.html
@@ -167,7 +167,7 @@ div.rules {
             </li>
             <li>
               Text block, beginning with <code>|||</code>, followed by optional whitespace and a
-              new-line.  The next line must be prefixed with some non-zero length whitespace
+              new-line.  The next non-blank line must be prefixed with some non-zero length whitespace
               <i>W</i>.  The block ends at the first subsequent line that does not begin with
               <i>W</i>, and it is an error if this line does not contain some optional whitespace
               followed by <code>|||</code>.  The content of the string is the concatenation of all


### PR DESCRIPTION
Apparently blank lines at the top of the text block are allowed, and are converted to newlines, according to the test suite https://github.com/google/jsonnet/blob/master/test_suite/text_block.jsonnet#L96