### PR TITLE
Add windows build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,11 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" OR
     set(OPT "-O3")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -pedantic -std=c99 -O3 ${OPT}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra -Woverloaded-virtual -pedantic -std=c++11 -fPIC ${OPT}")
+elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
+    #set(OPT "-O3")
+    #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -pedantic -std=c99 -O3 ${OPT}")
+    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra -Woverloaded-virtual -pedantic -std=c++11 -fPIC ${OPT}")
 else()
-    # TODO: Windows support.
     message(FATAL_ERROR "Compiler ${CMAKE_CXX_COMPILER_ID} not supported")
 endif()
 

--- a/setup.py
+++ b/setup.py
@@ -11,28 +11,42 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import print_function
 
+import errno
 import os
-from setuptools import setup
+import subprocess
+from io import open
+
 from setuptools import Extension
-from setuptools.command.build_ext import build_ext as BuildExt
-from subprocess import Popen
+from setuptools import setup
+from setuptools.command.build_ext import build_ext
 
 DIR = os.path.abspath(os.path.dirname(__file__))
-LIB_OBJECTS = [
-    'core/desugarer.o',
-    'core/formatter.o',
-    'core/libjsonnet.o',
-    'core/lexer.o',
-    'core/parser.o',
-    'core/pass.o',
-    'core/static_analysis.o',
-    'core/string_utils.o',
-    'core/vm.o',
-    'third_party/md5/md5.o'
-]
 
-MODULE_SOURCES = ['python/_jsonnet.c']
+
+def to_c_array(in_file, out_file):
+    """
+    Python port of stdlib/to_c_array.cpp
+    """
+    first_character = True
+
+    with open(out_file, 'wb') as out:
+        with open(in_file, 'rb') as i:
+            while True:
+                ba = i.read(1)
+                if not ba:
+                    break
+                b = ba[0]
+                if not isinstance(b, int):
+                    b = ord(b)
+                if first_character:
+                    first_character = False;
+                else:
+                    out.write(b',')
+                out.write(str(b).encode())
+        out.write(b",0")
+
 
 def get_version():
     """
@@ -46,19 +60,136 @@ def get_version():
                     v_code = v_code[1:]
                 return v_code
 
-class BuildJsonnetExt(BuildExt):
-    def run(self):
-        p = Popen(['make'] + LIB_OBJECTS, cwd=DIR)
-        p.wait()
-        if p.returncode != 0:
-            raise Exception('Could not build %s' % (', '.join(LIB_OBJECTS)))
-        BuildExt.run(self)
+
+def get_cpp_extra_compile_args(compiler):
+    """
+    Get the extra compile arguments for libjsonnet C++ compilation.
+    """
+    if compiler.compiler_type == 'msvc':
+        return []
+    else:
+        return ["-Wextra", "-Woverloaded-virtual", "-pedantic", "-std=c++11"]
+
+
+def get_c_extra_compile_args(compiler):
+    """
+    Get the extra compile arguments for python jsonnet C compilation.
+    """
+    if compiler.compiler_type == 'msvc':
+        return []
+    else:
+        return ["-Wextra", "-pedantic", "-std=c99"]
+
+
+def is_cmake_available():
+    try:
+        returncode = subprocess.call(["cmake", "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return returncode == 0
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            return False
+        raise
+
+
+def is_make_available():
+    try:
+        returncode = subprocess.call(["make", "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return returncode == 0
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            return False
+        raise
+
+
+class custom_build_ext(build_ext):
+    def build_extension(self, ext):
+        if ext.name == '_jsonnet':
+            libjsonnet_built = False
+
+            if not libjsonnet_built:
+                if is_cmake_available():
+                    print("CMake is available.")
+                    print("Building libjsonnet with CMake ...")
+                    subprocess.call(['cmake', '.', '-Bbuild'], cwd=DIR)
+                    returncode = subprocess.call(['cmake', '--build', 'build', '--target', 'libjsonnet_static'],
+                                                 cwd=DIR)
+
+                    ext.extra_objects = ['build/core/CMakeFiles/libjsonnet_static.dir/desugarer.cpp.o',
+                                         'build/core/CMakeFiles/libjsonnet_static.dir/formatter.cpp.o',
+                                         'build/core/CMakeFiles/libjsonnet_static.dir/libjsonnet.cpp.o',
+                                         'build/core/CMakeFiles/libjsonnet_static.dir/lexer.cpp.o',
+                                         'build/core/CMakeFiles/libjsonnet_static.dir/parser.cpp.o',
+                                         'build/core/CMakeFiles/libjsonnet_static.dir/pass.cpp.o',
+                                         'build/core/CMakeFiles/libjsonnet_static.dir/static_analysis.cpp.o',
+                                         'build/core/CMakeFiles/libjsonnet_static.dir/string_utils.cpp.o',
+                                         'build/core/CMakeFiles/libjsonnet_static.dir/vm.cpp.o',
+                                         'build/third_party/md5/CMakeFiles/md5.dir/md5.cpp.o']
+
+                    if returncode == 0:
+                        libjsonnet_built = True
+                    else:
+                        print("libjsonnet build has failed using CMake. Falling back to another build method ...")
+                else:
+                    print("CMake is not available.")
+            if not libjsonnet_built:
+                if is_make_available():
+                    print("make is available.")
+                    print("Building libjsonnet with make ...")
+
+                    ext.extra_objects = [
+                        'core/desugarer.o',
+                        'core/formatter.o',
+                        'core/libjsonnet.o',
+                        'core/lexer.o',
+                        'core/parser.o',
+                        'core/pass.o',
+                        'core/static_analysis.o',
+                        'core/string_utils.o',
+                        'core/vm.o',
+                        'third_party/md5/md5.o']
+
+                    returncode = subprocess.call(['make'] + ext.extra_objects, cwd=DIR)
+
+                    if returncode == 0:
+                        libjsonnet_built = True
+                    else:
+                        print("libjsonnet build has failed using make. Falling back to another build method ...")
+                else:
+                    print("make is not available")
+            if not libjsonnet_built:
+                print("Building libjsonnet with distutils compiler ...")
+                try:
+                    to_c_array(os.path.join(DIR, 'stdlib/std.jsonnet'), os.path.join(DIR, 'core/std.jsonnet.h'))
+
+                    ext.extra_objects = self.compiler.compile([
+                        'core/desugarer.cpp',
+                        'core/formatter.cpp',
+                        'core/libjsonnet.cpp',
+                        'core/lexer.cpp',
+                        'core/parser.cpp',
+                        'core/pass.cpp',
+                        'core/static_analysis.cpp',
+                        'core/string_utils.cpp',
+                        'core/vm.cpp',
+                        'third_party/md5/md5.cpp'],
+                        extra_postargs=get_cpp_extra_compile_args(self.compiler),
+                        include_dirs=['include', 'third_party/md5', 'third_party/json'])
+
+                    libjsonnet_built = True
+                except Exception as e:
+                    print(e)
+                    print("libjsonnet build has failed using distutils compiler.")
+                    raise Exception("Could not build libjsonnet")
+
+            ext.extra_compile_args = get_c_extra_compile_args(self.compiler)
+
+        build_ext.build_extension(self, ext)
+
 
 jsonnet_ext = Extension(
     '_jsonnet',
-    sources=MODULE_SOURCES,
-    extra_objects=LIB_OBJECTS,
-    include_dirs = ['include', 'third_party/md5', 'third_party/json'],
+    sources=['python/_jsonnet.c'],
+    include_dirs=['include', 'third_party/md5', 'third_party/json'],
     language='c++'
 )
 
@@ -69,8 +200,8 @@ setup(name='jsonnet',
       author_email='dcunnin@google.com',
       version=get_version(),
       cmdclass={
-          'build_ext': BuildJsonnetExt,
+          'build_ext': custom_build_ext,
       },
       ext_modules=[jsonnet_ext],
       test_suite="python._jsonnet_test",
-)
+      )

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(to_c_array to_c_array.cpp)
 # Custom command that will only build stdlib when it changes.
 add_custom_command(
 	OUTPUT ${PROJECT_SOURCE_DIR}/core/std.jsonnet.h
-	COMMAND ${GLOBAL_OUTPUT_PATH}/to_c_array
+	COMMAND to_c_array
 			    ${PROJECT_SOURCE_DIR}/stdlib/std.jsonnet
 					${PROJECT_SOURCE_DIR}/core/std.jsonnet.h
 	DEPENDS to_c_array std.jsonnet)


### PR DESCRIPTION
This should fix #476 and is a first step for #734 by fixing CMake.

With this PR, python extension build is now performed by either CMake, make or distutils compiler using a fallback strategy. (It will try using CMake first, then make, and fallback to distutils compiler).

CMake has been modifier to accept the build to run with MSVC compilet (tested on Windows with Visual C++ Build Tools v14.2)

Here's the command to run on windows to build.

```
cmake . -Bbuild && cmake --build build --config Release
```

Release files are then available in `build/Release`

There's still linker errors when, but exe files are available and works properly, any help welcome about those errors (I'm not a C/C++ developer). (maybe it's related to #778)

```
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_version rÚfÚrencÚ dans la fonction "public: static class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >__cdecl jsonnet::Jsonnet::version(void)" (?version@Jsonnet@jsonnet@@SA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@XZ) [C:\Users\xxx\projects\jsonnet\build\cpp\libjsonnet++.vcxproj]
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_make rÚfÚrencÚ dans la fonction "public: bool __cdecl jsonnet::Jsonnet::init(void)" (?init@Jsonnet@jsonnet@@QEAA_NXZ) [C:\Users\xxx\p rojects\jsonnet\build\cpp\libjsonnet++.vcxproj]
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_max_stack rÚfÚrencÚ dans la fonction "public: void __cdecl jsonnet::Jsonnet::setMaxStack(unsigned int)" (?setMaxStack@Jsonnet@jsonnet@@QEAA XI@Z) [C:\Users\xxx\projects\jsonnet\build\cpp\libjsonnet++.vcxproj]
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_gc_min_objects rÚfÚrencÚ dans la fonction "public: void __cdecl jsonnet::Jsonnet::setGcMinObjects(unsigned int)" (?setGcMinObjects@Jsonnet@ jsonnet@@QEAAXI@Z) [C:\Users\xxx\projects\jsonnet\build\cpp\libjsonnet++.vcxproj]
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_gc_growth_trigger rÚfÚrencÚ dans la fonction "public: void __cdecl jsonnet::Jsonnet::setGcGrowthTrigger(double)" (?setGcGrowthTrigger@Jsonn et@jsonnet@@QEAAXN@Z) [C:\Users\xxx\projects\jsonnet\build\cpp\libjsonnet++.vcxproj]
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_string_output rÚfÚrencÚ dans la fonction "public: void __cdecl jsonnet::Jsonnet::setStringOutput(bool)" (?setStringOutput@Jsonnet@jsonnet@@ QEAAX_N@Z) [C:\Users\xxx\projects\jsonnet\build\cpp\libjsonnet++.vcxproj]
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_ext_var rÚfÚrencÚ dans la fonction "public: void __cdecl jsonnet::Jsonnet::bindExtVar(class std::basic_string<char,struct std::char_traits< char>,class std::allocator<char> > const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (?bindExtVar@Jsonnet@jsonnet@@QEAAXAEBV?$basic_string@DU?$char_trai ts@D@std@@V?$allocator@D@2@@std@@0@Z) [C:\Users\xxx\projects\jsonnet\build\cpp\libjsonnet++.vcxproj]
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_ext_code rÚfÚrencÚ dans la fonction "public: void __cdecl jsonnet::Jsonnet::bindExtCodeVar(class std::basic_string<char,struct std::char_tr aits<char>,class std::allocator<char> > const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (?bindExtCodeVar@Jsonnet@jsonnet@@QEAAXAEBV?$basic_string@DU?$ char_traits@D@std@@V?$allocator@D@2@@std@@0@Z) [C:\Users\xxx\projects\jsonnet\build\cpp\libjsonnet++.vcxproj]
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_tla_var rÚfÚrencÚ dans la fonction "public: void __cdecl jsonnet::Jsonnet::bindTlaVar(class std::basic_string<char,struct std::char_traits< char>,class std::allocator<char> > const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (?bindTlaVar@Jsonnet@jsonnet@@QEAAXAEBV?$basic_string@DU?$char_trai ts@D@std@@V?$allocator@D@2@@std@@0@Z) [C:\Users\xxx\projects\jsonnet\build\cpp\libjsonnet++.vcxproj]
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_tla_code rÚfÚrencÚ dans la fonction "public: void __cdecl jsonnet::Jsonnet::bindTlaCodeVar(class std::basic_string<char,struct std::char_tr aits<char>,class std::allocator<char> > const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (?bindTlaCodeVar@Jsonnet@jsonnet@@QEAAXAEBV?$basic_string@DU?$ char_traits@D@std@@V?$allocator@D@2@@std@@0@Z) [C:\Users\xxx\projects\jsonnet\build\cpp\libjsonnet++.vcxproj]
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_max_trace rÚfÚrencÚ dans la fonction "public: void __cdecl jsonnet::Jsonnet::setMaxTrace(unsigned int)" (?setMaxTrace@Jsonnet@jsonnet@@QEAA XI@Z) [C:\Users\xxx\projects\jsonnet\build\cpp\libjsonnet++.vcxproj]
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_jpath_add rÚfÚrencÚ dans la fonction "public: void __cdecl jsonnet::Jsonnet::addImportPath(class std::basic_string<char,struct std::char_tr aits<char>,class std::allocator<char> > const &)" (?addImportPath@Jsonnet@jsonnet@@QEAAXAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z) [C:\Users\xxx\projects\jsonnet\build\cpp\libj sonnet++.vcxproj]
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_evaluate_file rÚfÚrencÚ dans la fonction "public: bool __cdecl jsonnet::Jsonnet::evaluateFile(class std::basic_string<char,struct std::char _traits<char>,class std::allocator<char> > const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?evaluateFile@Jsonnet@jsonnet@@QEAA_NAEBV?$basic_string@DU?$char _traits@D@std@@V?$allocator@D@2@@std@@PEAV34@@Z) [C:\Users\xxx\projects\jsonnet\build\cpp\libjsonnet++.vcxproj]
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_evaluate_snippet rÚfÚrencÚ dans la fonction "public: bool __cdecl jsonnet::Jsonnet::evaluateSnippet(class std::basic_string<char,struct std ::char_traits<char>,class std::allocator<char> > const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?evaluateSnippet@Jsonnet@jsonnet@@QEAA_NAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@0PEAV34@@Z) [C:\Users\xxx\projects\jsonnet\build\cpp\libjso nnet++.vcxproj]
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_evaluate_file_multi rÚfÚrencÚ dans la fonction "public: bool __cdecl jsonnet::Jsonnet::evaluateFileMulti(class std::basic_string<char,struc t std::char_traits<char>,class std::allocator<char> > const &,class std::map<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >,class std::basic_string<char,struct std::ch ar_traits<char>,class std::allocator<char> >,struct std::less<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > >,class std::allocator<struct std::pair<class std::basic_s tring<char,struct std::char_traits<char>,class std::allocator<char> > const ,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > > > > *)" (?evaluateFileMulti@Jsonnet@jsonn et@@QEAA_NAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEAV?$map@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V12@U?$less@V?$basic_string@DU?$char_traits@D@std@@V?$allocat or@D@2@@std@@@2@V?$allocator@U?$pair@$$CBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V12@@std@@@2@@4@@Z) [C:\Users\xxx\projects\jsonnet\build\cpp\libjsonnet++.vcxproj]
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_evaluate_snippet_multi rÚfÚrencÚ dans la fonction "public: bool __cdecl jsonnet::Jsonnet::evaluateSnippetMulti(class std::basic_string<char ,struct std::char_traits<char>,class std::allocator<char> > const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class std::map<class std::basic_string<char, struct std::char_traits<char>,class std::allocator<char> >,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >,struct std::less<class std::basic_string<char,struct std::cha r_traits<char>,class std::allocator<char> > >,class std::allocator<struct std::pair<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const ,class std::basic_string<char, struct std::char_traits<char>,class std::allocator<char> > > > > *)" (?evaluateSnippetMulti@Jsonnet@jsonnet@@QEAA_NAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@0PEAV?$map@V?$basic_string@D U?$char_traits@D@std@@V?$allocator@D@2@@std@@V12@U?$less@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@V?$allocator@U?$pair@$$CBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@ @V12@@std@@@2@@4@@Z) [C:\Users\xxx\projects\jsonnet\build\cpp\libjsonnet++.vcxproj]
libjsonnet++.obj : error LNK2019: symbole externe non rÚsolu jsonnet_destroy rÚfÚrencÚ dans la fonction "public: __cdecl jsonnet::Jsonnet::~Jsonnet(void)" (??1Jsonnet@jsonnet@@QEAA@XZ) [C:\Users\xxx\pro jects\jsonnet\build\cpp\libjsonnet++.vcxproj]
C:\Users\xxx\projects\jsonnet\build\Release\jsonnet++.dll : fatal error LNK1120: 17 externes non rÚsolus [C:\Users\xxx\projects\jsonnet\build\cpp\libjsonnet++.vcxproj]
```