### PR TITLE
Change sort algorithm

### DIFF
--- a/benchmarks/bench.06.jsonnet
+++ b/benchmarks/bench.06.jsonnet
@@ -1,0 +1,16 @@
+// A benchmark for builtin sort
+
+// TODO(sbarzowski) reverse functions should probably be a part of std
+local reverse(arr) =
+  local l = std.length(arr);
+  std.makeArray(l, function(i) arr[l - i - 1])
+;
+
+local sort = std.sort;
+
+true
+&& std.assertEqual(std.range(1, 500), sort(std.range(1, 500)))
+&& std.assertEqual(std.range(1, 1000), sort(std.range(1, 1000)))
+&& std.assertEqual(reverse(std.range(1, 1000)), sort(std.range(1, 1000), keyF=function(x) -x))
+&& std.assertEqual(std.range(1, 1000), sort(reverse(std.range(1, 1000))))
+&& std.assertEqual(std.makeArray(2000, function(i) std.floor((i + 2) / 2)), sort(std.range(1, 1000) + reverse(std.range(1, 1000))))

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1132,17 +1132,41 @@ limitations under the License.
     local bytes = std.base64DecodeBytes(str);
     std.join('', std.map(function(b) std.char(b), bytes)),
 
-  // Quicksort
+  // Merge-sort for long arrays and naive quicksort for shorter ones
   sort(arr, keyF=id)::
+    local quickSort(arr, keyF=id) = 
+      local l = std.length(arr);
+      if std.length(arr) <= 1 then
+        arr
+      else
+        local pos = 0;
+        local pivot = keyF(arr[pos]);
+        local rest = std.makeArray(l - 1, function(i) if i < pos then arr[i] else arr[i + 1]);
+        local left = std.filter(function(x) keyF(x) < pivot, rest);
+        local right = std.filter(function(x) keyF(x) >= pivot, rest);
+        quickSort(left, keyF) + [arr[pos]] + quickSort(right, keyF);
+
+    local merge(a, b) =
+      local la = std.length(a), lb = std.length(b);
+      local aux(i, j, prefix) = 
+      if i == la then
+        prefix + b[j:]
+      else if j == lb then
+        prefix + a[i:]
+      else
+        if keyF(a[i]) <= keyF(b[j]) then
+          aux(i + 1, j, prefix + [a[i]]) tailstrict
+        else
+          aux(i, j + 1, prefix + [b[j]]) tailstrict;
+      aux(0, 0, []);
+
     local l = std.length(arr);
-    if std.length(arr) == 0 then
-      []
+    if std.length(arr) <= 30 then
+      quickSort(arr, keyF=keyF)
     else
-      local pivot = keyF(arr[0]);
-      local rest = std.makeArray(l - 1, function(i) arr[i + 1]);
-      local left = std.filter(function(x) keyF(x) < pivot, rest);
-      local right = std.filter(function(x) keyF(x) >= pivot, rest);
-      std.sort(left, keyF) + [arr[0]] + std.sort(right, keyF),
+      local mid = std.floor(l/ 2);
+      local left = arr[:mid], right = arr[mid:];
+      merge(std.sort(left, keyF=keyF), std.sort(right, keyF=keyF)),
 
   uniq(arr, keyF=id)::
     local f(a, b) =

--- a/test_suite/error.equality_function.jsonnet.golden
+++ b/test_suite/error.equality_function.jsonnet.golden
@@ -1,3 +1,3 @@
 RUNTIME ERROR: cannot test equality of functions
-	std.jsonnet:1280:9-34	function <anonymous>
+	std.jsonnet:1304:9-34	function <anonymous>
 	error.equality_function.jsonnet:17:1-33	

--- a/test_suite/error.inside_equals_array.jsonnet.golden
+++ b/test_suite/error.inside_equals_array.jsonnet.golden
@@ -1,7 +1,7 @@
 RUNTIME ERROR: foobar
 	error.inside_equals_array.jsonnet:18:18-32	thunk <array_element>
-	std.jsonnet:1260:29-33	thunk <b>
-	std.jsonnet:1260:21-33	function <anonymous>
-	std.jsonnet:1260:21-33	function <aux>
-	std.jsonnet:1263:15-31	function <anonymous>
-	std.jsonnet:1264:11-23	
+	std.jsonnet:1284:29-33	thunk <b>
+	std.jsonnet:1284:21-33	function <anonymous>
+	std.jsonnet:1284:21-33	function <aux>
+	std.jsonnet:1287:15-31	function <anonymous>
+	std.jsonnet:1288:11-23	

--- a/test_suite/error.inside_equals_object.jsonnet.golden
+++ b/test_suite/error.inside_equals_object.jsonnet.golden
@@ -1,7 +1,7 @@
 RUNTIME ERROR: foobar
 	error.inside_equals_object.jsonnet:18:22-36	object <b>
-	std.jsonnet:1274:50-54	thunk <b>
-	std.jsonnet:1274:42-54	function <anonymous>
-	std.jsonnet:1274:42-54	function <aux>
-	std.jsonnet:1277:15-31	function <anonymous>
-	std.jsonnet:1278:11-23	
+	std.jsonnet:1298:50-54	thunk <b>
+	std.jsonnet:1298:42-54	function <anonymous>
+	std.jsonnet:1298:42-54	function <aux>
+	std.jsonnet:1301:15-31	function <anonymous>
+	std.jsonnet:1302:11-23	

--- a/test_suite/error.invariant.equality.jsonnet.golden
+++ b/test_suite/error.invariant.equality.jsonnet.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: Object assertion failed.
 	error.invariant.equality.jsonnet:17:10-15	thunk <object_assert>
-	std.jsonnet:1274:42-46	thunk <a>
-	std.jsonnet:1274:42-54	function <anonymous>
-	std.jsonnet:1274:42-54	function <anonymous>
-	std.jsonnet:1278:11-23	
+	std.jsonnet:1298:42-46	thunk <a>
+	std.jsonnet:1298:42-54	function <anonymous>
+	std.jsonnet:1298:42-54	function <anonymous>
+	std.jsonnet:1302:11-23	

--- a/test_suite/error.obj_assert.fail1.jsonnet.golden
+++ b/test_suite/error.obj_assert.fail1.jsonnet.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: Object assertion failed.
 	error.obj_assert.fail1.jsonnet:20:23-29	thunk <object_assert>
-	std.jsonnet:1274:42-46	thunk <a>
-	std.jsonnet:1274:42-54	function <anonymous>
-	std.jsonnet:1274:42-54	function <anonymous>
-	std.jsonnet:1278:11-23	
+	std.jsonnet:1298:42-46	thunk <a>
+	std.jsonnet:1298:42-54	function <anonymous>
+	std.jsonnet:1298:42-54	function <anonymous>
+	std.jsonnet:1302:11-23	

--- a/test_suite/error.obj_assert.fail2.jsonnet.golden
+++ b/test_suite/error.obj_assert.fail2.jsonnet.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: foo was not equal to bar
 	error.obj_assert.fail2.jsonnet:20:32-65	thunk <object_assert>
-	std.jsonnet:1274:42-46	thunk <a>
-	std.jsonnet:1274:42-54	function <anonymous>
-	std.jsonnet:1274:42-54	function <anonymous>
-	std.jsonnet:1278:11-23	
+	std.jsonnet:1298:42-46	thunk <a>
+	std.jsonnet:1298:42-54	function <anonymous>
+	std.jsonnet:1298:42-54	function <anonymous>
+	std.jsonnet:1302:11-23	


### PR DESCRIPTION
Current std.sort implementation recurses may recurse N
times for the array of size N. For example for sorted or
reverse sorted data. This causes problems with std.set for example.

This change implements mergesort which always divides the array
in half, so the depth of recursion is always reasonable.

For smaller arrays quicksort is still used (it is faster).