### PR TITLE
Fix conditionals example.

### DIFF
--- a/doc/_includes/examples/conditionals.jsonnet
+++ b/doc/_includes/examples/conditionals.jsonnet
@@ -10,9 +10,11 @@ local Mojito(virgin=false, large=false) = {
       qty: 6 * factor,
       unit: 'leaves',
     },
-  ] + if virgin then [] else [
-    { kind: 'Banks', qty: 1.5 * factor },
-  ] + [
+  ] + (
+    if virgin then [] else [
+      { kind: 'Banks', qty: 1.5 * factor },
+    ]
+  ) + [
     { kind: 'Lime', qty: 0.5 * factor },
     { kind: 'Simple Syrup', qty: 0.5 * factor },
     { kind: 'Soda', qty: 3 * factor },

--- a/doc/_includes/examples/conditionals.jsonnet.golden
+++ b/doc/_includes/examples/conditionals.jsonnet.golden
@@ -63,6 +63,18 @@
         "kind": "Mint",
         "qty": 6,
         "unit": "leaves"
+      },
+      {
+         "kind": "Lime",
+         "qty": 0.5
+      },
+      {
+         "kind": "Simple Syrup",
+         "qty": 0.5
+      },
+      {
+         "kind": "Soda",
+         "qty": 3
       }
     ],
     "served": "Over crushed ice"

--- a/examples/conditionals.jsonnet
+++ b/examples/conditionals.jsonnet
@@ -26,9 +26,11 @@ local Mojito(virgin=false, large=false) = {
       qty: 6 * factor,
       unit: 'leaves',
     },
-  ] + if virgin then [] else [
-    { kind: 'Banks', qty: 1.5 * factor },
-  ] + [
+  ] + (
+    if virgin then [] else [
+      { kind: 'Banks', qty: 1.5 * factor },
+    ]
+  ) + [
     { kind: 'Lime', qty: 0.5 * factor },
     { kind: 'Simple Syrup', qty: 0.5 * factor },
     { kind: 'Soda', qty: 3 * factor },

--- a/examples/conditionals.jsonnet.golden
+++ b/examples/conditionals.jsonnet.golden
@@ -63,6 +63,18 @@
         "kind": "Mint",
         "qty": 6,
         "unit": "leaves"
+      },
+      {
+         "kind": "Lime",
+         "qty": 0.5
+      },
+      {
+         "kind": "Simple Syrup",
+         "qty": 0.5
+      },
+      {
+         "kind": "Soda",
+         "qty": 3
       }
     ],
     "served": "Over crushed ice"


### PR DESCRIPTION
This change updates the conditionals example to exclude only the alcoholic ingredient when `virgin=true`.

Before this change, all ingredients after the `else` condition were also excluded when `virgin=true`

Fixes issue: https://github.com/google/jsonnet/issues/567