### PR TITLE
Change escape range to 0080-009F to match the latin-1 charset

### DIFF
--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -853,7 +853,7 @@ limitations under the License.
         '\\t'
       else
         local cp = std.codepoint(ch);
-        if cp < 32 || (cp >= 128 && cp <= 159) then
+        if cp < 32 || (cp >= 127 && cp <= 159) then
           '\\u%04x' % [cp]
         else
           ch;

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -853,7 +853,7 @@ limitations under the License.
         '\\t'
       else
         local cp = std.codepoint(ch);
-        if cp < 32 || (cp >= 126 && cp <= 159) then
+        if cp < 32 || (cp >= 128 && cp <= 159) then
           '\\u%04x' % [cp]
         else
           ch;

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -260,6 +260,7 @@ std.assertEqual(std.escapeStringJson('he"llo'), '"he\\"llo"') &&
 std.assertEqual(std.escapeStringJson('he"llo'), '"he\\"llo"') &&
 std.assertEqual(std.escapeStringBash("he\"l'lo"), "'he\"l'\"'\"'lo'") &&
 std.assertEqual(std.escapeStringDollars('The path is ${PATH}.'), 'The path is $${PATH}.') &&
+std.assertEqual(std.escapeStringJson('!~'), '"!~"') &&
 
 std.assertEqual(std.manifestPython({
   x: 'test',

--- a/test_suite/stdlib.jsonnet.golden
+++ b/test_suite/stdlib.jsonnet.golden
@@ -1,4 +1,3 @@
-TRACE: stdlib.jsonnet:580 
 TRACE: stdlib.jsonnet:581 
 TRACE: stdlib.jsonnet:582 
 TRACE: stdlib.jsonnet:583 
@@ -8,5 +7,6 @@ TRACE: stdlib.jsonnet:586
 TRACE: stdlib.jsonnet:587 
 TRACE: stdlib.jsonnet:588 
 TRACE: stdlib.jsonnet:589 
-TRACE: stdlib.jsonnet:590 Some Trace Message
+TRACE: stdlib.jsonnet:590 
+TRACE: stdlib.jsonnet:591 Some Trace Message
 true


### PR DESCRIPTION
Fixed the escape range for printable json values and added associated tests.

Should address #557