### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ brew install jsonnet
 
 ## Building Jsonnet
 
+You can download and install Jsonnet using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install jsonnet
+
+The Jsonnet port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 You can use either GCC or Clang to build Jsonnet. Note that on recent versions
 of macOS, `/usr/bin/gcc` and `/usr/bin/g++` are actually Clang, so there is no
 difference.


### PR DESCRIPTION
Jsonnet is available as a port in vcpkg. Adding installation instructions will help users get started by providing a set of commands they can use to build Jsonnet and include it into their projects