### PR TITLE
CMake: add {,SO}VERSION properties for libjsonnet.so

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -34,7 +34,8 @@ target_link_libraries(libjsonnet md5)
 
 # CMake prepends CMAKE_SHARED_LIBRARY_PREFIX to shared libraries, so without
 # this step the output would be |liblibjsonnet|.
-set_target_properties(libjsonnet PROPERTIES OUTPUT_NAME jsonnet)
+set_target_properties(libjsonnet PROPERTIES OUTPUT_NAME jsonnet
+	VERSION 0.12.1 SOVERSION 0)
 install(TARGETS libjsonnet DESTINATION lib)
 
 # Static library for jsonnet command-line tool.


### PR DESCRIPTION
Tracking ABI/API changes with SOVERSION is an important part for distribution packaging.