### PR TITLE
Changed to use multi-stage docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:latest AS builder
 
 RUN apk -U add build-base
 
@@ -7,8 +7,12 @@ WORKDIR /opt
 COPY . /opt/jsonnet
 
 RUN cd jsonnet && \
-    make && \
-    mv jsonnet /usr/local/bin && \
-    rm -rf /opt/jsonnet
+    make
+
+FROM alpine:latest
+
+RUN apk add --no-cache libstdc++ 
+
+COPY --from=builder /opt/jsonnet/jsonnet /usr/local/bin
 
 ENTRYPOINT ["/usr/local/bin/jsonnet"]


### PR DESCRIPTION
Multi stage build to make final image smaller.

```
> docker images
REPOSITORY                       TAG                 IMAGE ID            CREATED             SIZE
jsonnet                          latest              20460ec97937        18 minutes ago      16.2MB
sparkprime/jsonnet               latest              097d0a351c9a        8 days ago          246MB
```


Seems to only need libstdc++ to run, but only done limited testing, so would be worth confirming before merging.