### PR TITLE
Update std.parseInt error messages

### DIFF
--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -81,6 +81,8 @@ limitations under the License.
     std.foldl(addDigit, std.stringChars(str), 0),
 
   parseInt(str)::
+    assert std.isString(str): 'Expected string, got ' + std.type(str);
+    assert std.length(str) > 0 && str != "-": 'Not an integer: "%s"' % [str];
     if str[0] == '-' then
       -parse_nat(str[1:], 10)
     else

--- a/test_suite/error.equality_function.jsonnet.golden
+++ b/test_suite/error.equality_function.jsonnet.golden
@@ -1,3 +1,3 @@
 RUNTIME ERROR: cannot test equality of functions
-	std.jsonnet:1221:9-34	function <anonymous>
+	std.jsonnet:1223:9-34	function <anonymous>
 	error.equality_function.jsonnet:17:1-33	

--- a/test_suite/error.inside_equals_array.jsonnet.golden
+++ b/test_suite/error.inside_equals_array.jsonnet.golden
@@ -1,7 +1,7 @@
 RUNTIME ERROR: foobar
 	error.inside_equals_array.jsonnet:18:18-32	thunk <array_element>
-	std.jsonnet:1201:29-33	thunk <b>
-	std.jsonnet:1201:21-33	function <anonymous>
-	std.jsonnet:1201:21-33	function <aux>
-	std.jsonnet:1204:15-31	function <anonymous>
-	std.jsonnet:1205:11-23	
+	std.jsonnet:1203:29-33	thunk <b>
+	std.jsonnet:1203:21-33	function <anonymous>
+	std.jsonnet:1203:21-33	function <aux>
+	std.jsonnet:1206:15-31	function <anonymous>
+	std.jsonnet:1207:11-23	

--- a/test_suite/error.inside_equals_object.jsonnet.golden
+++ b/test_suite/error.inside_equals_object.jsonnet.golden
@@ -1,7 +1,7 @@
 RUNTIME ERROR: foobar
 	error.inside_equals_object.jsonnet:18:22-36	object <b>
-	std.jsonnet:1215:50-54	thunk <b>
-	std.jsonnet:1215:42-54	function <anonymous>
-	std.jsonnet:1215:42-54	function <aux>
-	std.jsonnet:1218:15-31	function <anonymous>
-	std.jsonnet:1219:11-23	
+	std.jsonnet:1217:50-54	thunk <b>
+	std.jsonnet:1217:42-54	function <anonymous>
+	std.jsonnet:1217:42-54	function <aux>
+	std.jsonnet:1220:15-31	function <anonymous>
+	std.jsonnet:1221:11-23	

--- a/test_suite/error.invariant.equality.jsonnet.golden
+++ b/test_suite/error.invariant.equality.jsonnet.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: Object assertion failed.
 	error.invariant.equality.jsonnet:17:10-15	thunk <object_assert>
-	std.jsonnet:1215:42-46	thunk <a>
-	std.jsonnet:1215:42-54	function <anonymous>
-	std.jsonnet:1215:42-54	function <anonymous>
-	std.jsonnet:1219:11-23	
+	std.jsonnet:1217:42-46	thunk <a>
+	std.jsonnet:1217:42-54	function <anonymous>
+	std.jsonnet:1217:42-54	function <anonymous>
+	std.jsonnet:1221:11-23	

--- a/test_suite/error.obj_assert.fail1.jsonnet.golden
+++ b/test_suite/error.obj_assert.fail1.jsonnet.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: Object assertion failed.
 	error.obj_assert.fail1.jsonnet:20:23-29	thunk <object_assert>
-	std.jsonnet:1215:42-46	thunk <a>
-	std.jsonnet:1215:42-54	function <anonymous>
-	std.jsonnet:1215:42-54	function <anonymous>
-	std.jsonnet:1219:11-23	
+	std.jsonnet:1217:42-46	thunk <a>
+	std.jsonnet:1217:42-54	function <anonymous>
+	std.jsonnet:1217:42-54	function <anonymous>
+	std.jsonnet:1221:11-23	

--- a/test_suite/error.obj_assert.fail2.jsonnet.golden
+++ b/test_suite/error.obj_assert.fail2.jsonnet.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: foo was not equal to bar
 	error.obj_assert.fail2.jsonnet:20:32-65	thunk <object_assert>
-	std.jsonnet:1215:42-46	thunk <a>
-	std.jsonnet:1215:42-54	function <anonymous>
-	std.jsonnet:1215:42-54	function <anonymous>
-	std.jsonnet:1219:11-23	
+	std.jsonnet:1217:42-46	thunk <a>
+	std.jsonnet:1217:42-54	function <anonymous>
+	std.jsonnet:1217:42-54	function <anonymous>
+	std.jsonnet:1221:11-23	

--- a/test_suite/error.sanity.jsonnet.golden
+++ b/test_suite/error.sanity.jsonnet.golden
@@ -1,3 +1,3 @@
 RUNTIME ERROR: Assertion failed. 1 != 2
-	std.jsonnet:780:7-50	function <anonymous>
+	std.jsonnet:782:7-50	function <anonymous>
 	error.sanity.jsonnet:17:1-22	

--- a/test_suite/error.std_join_types1.jsonnet.golden
+++ b/test_suite/error.std_join_types1.jsonnet.golden
@@ -1,5 +1,5 @@
 RUNTIME ERROR: expected string but arr[1] was array 
-	std.jsonnet:260:9-87	function <aux>
-	std.jsonnet:262:9-49	function <aux>
-	std.jsonnet:268:7-28	function <anonymous>
+	std.jsonnet:262:9-87	function <aux>
+	std.jsonnet:264:9-49	function <aux>
+	std.jsonnet:270:7-28	function <anonymous>
 	error.std_join_types1.jsonnet:17:1-26	

--- a/test_suite/error.std_join_types2.jsonnet.golden
+++ b/test_suite/error.std_join_types2.jsonnet.golden
@@ -1,4 +1,4 @@
 RUNTIME ERROR: expected array but arr[0] was string 
-	std.jsonnet:260:9-87	function <aux>
-	std.jsonnet:270:7-28	function <anonymous>
+	std.jsonnet:262:9-87	function <aux>
+	std.jsonnet:272:7-28	function <anonymous>
 	error.std_join_types2.jsonnet:17:1-31	


### PR DESCRIPTION
This change address issue #549 by adding more informative error messages when attempting to parse `''` or `'-'` as an integer.