### PR TITLE
Allow use of the system-installed JSON library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ option(BUILD_JSONNET "Build jsonnet command-line tool." ON)
 option(BUILD_JSONNETFMT "Build jsonnetfmt command-line tool." ON)
 option(BUILD_TESTS "Build and run jsonnet tests." ON)
 option(USE_SYSTEM_GTEST "Use system-provided gtest library" OFF)
+option(USE_SYSTEM_JSON "Use the system-provided json library" OFF)
 set(GLOBAL_OUTPUT_PATH_SUFFIX "" CACHE STRING
     "Output artifacts directory.")
 
@@ -79,6 +80,12 @@ elseif (BUILD_TESTS AND USE_SYSTEM_GTEST)
 	find_package(GTest REQUIRED)
 endif()
 
+if(USE_SYSTEM_JSON)
+    find_package(nlohmann_json 3.6.1 REQUIRED)
+else()
+    add_subdirectory(third_party/json)
+endif()
+
 # Compiler flags.
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" OR
         ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
@@ -98,7 +105,6 @@ link_directories(${GLOBAL_OUTPUT_PATH})
 include_directories(
     include
     third_party/md5
-    third_party/json
     core
     cpp)
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -30,7 +30,7 @@ set(LIBJSONNET_SOURCE
 
 add_library(libjsonnet SHARED ${LIBJSONNET_HEADERS} ${LIBJSONNET_SOURCE})
 add_dependencies(libjsonnet md5 stdlib)
-target_link_libraries(libjsonnet md5)
+target_link_libraries(libjsonnet md5 nlohmann_json::nlohmann_json)
 
 file(STRINGS ${CMAKE_SOURCE_DIR}/include/libjsonnet.h JSONNET_VERSION_DEF
      REGEX "[#]define[ \t]+LIB_JSONNET_VERSION[ \t]+")
@@ -52,7 +52,7 @@ install(TARGETS libjsonnet
 # Static library for jsonnet command-line tool.
 add_library(libjsonnet_static STATIC ${LIBJSONNET_SOURCE})
 add_dependencies(libjsonnet_static md5 stdlib)
-target_link_libraries(libjsonnet_static md5)
+target_link_libraries(libjsonnet_static md5 nlohmann_json::nlohmann_json)
 set_target_properties(libjsonnet_static PROPERTIES OUTPUT_NAME jsonnet)
 install(TARGETS libjsonnet_static DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 

--- a/third_party/json/CMakeLists.txt
+++ b/third_party/json/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(nlohmann_json INTERFACE)
+target_include_directories(nlohmann_json INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(nlohmann_json::nlohmann_json ALIAS nlohmann_json)


### PR DESCRIPTION
The version to look for was set to be the same as the one in third_party/json.