### PR TITLE
Remove LIB_JSONNET_VERSION from libjsonnet.h

### DIFF
--- a/core/libjsonnet.cpp
+++ b/core/libjsonnet.cpp
@@ -36,6 +36,8 @@ extern "C" {
 #include "static_analysis.h"
 #include "vm.h"
 
+#define LIB_JSONNET_VERSION "v0.12.1"
+
 static void memory_panic(void)
 {
     fputs("FATAL ERROR: a memory allocation error occurred.\n", stderr);

--- a/include/libjsonnet.h
+++ b/include/libjsonnet.h
@@ -24,8 +24,6 @@ limitations under the License.
  * of using the library.
  */
 
-#define LIB_JSONNET_VERSION "v0.12.1"
-
 /** Return the version string of the Jsonnet interpreter.  Conforms to semantic versioning
  * http://semver.org/ If this does not match LIB_JSONNET_VERSION then there is a mismatch between
  * header and compiled library.


### PR DESCRIPTION
It could be very confusing if header is linked with older/newer
version of the library. We have jsonnet_version function which
returns the version of the actual library underneath.

So unless it's some standard thing to provide the version of the
header separate from the version of the actual library, I think it's
just a bad idea to include it, especially considering go-jsonnet C bindings.