### PR TITLE
Fix disparities between actual and documented stdlib params

### DIFF
--- a/doc/ref/stdlib.html
+++ b/doc/ref/stdlib.html
@@ -18,15 +18,15 @@ title: Standard Library
       <p>
         This page describes the functions available in Jsonnet's standard library, i.e. the object
         implicitly bound to the <code>std</code> variable. Some of the standard library functions
-        can be implemented in Jsonnet.  Their code can be found in the <tt>std.jsonnet</tt> file.
+        can be implemented in Jsonnet. Their code can be found in the <tt>std.jsonnet</tt> file.
         The behavior of some of the other functions, i.e. the ones that expose extra functionality
         not otherwise available to programmers, is described formally in the <a
-        href="/language/spec.html">specification</a>.
+          href="/language/spec.html">specification</a>.
       </p>
       <p>
         The standard library is implicitly added to all Jsonnet programs by enclosing them in a
-        local construct.  For example, if the program given by the user is <code>{x: "foo"}</code>,
-        then the actual code executed would be <code>local std = { ... }; {x: "foo"}</code>.  The
+        local construct. For example, if the program given by the user is <code>{x: "foo"}</code>,
+        then the actual code executed would be <code>local std = { ... }; {x: "foo"}</code>. The
         functions in the standard library are all hidden fields of the <code>std</code> object.
       </p>
     </div>
@@ -90,7 +90,7 @@ title: Standard Library
       <p>
         Note that this is a field. It contains the current Jsonnet filename as a string.
       </p>
-    <div style="clear: both"></div>
+      <div style="clear: both"></div>
     </div>
   </div>
 </div>
@@ -109,7 +109,7 @@ title: Standard Library
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Return a string that indicates the type of the value.  The possible return values are:
+        Return a string that indicates the type of the value. The possible return values are:
         "array", "boolean", "function", "null", "number", "object", and "string".
       </p>
       <p>
@@ -139,7 +139,7 @@ title: Standard Library
       <p>
         Depending on the type of the value given, either returns the number of elements in the
         array, the number of codepoints in the string, the number of parameters in the function, or
-        the number of fields in the object.  Raises an error if given a primitive value, i.e.
+        the number of fields in the object. Raises an error if given a primitive value, i.e.
         <code>null</code>, <code>true</code> or <code>false</code>.
       </p>
     </div>
@@ -162,8 +162,8 @@ title: Standard Library
     <div class="panel">
       <p>
         Returns <code>true</code> if the given object has the field (given as a string), otherwise
-        <code>false</code>.  Raises an error if the arguments are not object and string
-        respectively.  Returns false if the field is hidden.
+        <code>false</code>. Raises an error if the arguments are not object and string
+        respectively. Returns false if the field is hidden.
       </p>
     </div>
     <div style="clear: both"></div>
@@ -184,8 +184,8 @@ title: Standard Library
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Returns an array of strings, each element being a field from the given object.  Does not include
-      hidden fields.
+        Returns an array of strings, each element being a field from the given object. Does not include
+        hidden fields.
       </p>
     </div>
     <div style="clear: both"></div>
@@ -234,7 +234,7 @@ title: Standard Library
 <div class="hgroup">
   <div class="hgroup-inline">
     <div class="panel">
-      <h4 id="prune">std.prune(x)</h4>
+      <h4 id="prune">std.prune(a)</h4>
     </div>
     <div style="clear: both"></div>
   </div>
@@ -244,8 +244,9 @@ title: Standard Library
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Recursively remove all "empty" members of `x`.  "Empty" is defined as zero
-      length `arrays`, zero length `objects`, or `null` values.
+        Recursively remove all "empty" members of <code>a</code>. "Empty" is defined as zero
+        length `arrays`, zero length `objects`, or `null` values.
+        The argument <code>a</code> may have any type.
       </p>
     </div>
     <div style="clear: both"></div>
@@ -313,7 +314,7 @@ title: Standard Library
         <ul><code>std.atan(x)</code></ul>
       </ul>
       <p>
-        The function <code>std.mod(a, b)</code> is what the % operator is desugared to.  It performs
+        The function <code>std.mod(a, b)</code> is what the % operator is desugared to. It performs
         modulo arithmetic if the left hand side is a number, or if the left hand side is a string,
         it does Python-style string formatting with <code>std.format()</code>.
       </p>
@@ -345,7 +346,7 @@ title: Standard Library
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Ensure that <code>a == b</code>.  Returns <code>true</code> or throws an error message.
+        Ensure that <code>a == b</code>. Returns <code>true</code> or throws an error message.
       </p>
     </div>
     <div style="clear: both"></div>
@@ -395,7 +396,7 @@ title: Standard Library
     <div class="panel">
       <p>
         Returns the positive integer representing the unicode codepoint of the character in the
-        given single-character string.  This function is the inverse of <code>std.char(n)</code>.
+        given single-character string. This function is the inverse of <code>std.char(n)</code>.
       </p>
     </div>
     <div style="clear: both"></div>
@@ -428,7 +429,7 @@ title: Standard Library
 <div class="hgroup">
   <div class="hgroup-inline">
     <div class="panel">
-      <h4 id="substr">std.substr(s, from, len)</h4>
+      <h4 id="substr">std.substr(str, from, len)</h4>
     </div>
     <div style="clear: both"></div>
   </div>
@@ -550,7 +551,7 @@ title: Standard Library
     <div class="panel">
       <p>
         As std.split(str, c) but will stop after <code>maxsplits</code> splits, thereby the largest
-        array it will return has length <code>maxsplits + 1</code>.  A limit of -1 means unlimited.
+        array it will return has length <code>maxsplits + 1</code>. A limit of -1 means unlimited.
       </p>
       <p>
         Example: <code>std.splitLimit("foo/bar", "/", 1)</code> yields <code>["foo", "bar"]</code>.
@@ -668,11 +669,11 @@ title: Standard Library
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Format the string <code>str</code> using the values in <code>vals</code>.  The values can be
+        Format the string <code>str</code> using the values in <code>vals</code>. The values can be
         an array, an object, or in other cases are treated as if they were provided in a singleton
-        array.  The string formatting follows the <a
-        href="https://docs.python.org/2/library/stdtypes.html#string-formatting">same rules</a> as
-        Python.  The <code>%</code> operator can be used as a shorthand for this function.
+        array. The string formatting follows the <a
+          href="https://docs.python.org/2/library/stdtypes.html#string-formatting">same rules</a> as
+        Python. The <code>%</code> operator can be used as a shorthand for this function.
       </p>
       <p>
         Example: <code>std.format("Hello %03d", 12)</code> yields <code>"Hello 012"</code>.
@@ -708,7 +709,7 @@ title: Standard Library
     <div class="panel">
       <p>
         Wrap <code>str</code> in single quotes, and escape any single quotes within <code>str</code>
-        by changing them to a sequence <tt>'"'"'</tt>.  This allows injection of arbitrary strings
+        by changing them to a sequence <tt>'"'"'</tt>. This allows injection of arbitrary strings
         as arguments of commands in bash scripts.
       </p>
     </div>
@@ -730,7 +731,7 @@ title: Standard Library
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Convert $ to $$ in <code>str</code>.  This allows injection of arbitrary strings into
+        Convert $ to $$ in <code>str</code>. This allows injection of arbitrary strings into
         systems that use $ for string interpolation (like Terraform).
       </p>
     </div>
@@ -753,7 +754,7 @@ title: Standard Library
     <div class="panel">
       <p>
         Convert <code>str</code> to allow it to be embedded in a JSON representation, within a
-        string.  This adds quotes, escapes backslashes, and escapes unprintable characters.
+        string. This adds quotes, escapes backslashes, and escapes unprintable characters.
       </p>
       <p>
         Example:<br />
@@ -782,7 +783,7 @@ title: Standard Library
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Convert <code>str</code> to allow it to be embedded in Python.  This is an alias for
+        Convert <code>str</code> to allow it to be embedded in Python. This is an alias for
         std.escapeStringJson.
       </p>
     </div>
@@ -853,7 +854,7 @@ title: Standard Library
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Parses an unsigned hexadecimal integer, from the input string.  Case insensitive.
+        Parses an unsigned hexadecimal integer, from the input string. Case insensitive.
       </p>
       <p>Example: <code>std.parseHex("ff")</code> yields <code>255</code>.</p>
     </div>
@@ -881,7 +882,8 @@ title: Standard Library
       <h4 id="encodeUTF8">std.encodeUTF8(str)</h4>
       <em>Available since version 0.13.0</em>
       <p>
-        Encode a string using <a href="https://en.wikipedia.org/wiki/UTF-8">UTF8</a>. Returns an array of numbers representing bytes.
+        Encode a string using <a href="https://en.wikipedia.org/wiki/UTF-8">UTF8</a>. Returns an array of numbers
+        representing bytes.
       </p>
     </div>
     <div style="clear: both"></div>
@@ -902,7 +904,8 @@ title: Standard Library
     <div class="panel">
       <em>Available since version 0.13.0</em>
       <p>
-        Decode an array of numbers representing bytes using <a href="https://en.wikipedia.org/wiki/UTF-8">UTF8</a>. Returns a string.
+        Decode an array of numbers representing bytes using <a href="https://en.wikipedia.org/wiki/UTF-8">UTF8</a>.
+        Returns a string.
       </p>
     </div>
     <div style="clear: both"></div>
@@ -921,7 +924,7 @@ title: Standard Library
 <div class="hgroup">
   <div class="hgroup-inline">
     <div class="panel">
-      <h4 id="manifestIni">std.manifestIni(v)</h4>
+      <h4 id="manifestIni">std.manifestIni(ini)</h4>
     </div>
     <div style="clear: both"></div>
   </div>
@@ -931,10 +934,10 @@ title: Standard Library
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Convert the given structure to a string in <a
-        href="http://en.wikipedia.org/wiki/INI_file">INI format</a>.  This allows using Jsonnet's
+        Convert the given structure to a string in <a href="http://en.wikipedia.org/wiki/INI_file">INI format</a>. This
+        allows using Jsonnet's
         object model to build a configuration to be consumed by an application expecting an INI
-        file.  The data is in the form of a set of sections, each containing a key/value mapping.
+        file. The data is in the form of a set of sections, each containing a key/value mapping.
         These examples should make it clear:
       </p>
 
@@ -981,7 +984,7 @@ q = </pre>
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Convert the given value to a JSON-like form that is compatible with Python.  The chief
+        Convert the given value to a JSON-like form that is compatible with Python. The chief
         differences are True / False / None instead of true / false / null.
       </p>
 
@@ -1011,7 +1014,7 @@ q = </pre>
 <div class="hgroup">
   <div class="hgroup-inline">
     <div class="panel">
-      <h4 id="manifestPythonVars">std.manifestPythonVars(v)</h4>
+      <h4 id="manifestPythonVars">std.manifestPythonVars(conf)</h4>
     </div>
     <div style="clear: both"></div>
   </div>
@@ -1021,7 +1024,7 @@ q = </pre>
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Convert the given object to a JSON-like form that is compatible with Python.  The key
+        Convert the given object to a JSON-like form that is compatible with Python. The key
         difference to <code>std.manifestPython</code> is that the top level is represented as a list
         of Python global variables.
       </p>
@@ -1061,7 +1064,7 @@ e = {"f1": False, "f2": 42}</pre>
     <div class="panel">
       <p>
         Convert the given object to a JSON form. <code>indent</code> is a string containing
-      one or more whitespaces that are used for indentation:
+        one or more whitespaces that are used for indentation:
       </p>
       <pre>std.manifestJsonEx(
 {
@@ -1108,8 +1111,8 @@ e = {"f1": False, "f2": 42}</pre>
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Convert the given value to a YAML form.  Note that <code>std.manifestJson</code> could also
-        be used for this purpose, because any JSON is also valid YAML.  But this function will
+        Convert the given value to a YAML form. Note that <code>std.manifestJson</code> could also
+        be used for this purpose, because any JSON is also valid YAML. But this function will
         produce more canonical-looking YAML.
       </p>
 
@@ -1141,7 +1144,7 @@ e = {"f1": False, "f2": 42}</pre>
     - 2</pre>
 
       <p>The <code>indent_array_in_object</code> param adds additional indentation which some people
-      may find easier to read.</p>
+        may find easier to read.</p>
 
     </div>
     <div style="clear: both"></div>
@@ -1234,8 +1237,8 @@ e = {"f1": False, "f2": 42}</pre>
       </svg>
       <p>
         JsonML is designed to preserve "mixed-mode content" (i.e., textual data outside of or next
-        to elements).  This includes the whitespace needed to avoid having all the XML on one line,
-        which is meaningful in XML.  In order to have whitespace in the XML output, it must be
+        to elements). This includes the whitespace needed to avoid having all the XML on one line,
+        which is meaningful in XML. In order to have whitespace in the XML output, it must be
         present in the JsonML input:
       </p>
       <pre>std.manifestXmlJsonml([
@@ -1280,7 +1283,7 @@ e = {"f1": False, "f2": 42}</pre>
     <div class="panel">
       <p>
         Create a new array of <code>sz</code> elements by calling <code>func(i)</code> to initialize
-        each element.  Func is expected to be a function that takes a single parameter, the index of
+        each element. Func is expected to be a function that takes a single parameter, the index of
         the element it should initialize.
       </p>
       <p>
@@ -1388,7 +1391,7 @@ e = {"f1": False, "f2": 42}</pre>
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        This is primarily used to desugar array comprehension syntax.  It first filters, then maps
+        This is primarily used to desugar array comprehension syntax. It first filters, then maps
         the given array, using the two functions provided.
       </p>
     </div>
@@ -1432,8 +1435,8 @@ e = {"f1": False, "f2": 42}</pre>
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Classic foldl function.  Calls the function on the result of the previous function call and
-        each array element, or <code>init</code> in the case of the initial element.  Traverses the
+        Classic foldl function. Calls the function on the result of the previous function call and
+        each array element, or <code>init</code> in the case of the initial element. Traverses the
         array from left to right.
       </p>
     </div>
@@ -1455,8 +1458,8 @@ e = {"f1": False, "f2": 42}</pre>
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Classic foldl function.  Calls the function on each array element and the result of the
-        previous function call, or <code>init</code> in the case of the initial element.  Traverses
+        Classic foldl function. Calls the function on each array element and the result of the
+        previous function call, or <code>init</code> in the case of the initial element. Traverses
         the array from right to left.
       </p>
     </div>
@@ -1498,7 +1501,7 @@ e = {"f1": False, "f2": 42}</pre>
     <div class="panel">
       <p>
         If <code>sep</code> is a string, then <code>arr</code> must be an array of strings, in which
-        case they are concatenated with <code>sep</code> used as a delimiter.  If <code>sep</code>
+        case they are concatenated with <code>sep</code> used as a delimiter. If <code>sep</code>
         is an array, then <code>arr</code> must be an array of arrays, in which case the arrays are
         concatenated in the same way, to produce a single array.
       </p>
@@ -1551,7 +1554,8 @@ e = {"f1": False, "f2": 42}</pre>
     <div class="panel">
       <p>Concatenate an array of arrays into a single array.</p>
       <p>
-        Example: <code>std.flattenArrays([[1, 2], [3, 4], [[5, 6], [7, 8]]])</code> yields <code>[1, 2, 3, 4, [5, 6], [7, 8]]</code>.
+        Example: <code>std.flattenArrays([[1, 2], [3, 4], [[5, 6], [7, 8]]])</code> yields
+        <code>[1, 2, 3, 4, [5, 6], [7, 8]]</code>.
       </p>
     </div>
     <div style="clear: both"></div>
@@ -1591,8 +1595,9 @@ e = {"f1": False, "f2": 42}</pre>
   <div class="hgroup-inline">
     <div class="panel">
       <p>Sorts the array using the <= operator.</p>
-      <p>Optional argument <code>keyF</code> is a single argument function used to extract comparison
-         key from each list element. Default value is identity function <code>keyF=function(x) x</code>.
+      <p>
+        Optional argument <code>keyF</code> is a single argument function used to extract comparison key from each array element.
+        Default value is identity function <code>keyF=function(x) x</code>.
       </p>
     </div>
     <div style="clear: both"></div>
@@ -1603,7 +1608,7 @@ e = {"f1": False, "f2": 42}</pre>
 <div class="hgroup">
   <div class="hgroup-inline">
     <div class="panel">
-      <h4 id="uniq">std.uniq(arr)</h4>
+      <h4 id="uniq">std.uniq(arr, keyF=id)</h4>
     </div>
     <div style="clear: both"></div>
   </div>
@@ -1612,7 +1617,11 @@ e = {"f1": False, "f2": 42}</pre>
 <div class="hgroup">
   <div class="hgroup-inline">
     <div class="panel">
-      <p>Removes successive duplicates.  When given a sorted array, removes all duplicates.</p>
+      <p>Removes successive duplicates. When given a sorted array, removes all duplicates.</p>
+      <p>
+        Optional argument <code>keyF</code> is a single argument function used to extract comparison key from each array element.
+        Default value is identity function <code>keyF=function(x) x</code>.
+      </p>
     </div>
     <div style="clear: both"></div>
   </div>
@@ -1699,7 +1708,8 @@ e = {"f1": False, "f2": 42}</pre>
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Set union operation (values in any of <code>a</code> or <code>b</code>).  Note that + on sets will simply concatenate
+        Set union operation (values in any of <code>a</code> or <code>b</code>). Note that + on sets will simply
+        concatenate
         the arrays, possibly forming an array that is not a set (due to not being ordered without
         duplicates).
       </p>
@@ -1708,7 +1718,8 @@ e = {"f1": False, "f2": 42}</pre>
         <code>[1, 2, 3]</code>.
       </p>
       <p>
-        Example2: <code>std.setUnion([{n:"A", v:1}, {n:"B"}], [{n:"A", v: 9999}, {n:"C"}],keyF=function(x) x.n)</code> yields
+        Example2: <code>std.setUnion([{n:"A", v:1}, {n:"B"}], [{n:"A", v: 9999}, {n:"C"}],keyF=function(x) x.n)</code>
+        yields
         <code>[{n: "A", v:1}, {n: "B"}, {n: "C"}]</code>.
       </p>
     </div>
@@ -1767,7 +1778,7 @@ e = {"f1": False, "f2": 42}</pre>
 <div class="hgroup">
   <div class="hgroup-inline">
     <div class="panel">
-      <h4 id="base64">std.base64(v)</h4>
+      <h4 id="base64">std.base64(input)</h4>
     </div>
     <div style="clear: both"></div>
   </div>
@@ -1777,9 +1788,10 @@ e = {"f1": False, "f2": 42}</pre>
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Encodes the given value into a base64 string.  The encoding sequence is <code>A-Za-z0-9+/</code> with <code>=</code>
-        to pad the output to a multiple of 4 characters.  The value can be a string or an array of
-        numbers, but the codepoints / numbers must be in the 0 to 255 range.  The resulting string
+        Encodes the given value into a base64 string. The encoding sequence is <code>A-Za-z0-9+/</code> with
+        <code>=</code>
+        to pad the output to a multiple of 4 characters. The value can be a string or an array of
+        numbers, but the codepoints / numbers must be in the 0 to 255 range. The resulting string
         has no line breaks.
       </p>
     </div>
@@ -1791,7 +1803,7 @@ e = {"f1": False, "f2": 42}</pre>
 <div class="hgroup">
   <div class="hgroup-inline">
     <div class="panel">
-      <h4 id="base64DecodeBytes">std.base64DecodeBytes(s)</h4>
+      <h4 id="base64DecodeBytes">std.base64DecodeBytes(str)</h4>
     </div>
     <div style="clear: both"></div>
   </div>
@@ -1801,7 +1813,7 @@ e = {"f1": False, "f2": 42}</pre>
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Decodes the given base64 string into an array of bytes (number values).  Currently assumes
+        Decodes the given base64 string into an array of bytes (number values). Currently assumes
         the input string has no linebreaks and is padded to a multiple of 4 (with the = character).
         In other words, it consumes the output of std.base64().
       </p>
@@ -1814,7 +1826,7 @@ e = {"f1": False, "f2": 42}</pre>
 <div class="hgroup">
   <div class="hgroup-inline">
     <div class="panel">
-      <h4 id="base64Decode">std.base64Decode(s)</h4>
+      <h4 id="base64Decode">std.base64Decode(str)</h4>
     </div>
     <div style="clear: both"></div>
   </div>
@@ -1823,8 +1835,9 @@ e = {"f1": False, "f2": 42}</pre>
 <div class="hgroup">
   <div class="hgroup-inline">
     <div class="panel">
+      <em>Deprecated, use <code>std.base64DecodeBytes and decode the string explicitly (e.g. with <code>std.decodeUTF8</code>) instead.</code></em>
       <p>
-        Behaves like std.base64DecodeBytes() except returns a string instead of an array of bytes.
+        Behaves like std.base64DecodeBytes() except returns a naively encoded string instead of an array of bytes.
       </p>
     </div>
     <div style="clear: both"></div>
@@ -1874,7 +1887,7 @@ e = {"f1": False, "f2": 42}</pre>
     <div class="panel">
       <p>
         Applies <code>patch</code> to <code>target</code> according to <a
-        href="https://tools.ietf.org/html/rfc7396">RFC7396</a>
+          href="https://tools.ietf.org/html/rfc7396">RFC7396</a>
       </p>
     </div>
     <div style="clear: both"></div>
@@ -1909,7 +1922,7 @@ e = {"f1": False, "f2": 42}</pre>
       <em>Available since version 0.11.0</em>
       <p>Example:</p>
       <p>
-      <pre>local conditionalReturn(cond, in1, in2) =
+        <pre>local conditionalReturn(cond, in1, in2) =
     if (cond) then
         std.trace('cond is true returning '
                   + std.toString(in1), in1)
@@ -1924,7 +1937,7 @@ e = {"f1": False, "f2": 42}</pre>
       </p>
       <p>Prints:</p>
       <p>
-      <pre>TRACE: test.jsonnet:3 cond is true returning {"b": true}
+        <pre>TRACE: test.jsonnet:3 cond is true returning {"b": true}
 {
    "a": {
       "b": true

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -160,21 +160,21 @@ limitations under the License.
     else
       replace_after(0, 0, ''),
 
-  asciiUpper(x)::
+  asciiUpper(str)::
     local cp = std.codepoint;
     local up_letter(c) = if cp(c) >= 97 && cp(c) < 123 then
       std.char(cp(c) - 32)
     else
       c;
-    std.join('', std.map(up_letter, std.stringChars(x))),
+    std.join('', std.map(up_letter, std.stringChars(str))),
 
-  asciiLower(x)::
+  asciiLower(str)::
     local cp = std.codepoint;
     local down_letter(c) = if cp(c) >= 65 && cp(c) < 91 then
       std.char(cp(c) + 32)
     else
       c;
-    std.join('', std.map(down_letter, std.stringChars(x))),
+    std.join('', std.map(down_letter, std.stringChars(str))),
 
 
   range(from, to)::
@@ -1018,26 +1018,26 @@ limitations under the License.
       ) + if c_document_end then '\n...\n' else '\n',
 
 
-  manifestPython(o)::
-    if std.type(o) == 'object' then
+  manifestPython(v)::
+    if std.type(v) == 'object' then
       local fields = [
-        '%s: %s' % [std.escapeStringPython(k), std.manifestPython(o[k])]
-        for k in std.objectFields(o)
+        '%s: %s' % [std.escapeStringPython(k), std.manifestPython(v[k])]
+        for k in std.objectFields(v)
       ];
       '{%s}' % [std.join(', ', fields)]
-    else if std.type(o) == 'array' then
-      '[%s]' % [std.join(', ', [std.manifestPython(o2) for o2 in o])]
-    else if std.type(o) == 'string' then
-      '%s' % [std.escapeStringPython(o)]
-    else if std.type(o) == 'function' then
+    else if std.type(v) == 'array' then
+      '[%s]' % [std.join(', ', [std.manifestPython(v2) for v2 in v])]
+    else if std.type(v) == 'string' then
+      '%s' % [std.escapeStringPython(v)]
+    else if std.type(v) == 'function' then
       error 'cannot manifest function'
-    else if std.type(o) == 'number' then
-      std.toString(o)
-    else if o == true then
+    else if std.type(v) == 'number' then
+      std.toString(v)
+    else if v == true then
       'True'
-    else if o == false then
+    else if v == false then
       'False'
-    else if o == null then
+    else if v == null then
       'None',
 
   manifestPythonVars(conf)::


### PR DESCRIPTION
During the work on the linter I started verifying the parameters of stdlib functions (it's something that linter will complain about, so I'm preparing the tests to make sure it's in sync with reality). I'm about 80% done with that test, so perhaps a few more things like that will appear. A side effect of this effort is this change. I found one missing optional argument (keyF for uniq) and a whole bunch of name mismatches. I fixed it in the documentation by default (less likely to introduce bugs or break someone's code) - unless the name in the code was actually worse, then I changed it in the code.

My editor automatically reformatted the stdlib.html file before I noticed. I may reverse that part if you don't want it here. IMO these changes seem reasonable so I didn't go out of my way to remove them so far. 