### PR TITLE
CMake: various improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Travis CI runs CMake 2.8.7 so we are pinned to that verison.
 cmake_minimum_required(VERSION 2.8.7)
 include(ExternalProject)
+include(GNUInstallDirs)
 
 # User-configurable options.
 option(BUILD_JSONNET "Build jsonnet command-line tool." ON)
@@ -95,13 +96,12 @@ include_directories(
     third_party/json
     core)
 
-install(DIRECTORY include DESTINATION include)
-
 if (BUILD_TESTS)
     # Set JSONNET_BIN variable required for regression tests.
     file(TO_NATIVE_PATH ${GLOBAL_OUTPUT_PATH}/jsonnet JSONNET_BIN)
 endif()
 
+add_subdirectory(include)
 add_subdirectory(stdlib)
 add_subdirectory(third_party/md5)
 add_subdirectory(core)

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -5,5 +5,5 @@ if (BUILD_JSONNET OR BUILD_TESTS)
     add_dependencies(jsonnet libjsonnet_static)
     target_link_libraries(jsonnet libjsonnet_static)
 
-    install(TARGETS jsonnet DESTINATION bin)
+	install(TARGETS jsonnet DESTINATION "${CMAKE_INSTALL_BINDIR}")
 endif()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -35,14 +35,20 @@ target_link_libraries(libjsonnet md5)
 # CMake prepends CMAKE_SHARED_LIBRARY_PREFIX to shared libraries, so without
 # this step the output would be |liblibjsonnet|.
 set_target_properties(libjsonnet PROPERTIES OUTPUT_NAME jsonnet
-	VERSION 0.12.1 SOVERSION 0)
-install(TARGETS libjsonnet DESTINATION lib)
+	VERSION     "0.12.1"
+	SOVERSION   "0"
+	PUBLIC_HEADER "${LIB_HEADER}")
+install(TARGETS libjsonnet
+	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 # Static library for jsonnet command-line tool.
 add_library(libjsonnet_static STATIC ${LIBJSONNET_SOURCE})
 add_dependencies(libjsonnet_static md5 stdlib)
 target_link_libraries(libjsonnet_static md5)
 set_target_properties(libjsonnet_static PROPERTIES OUTPUT_NAME jsonnet)
+install(TARGETS libjsonnet_static DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
 # Tests
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -2,4 +2,5 @@ set(LIB_HEADER
     ${LIB_HEADER}
     ${CMAKE_CURRENT_SOURCE_DIR}/libjsonnet.h
     ${CMAKE_CURRENT_SOURCE_DIR}/libjsonnet++.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/libjsonnet_fmt.h
     PARENT_SCOPE)


### PR DESCRIPTION
Changes:
1. Use `GNUInstallDirs` instead of hardcoded installation path
2. Also install the static library
3. Remove `install(DIRECTORY include DESTINATION include)` because it installs garbage to the dest dir. Headers will be installed along with the `libjsonnet` target through `PUBLIC_HEADER` property.

