### PR TITLE
Properly detect a system GTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,9 +70,13 @@ if (BUILD_TESTS AND NOT USE_SYSTEM_GTEST)
     # Include googletest headers.
     include_directories("${gtest_SOURCE_DIR}/include")
 
+	# Alias the targets to their namespaced versions.
+	add_library(GTest::GTest ALIAS gtest)
+	add_library(GTest::Main ALIAS gtest_main)
+
 elseif (BUILD_TESTS AND USE_SYSTEM_GTEST)
 	enable_testing()
-	add_subdirectory(/usr/src/googletest ${GLOBAL_OUTPUT_PATH}/googletest-build)
+	find_package(GTest REQUIRED)
 endif()
 
 # Compiler flags.

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # libjsonnet
 
-# Remember to update Bazel and Makefile builds when updating this list! 
+# Remember to update Bazel and Makefile builds when updating this list!
 set(LIBJSONNET_HEADERS
     ast.h
     desugarer.h
@@ -66,9 +66,9 @@ function(add_test_executable test_name)
     endif()
     add_executable(${test_name} ${test_name}.${TEST_EXT})
 
-    add_dependencies(${test_name} libjsonnet_static gtest_main)
+    add_dependencies(${test_name} libjsonnet_static GTest::Main)
     target_link_libraries(
-        ${test_name} gtest gtest_main libjsonnet_static)
+        ${test_name} GTest::GTest GTest::Main libjsonnet_static)
 endfunction()
 
 if (BUILD_TESTS)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -39,9 +39,9 @@ function(add_test_executablepp test_name)
     endif()
     add_executable(${test_name} ${test_name}.${TEST_EXT})
 
-    add_dependencies(${test_name} libjsonnet++_static jsonnet gtest_main)
+    add_dependencies(${test_name} libjsonnet++_static jsonnet GTest::Main)
     target_link_libraries(
-        ${test_name} gtest gtest_main libjsonnet++_static libjsonnet_static)
+        ${test_name} GTest::GTest GTest::Main libjsonnet++_static libjsonnet_static)
 endfunction()
 
 if (BUILD_TESTS)


### PR DESCRIPTION
I'm hoping to try making a Fedora COPR package for jsonnet, but right now using a system GTest requires the given hardcoded path. I switched it to use CMake's find_package, which AFAIK should detect GTest on pretty much every distro.