### PR TITLE
Fix parseHex off-by-one with 'a' and 'A'

### DIFF
--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -70,9 +70,9 @@ limitations under the License.
     local lower_a_code = std.codepoint('a');
     local addDigit(aggregate, char) =
       local code = std.codepoint(char);
-      local digit = if code > lower_a_code then
+      local digit = if code >= lower_a_code then
         code - lower_a_code + 10
-      else if code > upper_a_code then
+      else if code >= upper_a_code then
         code - upper_a_code + 10
       else
         code - zero_code;

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -552,6 +552,10 @@ std.assertEqual(std.parseHex('ff'), 255) &&
 std.assertEqual(std.parseHex('FF'), 255) &&
 std.assertEqual(std.parseHex('0ff'), 255) &&
 std.assertEqual(std.parseHex('0FF'), 255) &&
+std.assertEqual(std.parseHex('a'), 10) &&
+std.assertEqual(std.parseHex('A'), 10) &&
+std.assertEqual(std.parseHex('4a'), 74) &&
+
 // verified by running md5 -s value
 std.assertEqual(std.md5(''), 'd41d8cd98f00b204e9800998ecf8427e') &&
 std.assertEqual(std.md5('grape'), 'b781cbb29054db12f88f08c6e161c199') &&

--- a/test_suite/stdlib.jsonnet.golden
+++ b/test_suite/stdlib.jsonnet.golden
@@ -1,12 +1,12 @@
-TRACE: stdlib.jsonnet:576 
-TRACE: stdlib.jsonnet:577 
-TRACE: stdlib.jsonnet:578 
-TRACE: stdlib.jsonnet:579 
 TRACE: stdlib.jsonnet:580 
 TRACE: stdlib.jsonnet:581 
 TRACE: stdlib.jsonnet:582 
 TRACE: stdlib.jsonnet:583 
 TRACE: stdlib.jsonnet:584 
 TRACE: stdlib.jsonnet:585 
-TRACE: stdlib.jsonnet:586 Some Trace Message
+TRACE: stdlib.jsonnet:586 
+TRACE: stdlib.jsonnet:587 
+TRACE: stdlib.jsonnet:588 
+TRACE: stdlib.jsonnet:589 
+TRACE: stdlib.jsonnet:590 Some Trace Message
 true


### PR DESCRIPTION
Fixes #546