### PR TITLE
Add cpp/ to cmake and libs and install targets to Makefile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,8 @@ include_directories(
     include
     third_party/md5
     third_party/json
-    core)
+    core
+    cpp)
 
 if (BUILD_TESTS)
     # Set JSONNET_BIN variable required for regression tests.
@@ -106,6 +107,7 @@ add_subdirectory(include)
 add_subdirectory(stdlib)
 add_subdirectory(third_party/md5)
 add_subdirectory(core)
+add_subdirectory(cpp)
 add_subdirectory(cmd)
 add_subdirectory(test_suite)
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ OD ?= od
 
 OPT ?= -O3
 
+PREFIX ?= /usr/local
+
 CXXFLAGS ?= -g $(OPT) -Wall -Wextra -Woverloaded-virtual -pedantic -std=c++0x -fPIC
 CXXFLAGS += -Iinclude -Ithird_party/md5 -Ithird_party/json
 CFLAGS ?= -g $(OPT) -Wall -Wextra -pedantic -std=c99 -fPIC
@@ -63,16 +65,28 @@ LIB_CPP_SRC = \
 
 LIB_CPP_OBJ = $(LIB_OBJ) $(LIB_CPP_SRC:.cpp=.o)
 
-ALL = \
+BINS = \
 	jsonnet \
-	jsonnetfmt \
+	jsonnetfmt
+
+LIBS = \
 	libjsonnet.so \
-	libjsonnet++.so \
+	libjsonnet++.so
+
+ALL = \
 	libjsonnet_test_snippet \
 	libjsonnet_test_file \
 	libjsonnet.js \
 	doc/js/libjsonnet.js \
+	$(BINS) \
+	$(LIBS) \
 	$(LIB_OBJ)
+
+# public headers
+INCS = \
+	include/libjsonnet.h \
+	include/libjsonnet_fmt.h \
+	include/libjsonnet++.h
 
 ALL_HEADERS = \
 	core/ast.h \
@@ -86,13 +100,23 @@ ALL_HEADERS = \
 	core/string_utils.h \
 	core/vm.h \
 	core/std.jsonnet.h \
-	include/libjsonnet.h \
-	include/libjsonnet_fmt.h \
-	include/libjsonnet++.h \
 	third_party/md5/md5.h \
-	third_party/json/json.hpp
+	third_party/json/json.hpp \
+	$(INCS)
 
-default: jsonnet jsonnetfmt
+
+default: $(LIBS) $(BINS)
+
+bins: jsonnet jsonnetfmt
+libs: libjsonnet.so libjsonnet++.so
+
+install: bins libs
+	mkdir -p $(PREFIX)/bin
+	cp $(BINS) $(PREFIX)/bin/
+	mkdir -p $(PREFIX)/lib
+	cp $(LIBS) $(PREFIX)/lib/
+	mkdir -p $(PREFIX)/include
+	cp $(INCS) $(PREFIX)/include/
 
 all: $(ALL)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(libjsonnet++_static STATIC ${LIBJSONNETPP_SOURCE})
 add_dependencies(libjsonnet++_static jsonnet)
 target_link_libraries(libjsonnet++_static libjsonnet_static)
 set_target_properties(libjsonnet++_static PROPERTIES OUTPUT_NAME jsonnet++)
-install(TARGETS libjsonnet_static DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+install(TARGETS libjsonnet++_static DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
 # Tests
 function(add_test_executablepp test_name)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,51 @@
+# libjsonnet++
+
+set(LIBJSONNETPP_HEADERS
+    ../include/libjsonnet++.h
+)
+
+set(LIBJSONNETPP_SOURCE
+    libjsonnet++.cpp
+)
+
+add_library(libjsonnet++ SHARED ${LIBJSONNETPP_HEADERS} ${LIBJSONNETPP_SOURCE})
+add_dependencies(libjsonnet++ jsonnet)
+# target_link_libraries(libjsonnet libjsonnet)
+
+# CMake prepends CMAKE_SHARED_LIBRARY_PREFIX to shared libraries, so without
+# this step the output would be |liblibjsonnet|.
+set_target_properties(libjsonnet++ PROPERTIES OUTPUT_NAME jsonnet++
+	VERSION     "0.13.0"
+	SOVERSION   "0"
+	PUBLIC_HEADER "${LIB_HEADER}")
+install(TARGETS libjsonnet++
+	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
+# Static library for jsonnet command-line tool.
+add_library(libjsonnet++_static STATIC ${LIBJSONNETPP_SOURCE})
+add_dependencies(libjsonnet++_static jsonnet)
+target_link_libraries(libjsonnet++_static libjsonnet_static)
+set_target_properties(libjsonnet++_static PROPERTIES OUTPUT_NAME jsonnet++)
+install(TARGETS libjsonnet_static DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+
+# Tests
+function(add_test_executablepp test_name)
+    if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/${test_name}.cpp)
+        set(TEST_EXT cpp)
+    else()
+        set(TEST_EXT c)
+    endif()
+    add_executable(${test_name} ${test_name}.${TEST_EXT})
+
+    add_dependencies(${test_name} libjsonnet++_static jsonnet gtest_main)
+    target_link_libraries(
+        ${test_name} gtest gtest_main libjsonnet++_static libjsonnet_static)
+endfunction()
+
+if (BUILD_TESTS)
+    add_test_executablepp(libjsonnet++_test)
+    add_test(libjsonnet++_test ${GLOBAL_OUTPUT_PATH}/libjsonnet++_test)
+
+endif()


### PR DESCRIPTION
Changes for

* `cmake` to build targets under `cpp/` (`libjsonnet++.so` and tests)
* `make` to build libs in addition to bins by default
* `make install` target to install bins, libs and incs

FYI, I signed a CLA.