### PR TITLE
fix dangling pointer warning

### DIFF
--- a/cmd/jsonnet.cpp
+++ b/cmd/jsonnet.cpp
@@ -295,15 +295,15 @@ static ArgStatus process_args(int argc, const char **argv, JsonnetConfig *config
             }
             jsonnet_max_trace(vm, l);
         } else if (arg == "--gc-growth-trigger") {
-            const char *arg = next_arg(i, args).c_str();
+            std::string num = next_arg(i, args);
             char *ep;
-            double v = std::strtod(arg, &ep);
-            if (*ep != '\0' || *arg == '\0') {
-                std::cerr << "ERROR: invalid number \"" << arg << "\"" << std::endl;
+            double v = std::strtod(num.c_str(), &ep);
+            if (*ep != '\0' || num.length() == 0) {
+                std::cerr << "ERROR: invalid number \"" << num << "\"" << std::endl;
                 return ARG_FAILURE;
             }
             if (v < 0) {
-                std::cerr << "ERROR: invalid --gc-growth-trigger \"" << arg << "\""
+                std::cerr << "ERROR: invalid --gc-growth-trigger \"" << num << "\""
                             << std::endl;
                 return ARG_FAILURE;
             }


### PR DESCRIPTION
fixes:
```
external/jsonnet/cmd/jsonnet.cpp:298:31: warning: object backing the pointer will be destroyed at the end of the full-expression [-Wdangling-gsl]
            const char *arg = next_arg(i, args).c_str();
                              ^~~~~~~~~~~~~~~~~
```
(I think, admittedly untested)
seen when compiling with bazel for https://github.com/kubernetes/test-infra