### PR TITLE
Redact stdlib line numbers in tests

### DIFF
--- a/test_suite/error.equality_function.jsonnet.golden
+++ b/test_suite/error.equality_function.jsonnet.golden
@@ -1,3 +1,3 @@
 RUNTIME ERROR: cannot test equality of functions
-	std.jsonnet:1313:9-34	function <anonymous>
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
 	error.equality_function.jsonnet:17:1-33	

--- a/test_suite/error.format.too_few_values.jsonnet.golden
+++ b/test_suite/error.format.too_few_values.jsonnet.golden
@@ -1,22 +1,22 @@
 RUNTIME ERROR: Not enough values to format: 1, expected more than 1
-	std.jsonnet:690:15-103	thunk <val>
-	std.jsonnet:695:27-30	thunk <val>
-	std.jsonnet:567:21-24	
-	std.jsonnet:567:12-25	thunk <a>
-	std.jsonnet:567:12-37	function <anonymous>
-	std.jsonnet:567:12-37	function <format_code>
-	std.jsonnet:695:15-60	thunk <s>
-	std.jsonnet:700:24	thunk <str>
-	std.jsonnet:475:30-33	
-	std.jsonnet:475:19-34	thunk <w>
+	std.jsonnet:<stdlib_position_redacted>	thunk <val>
+	std.jsonnet:<stdlib_position_redacted>	thunk <val>
+	std.jsonnet:<stdlib_position_redacted>	
+	std.jsonnet:<stdlib_position_redacted>	thunk <a>
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
+	std.jsonnet:<stdlib_position_redacted>	function <format_code>
+	std.jsonnet:<stdlib_position_redacted>	thunk <s>
+	std.jsonnet:<stdlib_position_redacted>	thunk <str>
+	std.jsonnet:<stdlib_position_redacted>	
+	std.jsonnet:<stdlib_position_redacted>	thunk <w>
 	...
-	std.jsonnet:467:12	function <aux>
-	std.jsonnet:471:7-17	function <padding>
-	std.jsonnet:475:7-38	function <pad_left>
-	std.jsonnet:700:15-39	thunk <s_padded>
-	std.jsonnet:706:55-63	thunk <v>
-	std.jsonnet:706:11-64	function <format_codes_arr>
-	std.jsonnet:706:11-64	function <format_codes_arr>
-	std.jsonnet:750:7-46	function <anonymous>
-	std.jsonnet:227:7-23	function <anonymous>
+	std.jsonnet:<stdlib_position_redacted>	function <aux>
+	std.jsonnet:<stdlib_position_redacted>	function <padding>
+	std.jsonnet:<stdlib_position_redacted>	function <pad_left>
+	std.jsonnet:<stdlib_position_redacted>	thunk <s_padded>
+	std.jsonnet:<stdlib_position_redacted>	thunk <v>
+	std.jsonnet:<stdlib_position_redacted>	function <format_codes_arr>
+	std.jsonnet:<stdlib_position_redacted>	function <format_codes_arr>
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
 	error.format.too_few_values.jsonnet:1:1-18	

--- a/test_suite/error.inside_equals_array.jsonnet.golden
+++ b/test_suite/error.inside_equals_array.jsonnet.golden
@@ -1,7 +1,7 @@
 RUNTIME ERROR: foobar
 	error.inside_equals_array.jsonnet:18:18-32	thunk <array_element>
-	std.jsonnet:1293:29-33	thunk <b>
-	std.jsonnet:1293:21-33	function <anonymous>
-	std.jsonnet:1293:21-33	function <aux>
-	std.jsonnet:1296:15-31	function <anonymous>
-	std.jsonnet:1297:11-23	
+	std.jsonnet:<stdlib_position_redacted>	thunk <b>
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
+	std.jsonnet:<stdlib_position_redacted>	function <aux>
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
+	std.jsonnet:<stdlib_position_redacted>	

--- a/test_suite/error.inside_equals_object.jsonnet.golden
+++ b/test_suite/error.inside_equals_object.jsonnet.golden
@@ -1,7 +1,7 @@
 RUNTIME ERROR: foobar
 	error.inside_equals_object.jsonnet:18:22-36	object <b>
-	std.jsonnet:1307:50-54	thunk <b>
-	std.jsonnet:1307:42-54	function <anonymous>
-	std.jsonnet:1307:42-54	function <aux>
-	std.jsonnet:1310:15-31	function <anonymous>
-	std.jsonnet:1311:11-23	
+	std.jsonnet:<stdlib_position_redacted>	thunk <b>
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
+	std.jsonnet:<stdlib_position_redacted>	function <aux>
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
+	std.jsonnet:<stdlib_position_redacted>	

--- a/test_suite/error.invariant.equality.jsonnet.golden
+++ b/test_suite/error.invariant.equality.jsonnet.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: Object assertion failed.
 	error.invariant.equality.jsonnet:17:10-15	thunk <object_assert>
-	std.jsonnet:1307:42-46	thunk <a>
-	std.jsonnet:1307:42-54	function <anonymous>
-	std.jsonnet:1307:42-54	function <anonymous>
-	std.jsonnet:1311:11-23	
+	std.jsonnet:<stdlib_position_redacted>	thunk <a>
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
+	std.jsonnet:<stdlib_position_redacted>	

--- a/test_suite/error.obj_assert.fail1.jsonnet.golden
+++ b/test_suite/error.obj_assert.fail1.jsonnet.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: Object assertion failed.
 	error.obj_assert.fail1.jsonnet:20:23-29	thunk <object_assert>
-	std.jsonnet:1307:42-46	thunk <a>
-	std.jsonnet:1307:42-54	function <anonymous>
-	std.jsonnet:1307:42-54	function <anonymous>
-	std.jsonnet:1311:11-23	
+	std.jsonnet:<stdlib_position_redacted>	thunk <a>
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
+	std.jsonnet:<stdlib_position_redacted>	

--- a/test_suite/error.obj_assert.fail2.jsonnet.golden
+++ b/test_suite/error.obj_assert.fail2.jsonnet.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: foo was not equal to bar
 	error.obj_assert.fail2.jsonnet:20:32-65	thunk <object_assert>
-	std.jsonnet:1307:42-46	thunk <a>
-	std.jsonnet:1307:42-54	function <anonymous>
-	std.jsonnet:1307:42-54	function <anonymous>
-	std.jsonnet:1311:11-23	
+	std.jsonnet:<stdlib_position_redacted>	thunk <a>
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
+	std.jsonnet:<stdlib_position_redacted>	

--- a/test_suite/error.sanity.jsonnet.golden
+++ b/test_suite/error.sanity.jsonnet.golden
@@ -1,3 +1,3 @@
 RUNTIME ERROR: Assertion failed. 1 != 2
-	std.jsonnet:787:7-50	function <anonymous>
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
 	error.sanity.jsonnet:17:1-22	

--- a/test_suite/refresh_golden.sh
+++ b/test_suite/refresh_golden.sh
@@ -49,7 +49,7 @@ for FILE in "$@" ; do
     JSONNET_CMD="$JSONNET_BIN $PARAMS $EXT_PARAMS $TLA_PARAMS"
 
     # Avoid set -e terminating us if the run fails.
-    eval "$JSONNET_CMD" "$FILE" > "${FILE}.golden" 2>&1 || true
+    eval "$JSONNET_CMD" "$FILE" 2>&1 | postprocess_output > "${FILE}.golden"  || true
 
 done
 

--- a/test_suite/tests.source
+++ b/test_suite/tests.source
@@ -53,6 +53,12 @@ deinit() {
     remove_temp_dir
 }
 
+postprocess_output() {
+    # Redact stdlib line numbers - otherwise many error tests need to change with every stdlib change
+    # TODO(sbarzowski) Consider moving noise-reducing functionality to Jsonnet interpreter
+    sed 's/	std\.jsonnet:[0-9]*:[0-9-]*/	std.jsonnet:<stdlib_position_redacted>/'
+}
+
 test_eval() {
     JSONNET_CMD="$1"
     JSONNET_FILE="$2"
@@ -66,6 +72,7 @@ test_eval() {
     TEST_CMD="$JSONNET_CMD $JSONNET_FILE"
     TEST_OUTPUT="$(eval $TEST_CMD 2>&1)"
     TEST_EXIT_CODE="$?"
+    TEST_OUTPUT="$(echo "$TEST_OUTPUT" | postprocess_output)"
     EXECUTED=$((EXECUTED + 1))
 
     if [ "$TEST_EXIT_CODE" -ne "$EXPECTED_EXIT_CODE" ] ; then


### PR DESCRIPTION
Before this change, every time stdlib was modified
a bunch of tests would need to be updated, because
some line numbers in stack traces changed.

It may not be the most elegant way to do it, but
it is simple and I grew tired of fixing the tests
every time - also the noise makes it harder to spot
genuine changes to the Jsonnet output.