### PR TITLE
Implement several stdlib functions with native builtins.

### DIFF
--- a/core/desugarer.cpp
+++ b/core/desugarer.cpp
@@ -32,7 +32,7 @@ struct BuiltinDecl {
     std::vector<UString> params;
 };
 
-static unsigned long max_builtin = 27;
+static unsigned long max_builtin = 33;
 BuiltinDecl jsonnet_builtin_decl(unsigned long builtin)
 {
     switch (builtin) {
@@ -64,6 +64,12 @@ BuiltinDecl jsonnet_builtin_decl(unsigned long builtin)
         case 25: return {U"native", {U"name"}};
         case 26: return {U"md5", {U"str"}};
         case 27: return {U"trace", {U"str", U"rest"}};
+        case 28: return {U"splitLimit", {U"str", U"c", U"maxsplits"}};
+        case 29: return {U"substr", {U"str", U"from", U"len"}};
+        case 30: return {U"range", {U"from", U"to"}};
+        case 31: return {U"strReplace", {U"str", U"from", U"to"}};
+        case 32: return {U"asciiLower", {U"str"}};
+        case 33: return {U"asciiUpper", {U"str"}};
         default:
             std::cerr << "INTERNAL ERROR: Unrecognized builtin function: " << builtin << std::endl;
             std::abort();

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -35,18 +35,6 @@ limitations under the License.
   toString(a)::
     if std.type(a) == 'string' then a else '' + a,
 
-  substr(str, from, len)::
-    if std.type(str) != 'string' then
-      error 'substr first parameter should be a string, got ' + std.type(str)
-    else if std.type(from) != 'number' then
-      error 'substr second parameter should be a number, got ' + std.type(from)
-    else if std.type(len) != 'number' then
-      error 'substr third parameter should be a number, got ' + std.type(len)
-    else if len < 0 then
-      error 'substr third parameter should be greater than zero, got ' + len
-    else
-      std.join('', std.makeArray(len, function(i) str[i + from])),
-
   startsWith(a, b)::
     if std.length(a) < std.length(b) then
       false
@@ -108,77 +96,6 @@ limitations under the License.
     else
       std.splitLimit(str, c, -1),
 
-  splitLimit(str, c, maxsplits)::
-    if std.type(str) != 'string' then
-      error 'std.splitLimit first parameter should be a string, got ' + std.type(str)
-    else if std.type(c) != 'string' then
-      error 'std.splitLimit second parameter should be a string, got ' + std.type(c)
-    else if std.length(c) != 1 then
-      error 'std.splitLimit second parameter should have length 1, got ' + std.length(c)
-    else if std.type(maxsplits) != 'number' then
-      error 'std.splitLimit third parameter should be a number, got ' + std.type(maxsplits)
-    else
-      local aux(str, delim, i, arr, v) =
-        local c = str[i];
-        local i2 = i + 1;
-        if i >= std.length(str) then
-          arr + [v]
-        else if c == delim && (maxsplits == -1 || std.length(arr) < maxsplits) then
-          aux(str, delim, i2, arr + [v], '') tailstrict
-        else
-          aux(str, delim, i2, arr, v + c) tailstrict;
-      aux(str, c, 0, [], ''),
-
-  strReplace(str, from, to)::
-    assert std.type(str) == 'string';
-    assert std.type(from) == 'string';
-    assert std.type(to) == 'string';
-    assert from != '' : "'from' string must not be zero length.";
-
-    // Cache for performance.
-    local str_len = std.length(str);
-    local from_len = std.length(from);
-
-    // True if from is at str[i].
-    local found_at(i) = str[i:i + from_len] == from;
-
-    // Return the remainder of 'str' starting with 'start_index' where
-    // all occurrences of 'from' after 'curr_index' are replaced with 'to'.
-    local replace_after(start_index, curr_index, acc) =
-      if curr_index > str_len then
-        acc + str[start_index:curr_index]
-      else if found_at(curr_index) then
-        local new_index = curr_index + std.length(from);
-        replace_after(new_index, new_index, acc + str[start_index:curr_index] + to) tailstrict
-      else
-        replace_after(start_index, curr_index + 1, acc) tailstrict;
-
-    // if from_len==1, then we replace by splitting and rejoining the
-    // string which is much faster than recursing on replace_after
-    if from_len == 1 then
-      std.join(to, std.split(str, from))
-    else
-      replace_after(0, 0, ''),
-
-  asciiUpper(x)::
-    local cp = std.codepoint;
-    local up_letter(c) = if cp(c) >= 97 && cp(c) < 123 then
-      std.char(cp(c) - 32)
-    else
-      c;
-    std.join('', std.map(up_letter, std.stringChars(x))),
-
-  asciiLower(x)::
-    local cp = std.codepoint;
-    local down_letter(c) = if cp(c) >= 65 && cp(c) < 91 then
-      std.char(cp(c) + 32)
-    else
-      c;
-    std.join('', std.map(down_letter, std.stringChars(x))),
-
-
-  range(from, to)::
-    std.makeArray(to - from + 1, function(i) i + from),
 
   slice(indexable, index, end, step)::
     local invar =

--- a/test_suite/error.equality_function.jsonnet.golden
+++ b/test_suite/error.equality_function.jsonnet.golden
@@ -1,3 +1,3 @@
 RUNTIME ERROR: cannot test equality of functions
-	std.jsonnet:1223:9-34	function <anonymous>
+	std.jsonnet:1140:9-34	function <anonymous>
 	error.equality_function.jsonnet:17:1-33	

--- a/test_suite/error.inside_equals_array.jsonnet.golden
+++ b/test_suite/error.inside_equals_array.jsonnet.golden
@@ -1,7 +1,7 @@
 RUNTIME ERROR: foobar
 	error.inside_equals_array.jsonnet:18:18-32	thunk <array_element>
-	std.jsonnet:1203:29-33	thunk <b>
-	std.jsonnet:1203:21-33	function <anonymous>
-	std.jsonnet:1203:21-33	function <aux>
-	std.jsonnet:1206:15-31	function <anonymous>
-	std.jsonnet:1207:11-23	
+	std.jsonnet:1120:29-33	thunk <b>
+	std.jsonnet:1120:21-33	function <anonymous>
+	std.jsonnet:1120:21-33	function <aux>
+	std.jsonnet:1123:15-31	function <anonymous>
+	std.jsonnet:1124:11-23	

--- a/test_suite/error.inside_equals_object.jsonnet.golden
+++ b/test_suite/error.inside_equals_object.jsonnet.golden
@@ -1,7 +1,7 @@
 RUNTIME ERROR: foobar
 	error.inside_equals_object.jsonnet:18:22-36	object <b>
-	std.jsonnet:1217:50-54	thunk <b>
-	std.jsonnet:1217:42-54	function <anonymous>
-	std.jsonnet:1217:42-54	function <aux>
-	std.jsonnet:1220:15-31	function <anonymous>
-	std.jsonnet:1221:11-23	
+	std.jsonnet:1134:50-54	thunk <b>
+	std.jsonnet:1134:42-54	function <anonymous>
+	std.jsonnet:1134:42-54	function <aux>
+	std.jsonnet:1137:15-31	function <anonymous>
+	std.jsonnet:1138:11-23	

--- a/test_suite/error.invariant.equality.jsonnet.golden
+++ b/test_suite/error.invariant.equality.jsonnet.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: Object assertion failed.
 	error.invariant.equality.jsonnet:17:10-15	thunk <object_assert>
-	std.jsonnet:1217:42-46	thunk <a>
-	std.jsonnet:1217:42-54	function <anonymous>
-	std.jsonnet:1217:42-54	function <anonymous>
-	std.jsonnet:1221:11-23	
+	std.jsonnet:1134:42-46	thunk <a>
+	std.jsonnet:1134:42-54	function <anonymous>
+	std.jsonnet:1134:42-54	function <anonymous>
+	std.jsonnet:1138:11-23	

--- a/test_suite/error.obj_assert.fail1.jsonnet.golden
+++ b/test_suite/error.obj_assert.fail1.jsonnet.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: Object assertion failed.
 	error.obj_assert.fail1.jsonnet:20:23-29	thunk <object_assert>
-	std.jsonnet:1217:42-46	thunk <a>
-	std.jsonnet:1217:42-54	function <anonymous>
-	std.jsonnet:1217:42-54	function <anonymous>
-	std.jsonnet:1221:11-23	
+	std.jsonnet:1134:42-46	thunk <a>
+	std.jsonnet:1134:42-54	function <anonymous>
+	std.jsonnet:1134:42-54	function <anonymous>
+	std.jsonnet:1138:11-23	

--- a/test_suite/error.obj_assert.fail2.jsonnet.golden
+++ b/test_suite/error.obj_assert.fail2.jsonnet.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: foo was not equal to bar
 	error.obj_assert.fail2.jsonnet:20:32-65	thunk <object_assert>
-	std.jsonnet:1217:42-46	thunk <a>
-	std.jsonnet:1217:42-54	function <anonymous>
-	std.jsonnet:1217:42-54	function <anonymous>
-	std.jsonnet:1221:11-23	
+	std.jsonnet:1134:42-46	thunk <a>
+	std.jsonnet:1134:42-54	function <anonymous>
+	std.jsonnet:1134:42-54	function <anonymous>
+	std.jsonnet:1138:11-23	

--- a/test_suite/error.sanity.jsonnet.golden
+++ b/test_suite/error.sanity.jsonnet.golden
@@ -1,3 +1,3 @@
 RUNTIME ERROR: Assertion failed. 1 != 2
-	std.jsonnet:782:7-50	function <anonymous>
+	std.jsonnet:699:7-50	function <anonymous>
 	error.sanity.jsonnet:17:1-22	

--- a/test_suite/error.std_join_types1.jsonnet.golden
+++ b/test_suite/error.std_join_types1.jsonnet.golden
@@ -1,5 +1,5 @@
 RUNTIME ERROR: expected string but arr[1] was array 
-	std.jsonnet:262:9-87	function <aux>
-	std.jsonnet:264:9-49	function <aux>
-	std.jsonnet:270:7-28	function <anonymous>
+	std.jsonnet:179:9-87	function <aux>
+	std.jsonnet:181:9-49	function <aux>
+	std.jsonnet:187:7-28	function <anonymous>
 	error.std_join_types1.jsonnet:17:1-26	

--- a/test_suite/error.std_join_types2.jsonnet.golden
+++ b/test_suite/error.std_join_types2.jsonnet.golden
@@ -1,4 +1,4 @@
 RUNTIME ERROR: expected array but arr[0] was string 
-	std.jsonnet:262:9-87	function <aux>
-	std.jsonnet:272:7-28	function <anonymous>
+	std.jsonnet:179:9-87	function <aux>
+	std.jsonnet:189:7-28	function <anonymous>
 	error.std_join_types2.jsonnet:17:1-31	


### PR DESCRIPTION
Migrate several function from std.jsonnet to native implementations.  This improves performance of our jsonnet conversion by about 30%.