### PR TITLE
Add tar of executables to github releases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: generic
+
 matrix:
   include:
     - os: linux
@@ -9,7 +10,7 @@ matrix:
             - g++-4.9
           sources: &sources
             - llvm-toolchain-precise-3.8
-            - ubuntu-toolchain-r-test
+            - ubuntu-toolchain-r-test    
     - os: linux
       env: COMPILER_NAME=clang CXX=clang++-3.8 CC=clang-3.8
       addons:
@@ -23,22 +24,42 @@ matrix:
     - os: osx
       osx_image: xcode8
       env: CC=clang && CXX=clang++
+
 before_install:
   - echo $LANG
   - echo $LC_ALL
   - $CXX --version
-before_script:
+
 script:
-#    - rvm get head  # Workaround 'shell_session_update: command not found'
-    - set -e
-    - make test
-    - python setup.py build
-    - python setup.py test
-    # Test CMake build scripts.
-    - cmake . -Bbuild && cmake --build build --target run_tests
+  #    - rvm get head  # Workaround 'shell_session_update: command not found'
+  - set -e
+  - make test
+  - python setup.py build
+  - python setup.py test
+  # Test CMake build scripts.
+  - cmake . -Bbuild && cmake --build build --target run_tests
+  # make a tarfile for the binaries and rename for os and tag
+  - make dist
+  - mv jsonnet-bin.tar.gz jsonnet-bin-${TRAVIS_TAG}-${TRAVIS_OS_NAME}.tar.gz
+
+deploy:
+  provider: releases
+  api_key: $JSONNET_GITHUB_TOKEN
+  file: jsonnet-bin-${TRAVIS_TAG}-${TRAVIS_OS_NAME}.tar.gz
+  skip_cleanup: true
+  on:
+    tags: true
+    # no point deploying the images built with both compilers
+    condition: $CC =~ gcc
+
 branches:
   only:
     - master
+    # the branch name is the tag name, so having only master means you can't
+    # trigger a build by just push a tag - so add in a regex to match tags that
+    # should trigger. 
+    - /^v.*$/
+
 notifications:
   recipients:
     - sparkprime@gmail.com

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ EMCXXFLAGS = $(CXXFLAGS) -g0 -Os --memory-init-file 0 -s DISABLE_EXCEPTION_CATCH
 EMCFLAGS = $(CFLAGS) --memory-init-file 0 -s DISABLE_EXCEPTION_CATCHING=0 -s ASSERTIONS=1 -s ALLOW_MEMORY_GROWTH=1
 LDFLAGS ?=
 
+
 SHARED_LDFLAGS ?= -shared
 
 VERSION := $(shell grep '\#define.*LIB_JSONNET_VERSION' include/libjsonnet.h | head -n 1 | cut -f 2 -d '"' | sed 's/^v//g' )
@@ -218,8 +219,16 @@ core/%.jsonnet.h: stdlib/%.jsonnet
 		| tr "\n" "," ) && echo "0") > $@
 	echo >> $@
 
+
+RELEASE_FILE = jsonnet-bin.tar.gz
+
+$(RELEASE_FILE): bins
+	tar czf $@ $(BINS)
+
+dist: $(RELEASE_FILE)
+
 clean:
-	rm -vf */*~ *~ .*~ */.*.swp .*.swp $(ALL) *.o core/*.jsonnet.h Makefile.depend *.so.*
+	rm -vf */*~ *~ .*~ */.*.swp .*.swp $(ALL) *.o core/*.jsonnet.h Makefile.depend *.so.* $(RELEASE_FILE)
 
 -include Makefile.depend
 


### PR DESCRIPTION
This gets travis to add 2 tar files containing the two executables to github releases; one for linux and one for mac. I've arbitrarily picked the gcc build binaries, since it seems there's little point in including the ones built with both compilers. 

This should happen anytime a new tag is pushed.

In order to for this to work someone with appropriate permissions needs to create a github personal access token with (at least) the public_repo permission in the github UI, and then add this as a secure environment variable called JSONNET_GITHUB_TOKEN in the project's settings in the travis dashboard.