### PR TITLE
Less dynamic casts (2nd phase, gc heap)

### DIFF
--- a/cpp/testdata/invalid.out
+++ b/cpp/testdata/invalid.out
@@ -1,2 +1,2 @@
 RUNTIME ERROR: Foo.
-	cpp/testdata/invalid.jsonnet:15:1-12	
+	cpp/testdata/invalid.jsonnet:15:1-13	


### PR DESCRIPTION
On my chromebook (edgar, under crouton) this speeds up 10% two of the perf_tests, and 20% in another. It's similar to something I did previously - e.g. getting rid of more dynamic_casts with static_cast-ing by having the type stored as enum (I believe the Go version of jsonnet uses the same approach).

Some more details here: https://gist.github.com/malkia/975e1620799d63d52f283110271592dc
