### PR TITLE
Initial implementation of 'switch' syntax.

### DIFF
--- a/core/ast.h
+++ b/core/ast.h
@@ -39,6 +39,7 @@ enum ASTType {
     AST_BINARY,
     AST_BUILTIN_FUNCTION,
     AST_CONDITIONAL,
+    AST_SWITCH,
     AST_DESUGARED_OBJECT,
     AST_DOLLAR,
     AST_ERROR,
@@ -74,6 +75,7 @@ static inline std::string ASTTypeToString(ASTType type)
         case AST_BINARY: return "AST_BINARY";
         case AST_BUILTIN_FUNCTION: return "AST_BUILTIN_FUNCTION";
         case AST_CONDITIONAL: return "AST_CONDITIONAL";
+        case AST_SWITCH: return "AST_SWITCH";
         case AST_DESUGARED_OBJECT: return "AST_DESUGARED_OBJECT";
         case AST_DOLLAR: return "AST_DOLLAR";
         case AST_ERROR: return "AST_ERROR";
@@ -397,6 +399,47 @@ struct Conditional : public AST {
           branchTrue(branch_true),
           elseFodder(else_fodder),
           branchFalse(branch_false)
+    {
+    }
+};
+
+/** Represents switch expressions.
+ *
+ * The parser converts the AST into a if/else chain, but keeps
+ * enough of the original structure for formatting.
+ */
+struct Switch : public AST {
+    AST* pivot;
+    Fodder ofFodder;
+    std::vector<AST*> cases;
+    std::vector<Fodder> whenFodders;
+    std::vector<AST*> branches;
+    std::vector<Fodder> thenFodders;
+    AST* elseBranch;
+    Fodder elseFodder;
+    AST* ifChain;
+
+    Switch(const LocationRange &lr, const Fodder &open_fodder,
+           AST *pivot,
+           Fodder of_fodder,
+           const std::vector<AST*> &cases,
+           const std::vector<Fodder> &when_fodders,
+           const std::vector<AST*> &branches,
+           const std::vector<Fodder> &then_fodders,
+           AST *else_branch,
+           const Fodder &else_fodder,
+           AST *if_chain
+           )
+       : AST(lr, AST_SWITCH, open_fodder),
+         pivot(pivot),
+         ofFodder(of_fodder),
+         cases(cases),
+         whenFodders(when_fodders),
+         branches(branches),
+         thenFodders(then_fodders),
+         elseBranch(else_branch),
+         elseFodder(else_fodder),
+         ifChain(if_chain)
     {
     }
 };

--- a/core/desugarer.cpp
+++ b/core/desugarer.cpp
@@ -631,6 +631,8 @@ class Desugarer {
                 ast->branchFalse = null();
             desugar(ast->branchFalse, obj_level);
 
+        } else if (auto *ast = dynamic_cast<Switch *>(ast_)) {
+            desugar(ast->ifChain, obj_level);
         } else if (auto *ast = dynamic_cast<Dollar *>(ast_)) {
             if (obj_level == 0) {
                 throw StaticError(ast->location, "No top-level object found.");

--- a/core/formatter.cpp
+++ b/core/formatter.cpp
@@ -380,6 +380,22 @@ class Unparser {
                 unparse(ast->branchTrue, true);
             }
 
+        } else if (auto *ast = dynamic_cast<const Switch *>(ast_)) {
+            o << "switch";
+            unparse(ast->pivot, true);
+            fill(ast->ofFodder, true, true);
+            o << "for";
+            for (size_t i = 0; i < ast->cases.size(); i++) {
+              fill(ast->whenFodders[i], true, true);
+              o << "if";
+              unparse(ast->cases[i], true);
+              fill(ast->thenFodders[i], true, true);
+              o << "then";
+              unparse(ast->branches[i], true);
+            }
+            fill(ast->elseFodder, true, true);
+            o << "else";
+            unparse(ast->elseBranch, true);
         } else if (dynamic_cast<const Dollar *>(ast_)) {
             o << "$";
 
@@ -1737,6 +1753,8 @@ class FixIndentation {
                 expr(ast->branchFalse, false_indent, true);
             }
 
+        } else if (auto *ast = dynamic_cast<Switch *>(ast_)) {
+          // TODO - Sam
         } else if (dynamic_cast<Dollar *>(ast_)) {
             column++;  // $
 

--- a/core/lexer.cpp
+++ b/core/lexer.cpp
@@ -188,6 +188,7 @@ static const std::map<std::string, Token::Kind> keywords = {
     {"for", Token::FOR},
     {"function", Token::FUNCTION},
     {"if", Token::IF},
+    {"switch", Token::SWITCH},
     {"import", Token::IMPORT},
     {"importstr", Token::IMPORTSTR},
     {"in", Token::IN},

--- a/core/lexer.h
+++ b/core/lexer.h
@@ -261,6 +261,7 @@ struct Token {
         FOR,
         FUNCTION,
         IF,
+        SWITCH,
         IMPORT,
         IMPORTSTR,
         IN,
@@ -344,6 +345,7 @@ struct Token {
             case FOR: return "for";
             case FUNCTION: return "function";
             case IF: return "if";
+            case SWITCH: return "switch";
             case IMPORT: return "import";
             case IMPORTSTR: return "importstr";
             case IN: return "in";

--- a/core/pass.cpp
+++ b/core/pass.cpp
@@ -173,6 +173,22 @@ void CompilerPass::visit(Conditional *ast)
     }
 }
 
+void CompilerPass::visit(Switch *ast)
+{
+    // TODO?
+    //expr(ast->pivot);
+    //for(size_t i = 0; i < ast->conds.size(); i++) {
+    //    expr(ast->conds[i]);
+    //    fodder(ast->when_fodders[i]);
+	//expr(ast->branches[i]);
+	//fodder(ast->then_fodders[i]);
+    //}
+    //expr(ast->else_branch);
+    //fodder(ast->else_fodder);
+  // TODO - Sam
+    expr(ast->ifChain);
+}
+
 void CompilerPass::visit(Error *ast)
 {
     expr(ast->expr);
@@ -301,6 +317,7 @@ void CompilerPass::visitExpr(AST *&ast_)
         VISIT(ast_, AST_BINARY, Binary);
         VISIT(ast_, AST_BUILTIN_FUNCTION, BuiltinFunction);
         VISIT(ast_, AST_CONDITIONAL, Conditional);
+        VISIT(ast_, AST_SWITCH, Switch);
         VISIT(ast_, AST_DESUGARED_OBJECT, DesugaredObject);
         VISIT(ast_, AST_DOLLAR, Dollar);
         VISIT(ast_, AST_ERROR, Error);

--- a/core/pass.h
+++ b/core/pass.h
@@ -59,6 +59,8 @@ class CompilerPass {
 
     virtual void visit(Conditional *ast);
 
+    virtual void visit(Switch *ast);
+
     virtual void visit(Dollar *) {}
 
     virtual void visit(Error *ast);

--- a/core/static_analysis.cpp
+++ b/core/static_analysis.cpp
@@ -74,6 +74,11 @@ static IdSet static_analysis(AST *ast_, bool in_object, const IdSet &vars)
         append(r, static_analysis(ast->branchTrue, in_object, vars));
         append(r, static_analysis(ast->branchFalse, in_object, vars));
     } break;
+    case AST_SWITCH: {
+        assert(dynamic_cast<Switch *>(ast_));
+        auto* ast = static_cast<Switch *>(ast_);
+        append(r, static_analysis(ast->ifChain, in_object, vars));
+    } break;
     case AST_ERROR: {
         assert(dynamic_cast<Error *>(ast_));
         auto* ast = static_cast<Error *>(ast_);

--- a/core/vm.cpp
+++ b/core/vm.cpp
@@ -30,6 +30,9 @@ limitations under the License.
 #include "string_utils.h"
 #include "vm.h"
 
+static const Fodder EF;
+static const LocationRange E;
+
 namespace {
 
 /** Turn a path e.g. "/a/b/c" into a dir, e.g. "/a/b/".  If there is no path returns "".
@@ -1502,6 +1505,12 @@ class Interpreter {
                 const auto &ast = *static_cast<const Conditional *>(ast_);
                 stack.newFrame(FRAME_IF, ast_);
                 ast_ = ast.cond;
+                goto recurse;
+            } break;
+
+            case AST_SWITCH: {
+                const auto &ast = *static_cast<const Switch *>(ast_);
+                ast_ = ast.ifChain;
                 goto recurse;
             } break;
 

--- a/test_suite/condition.jsonnet
+++ b/test_suite/condition.jsonnet
@@ -26,6 +26,12 @@ local f(x) =
   else
     'huge';
 
+local g(x) =
+  switch x for
+  if 'hello' then 42
+  if 'world' then 37
+  else 54;
+
 std.assertEqual(f(-10), 'negative') &&
 std.assertEqual(f(0), 'zero') &&
 std.assertEqual(f(3), 'small') &&
@@ -40,5 +46,9 @@ std.assertEqual(if true then (if false then 'f') else 'y', null) &&
 std.assertEqual(if true then if true then 'f' + 'y', 'fy') &&
 std.assertEqual(if false then (if true then 'f') + 'y', null) &&
 std.assertEqual((if false then (if true then 'f')) + 'y', 'nully') &&
+
+std.assertEqual(g('hello'), 42) &&
+std.assertEqual(g('world'), 37) &&
+std.assertEqual(g('other'), 54) &&
 
 true


### PR DESCRIPTION
The Jsonnet language is clearly inspired from functional programming. It currently lacks, however, something analogous to a C-style `switch` or ML/Rust `match`. So, I set out to implement one. This PR isn't ready to merge as-is (see the notes below,) but meant to open a discussion for whether the community views such a feature as worthwhile.

This is purely syntactic sugar. A construct like

	switch x for
	if 'hello' then 42
	if 'world' then 37
	else 54;

is transformed by the parser into an equivalent if-else chain

	if x == 'hello' then
	  42
	else if x == 'world' then
	  37
	else
	  54;

which is evaluated by the VM normally. For simplicity, an `else` clause is mandatory, and there's a limit of 1024 cases.

There are still some potential issues to resolve before merging:

- The branch for fixing indentation is currently empty. The formatting tests pass, so I'm not sure if one is needed.
- The compiler pass visitor just explores the internal if chain, but I'd guess that it should visit the logical structure instead.
- The code for constructing the if-chain should probably move into the desugarer module.
- As written, the desugared if-chain simply re-uses the pivot AST. So if it is an expression instead of a variable lookup, it could be expensive to re-compute it for each case.