### PR TITLE
Move kubecfg to bitnami org

### DIFF
--- a/doc/articles/kubernetes.html
+++ b/doc/articles/kubernetes.html
@@ -62,7 +62,7 @@ layout: default
           example</a> from the Jsonnet repo.
         </li>
         <li>
-          <a href="https://github.com/ksonnet/kubecfg">Kubecfg</a> (whose name may sound familiar to
+          <a href="https://github.com/bitnami/kubecfg">Kubecfg</a> (whose name may sound familiar to
           current or ex-Googlers) is an unopiniated tool for evaluating Jsonnet and
           pushing the results to Kubernetes.  It comes with a <a
           href="https://github.com/bitnami-labs/kube-libsonnet">useful template library</a>.  See


### PR DESCRIPTION
Kubecfg now lives under the bitnami github org.
GitHub redirects old links but I guess it's a good idea to fix the links anyway (also to break the ties with the deprecated ksonnet tool)