### PR TITLE
Fix tiny typo in documentation

### DIFF
--- a/cmd/jsonnet.cpp
+++ b/cmd/jsonnet.cpp
@@ -139,7 +139,7 @@ void usage(std::ostream &o)
     o << "  --comment-style <h|s|l> # (h), // (s)(default), or 'leave'; never changes she-bang\n";
     o << "  --[no-]pretty-field-names Use syntax sugar for fields and indexing (on by default)\n";
     o << "  --[no-]pad-arrays       [ 1, 2, 3 ] instead of [1, 2, 3]\n";
-    o << "  --[no-]pad-objects      { x: 1, x: 2 } instead of {x: 1, y: 2} (on by default)\n";
+    o << "  --[no-]pad-objects      { x: 1, y: 2 } instead of {x: 1, y: 2} (on by default)\n";
     o << "  --[no-]sort-imports     Sorting of imports (on by default)\n";
     o << "  --debug-desugaring      Unparse the desugared AST without executing it\n";
     o << "  --version               Print version\n";

--- a/test_cmd/eval.golden.stderr.cpp
+++ b/test_cmd/eval.golden.stderr.cpp
@@ -60,7 +60,7 @@ Available fmt options:
   --comment-style <h|s|l> # (h), // (s)(default), or 'leave'; never changes she-bang
   --[no-]pretty-field-names Use syntax sugar for fields and indexing (on by default)
   --[no-]pad-arrays       [ 1, 2, 3 ] instead of [1, 2, 3]
-  --[no-]pad-objects      { x: 1, x: 2 } instead of {x: 1, y: 2} (on by default)
+  --[no-]pad-objects      { x: 1, y: 2 } instead of {x: 1, y: 2} (on by default)
   --[no-]sort-imports     Sorting of imports (on by default)
   --debug-desugaring      Unparse the desugared AST without executing it
   --version               Print version

--- a/test_cmd/help.golden.stdout.cpp
+++ b/test_cmd/help.golden.stdout.cpp
@@ -58,7 +58,7 @@ Available fmt options:
   --comment-style <h|s|l> # (h), // (s)(default), or 'leave'; never changes she-bang
   --[no-]pretty-field-names Use syntax sugar for fields and indexing (on by default)
   --[no-]pad-arrays       [ 1, 2, 3 ] instead of [1, 2, 3]
-  --[no-]pad-objects      { x: 1, x: 2 } instead of {x: 1, y: 2} (on by default)
+  --[no-]pad-objects      { x: 1, y: 2 } instead of {x: 1, y: 2} (on by default)
   --[no-]sort-imports     Sorting of imports (on by default)
   --debug-desugaring      Unparse the desugared AST without executing it
   --version               Print version

--- a/test_cmd/no_args.golden.stderr.cpp
+++ b/test_cmd/no_args.golden.stderr.cpp
@@ -60,7 +60,7 @@ Available fmt options:
   --comment-style <h|s|l> # (h), // (s)(default), or 'leave'; never changes she-bang
   --[no-]pretty-field-names Use syntax sugar for fields and indexing (on by default)
   --[no-]pad-arrays       [ 1, 2, 3 ] instead of [1, 2, 3]
-  --[no-]pad-objects      { x: 1, x: 2 } instead of {x: 1, y: 2} (on by default)
+  --[no-]pad-objects      { x: 1, y: 2 } instead of {x: 1, y: 2} (on by default)
   --[no-]sort-imports     Sorting of imports (on by default)
   --debug-desugaring      Unparse the desugared AST without executing it
   --version               Print version


### PR DESCRIPTION
Fix for a tiny typo that was really confusing when first reading through the jsonnet fmt help ;) 