### PR TITLE
Fix std.substr out of bounds inconsistency

### DIFF
--- a/core/vm.cpp
+++ b/core/vm.cpp
@@ -1435,6 +1435,10 @@ class Interpreter {
             ss << "substr third parameter should be greater than zero, got " << len;
             throw makeError(loc, ss.str());
         }
+        if (from > str->value.size()) {
+            scratch = makeString(UString());
+            return nullptr;
+        }
         if (size_t(len + from) > str->value.size()) {
           len = str->value.size() - from;
         }

--- a/doc/ref/stdlib.html
+++ b/doc/ref/stdlib.html
@@ -438,7 +438,8 @@ layout: default
     <div class="panel">
       <p>
         Returns a string that is the part of <code>s</code> that starts at offset <code>from</code>
-        and is <code>len</code> codepoints long.
+        and is <code>len</code> codepoints long. If the string <code>s</code> is shorter than 
+        <code>from+len</code>, the suffix starting at position <code>from</code> will be returned.
       </p>
     </div>
     <div style="clear: both"></div>

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -45,7 +45,7 @@ limitations under the License.
     else if len < 0 then
       error 'substr third parameter should be greater than zero, got ' + len
     else
-      std.join('', std.makeArray(len, function(i) str[i + from])),
+      std.join('', std.makeArray(std.max(0, std.min(len, std.length(str) - from)), function(i) str[i + from])),
 
   startsWith(a, b)::
     if std.length(a) < std.length(b) then

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -157,6 +157,16 @@ std.assertEqual(std.toString([1, 2, 'foo']), '[1, 2, "foo"]') &&
 
 std.assertEqual(std.substr('cookie', 1, 3), 'ook') &&
 std.assertEqual(std.substr('cookie', 1, 0), '') &&
+std.assertEqual(std.substr('cookie', 1, 15), 'ookie') &&
+std.assertEqual(std.substr('cookie', 0, 5), 'cooki') &&
+std.assertEqual(std.substr('cookie', 0, 6), 'cookie') &&
+std.assertEqual(std.substr('cookie', 0, 15), 'cookie') &&
+std.assertEqual(std.substr('cookie', 3, 1), 'k') &&
+std.assertEqual(std.substr('cookie', 20, 1), '') &&
+std.assertEqual(std.substr('cookie', 6, 1), '') &&
+
+
+std.assertEqual(std.substr('ąę', 1, 1), 'ę') &&
 
 std.assertEqual(std.startsWith('food', 'foo'), true) &&
 std.assertEqual(std.startsWith('food', 'food'), true) &&


### PR DESCRIPTION
Make both Jsonnet and C++-native implementation clip
the substring which go beyond the end of string.