### PR TITLE
Add benchmarks

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,1 @@
+*.gen.jsonnet

--- a/benchmarks/bench.04.jsonnet
+++ b/benchmarks/bench.04.jsonnet
@@ -1,0 +1,1 @@
+std.foldl(function(e, res) e + res, std.makeArray(20000, function(i) 'aaaaa'), '')

--- a/benchmarks/bench.07.jsonnet
+++ b/benchmarks/bench.07.jsonnet
@@ -1,0 +1,6 @@
+local f2(f) = function(x) f(f(x));
+local id(x) = x;
+
+local slowId = std.makeArray(20, function(i) if i == 0 then id else f2(slowId[i - 1]));
+
+slowId[15](42)

--- a/benchmarks/gen_big_object.jsonnet
+++ b/benchmarks/gen_big_object.jsonnet
@@ -1,0 +1,18 @@
+local n = 2000;
+
+local objLocal(name, body) = 'local ' + name + ' = ' + body + ',';
+local objField(name, body) = name + ': ' + body + ',';
+
+local allLocals =
+  std.makeArray(n, function(i) objLocal('l' + i, '1'));
+
+local allFields =
+  std.makeArray(n, function(i) objField('f' + i, '2'));
+
+local indent = '  ';
+local indentAndSeparate(s) = indent + s + '\n';
+
+local objContents = std.map(indentAndSeparate, allLocals + allFields);
+
+local objectBody = std.join('', objContents);
+'{\n' + objectBody + '}\n'

--- a/benchmarks/regen_benchmarks.sh
+++ b/benchmarks/regen_benchmarks.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+set -x
+
+../jsonnet -S gen_big_object.jsonnet > bench.05.gen.jsonnet
+
+for i in *.gen.jsonnet; do
+	../jsonnet fmt -i "$i"
+done


### PR DESCRIPTION
One of the benchmarks is generated. It may be useful to do that
sometimes, especially with parser-oriented benchmarks. Jsonnet
is used to generate the 5th benchmark (dogfooding!).

*.gen.jsonnet files are added to local .gitignore so that we don't
keep big benchmarks in the repo. Run ./regen_benchmarks.sh to generate
them.