### PR TITLE
Include jsonnetfmt build artifact in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,6 @@ FROM alpine:latest
 RUN apk add --no-cache libstdc++ 
 
 COPY --from=builder /opt/jsonnet/jsonnet /usr/local/bin
+COPY --from=builder /opt/jsonnet/jsonnetfmt /usr/local/bin
 
 ENTRYPOINT ["/usr/local/bin/jsonnet"]


### PR DESCRIPTION
Following v0.13.0 release, this adds the `jsonnetfmt` binary to the docker image.

Re [issue #669](https://github.com/google/jsonnet/issues/669)

Build:
```bash
docker build -t sparkprime/jsonnet:669 .
```

Run:
```bash
docker run -u --rm \
   --entrypoint=jsonnetfmt \
   -u $(id -u ${USER}):$(id -g ${USER}) \
   -v `pwd`/test_suite:/workspace:delegated \
   sparkprime/jsonnet:669 --indent 2 --max-blank-lines 2 /workspace/assert.jsonnet
```

Output:
```
/*
Copyright 2015 Google Inc. All rights reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
*/

assert true;
assert 10 > 5;

std.assertEqual(assert 10 > 5; 32, 32) &&

true
```