### PR TITLE
Add Windows support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
             - g++-4.9
           sources: &sources
             - llvm-toolchain-precise-3.8
-            - ubuntu-toolchain-r-test    
+            - ubuntu-toolchain-r-test
     - os: linux
       env: COMPILER_NAME=clang CXX=clang++-3.8 CC=clang-3.8 COMMON_OS_NAME=${TRAVIS_OS_NAME}
       addons:
@@ -24,6 +24,11 @@ matrix:
     - os: osx
       osx_image: xcode11.3
       env: CC=clang && CXX=clang++ COMMON_OS_NAME=darwin
+    - os: windows
+      language: cpp
+      env: CC=clang CXX=clang++ COMMON_OS_NAME=${TRAVIS_OS_NAME} GENERATOR="Unix Makefiles"
+      install: choco install make -y
+      script: ./travis/build-windows.bat
 
 before_install:
   - echo $LANG
@@ -40,24 +45,26 @@ script:
   - cmake . -Bbuild && cmake --build build --target run_tests
   # make a tarfile for the binaries and rename for os and tag
   - make dist
-  - mv jsonnet-bin.tar.gz jsonnet-bin-${TRAVIS_TAG}-${COMMON_OS_NAME}.tar.gz
+  - mkdir upload
+  - mv jsonnet-bin.tar.gz upload/jsonnet-bin-${TRAVIS_TAG}-${COMMON_OS_NAME}.tar.gz
 
 deploy:
   provider: releases
   api_key: $JSONNET_GITHUB_TOKEN
-  file: jsonnet-bin-${TRAVIS_TAG}-${TRAVIS_OS_NAME}.tar.gz
+  file_glob: true
+  file: upload/*
   skip_cleanup: true
   on:
     tags: true
     # no point deploying the images built with both compilers
-    condition: $CC =~ gcc
+    condition: $CC =~ gcc && $COMMON_OS_NAME =~ ^(linux|darwin)$
 
 branches:
   only:
     - master
     # the branch name is the tag name, so having only master means you can't
     # trigger a build by just push a tag - so add in a regex to match tags that
-    # should trigger. 
+    # should trigger.
     - /^v.*$/
 
 notifications:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,17 +33,23 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${GLOBAL_OUTPUT_PATH})
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${GLOBAL_OUTPUT_PATH})
 
 # Compiler flags.
-if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" OR
+if ((${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" OR
         ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+    AND
+	(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Linux"
+	    OR ${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin"))
     set(OPT "-O3")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -pedantic -std=c99 -O3 ${OPT}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -pedantic -std=c99 ${OPT}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra -Woverloaded-virtual -pedantic -std=c++11 -fPIC ${OPT}")
+    set(CMAKE_CXX_STANDARD 11)
+elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Windows" AND ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -std=c99 ${OPT}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra -Woverloaded-virtual -std=c++14 ${OPT}")
+    set(CMAKE_CXX_STANDARD 14)
 else()
-    # TODO: Windows support.
     message(FATAL_ERROR "Compiler ${CMAKE_CXX_COMPILER_ID} not supported")
 endif()
 
-set(CMAKE_CXX_STANDARD 11)
 
 
 # Include external googletest project. This runs a CMake sub-script

--- a/README.md
+++ b/README.md
@@ -99,10 +99,48 @@ bazel-bin/cmd/jsonnetfmt
 
 ### Cmake
 
+Linux/OSX:
 
 ```
 cmake . -Bbuild
 ```
+
+```
+cmake --build build --target run_tests
+```
+
+Windows:
+
+In order to build under Windows using cmake, you need to install:
+
+- chocolatey
+- llvm
+
+Only `Unix Makefiles` generator is currently supported, so we also need `make`:
+
+```
+choco install make
+```
+
+Finally, we can build Jsonnet:
+
+```
+cmake . -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -G "Unix MakeFiles"
+```
+
+`jsonnet.exe`:
+
+```
+cmake --build build --target jsonnet
+```
+
+`jsonnetfmt.exe`:
+
+```
+cmake --build build --target jsonnetfmt
+```
+
+Tests:
 
 ```
 cmake --build build --target run_tests

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -5,10 +5,11 @@ add_executable(to_c_array to_c_array.cpp)
 # Custom command that will only build stdlib when it changes.
 add_custom_command(
 	OUTPUT ${PROJECT_SOURCE_DIR}/core/std.jsonnet.h
-	COMMAND ${GLOBAL_OUTPUT_PATH}/to_c_array
+	COMMAND to_c_array
 			    ${PROJECT_SOURCE_DIR}/stdlib/std.jsonnet
 					${PROJECT_SOURCE_DIR}/core/std.jsonnet.h
-	DEPENDS to_c_array std.jsonnet)
+	DEPENDS to_c_array std.jsonnet
+	WORKING_DIRECTORY ${GLOBAL_OUTPUT_PATH})
 
 # Standard library build target that libjsonnet can depend on.
 add_custom_target(stdlib ALL

--- a/test_suite/CMakeLists.txt
+++ b/test_suite/CMakeLists.txt
@@ -1,6 +1,8 @@
 find_program(BASH bash)
 if (BASH STREQUAL "BASH-NOTFOUND")
     message(WARNING "Bash not found, can't run regression tests.")
+elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Windows")
+    message(WARNING "Regression tests for Windows are not supported.")
 else()
     # Note: this test relies on the JSONNET_BIN variable, which
     # is set in the root CMakeLists.txt.

--- a/travis/build-windows.bat
+++ b/travis/build-windows.bat
@@ -1,0 +1,12 @@
+call RefreshEnv.cmd
+cmake . -B build -DCMAKE_C_COMPILER="%CC%" -DCMAKE_CXX_COMPILER="%CXX%" -G "%GENERATOR%"
+if %errorlevel% NEQ 0 exit /b %errorlevel%
+cmake --build build --target jsonnetfmt
+if %errorlevel% NEQ 0 exit /b %errorlevel%
+cmake --build build --target jsonnet
+if %errorlevel% NEQ 0 exit /b %errorlevel%
+cmake --build build --target run_tests
+if %errorlevel% NEQ 0 exit /b %errorlevel%
+mkdir upload
+7z -tzip a .\upload\jsonnet-bin-"%TRAVIS_TAG%"-"%COMMON_OS_NAME%".zip .\build\jsonnet*.exe
+if %errorlevel% NEQ 0 exit /b %errorlevel%


### PR DESCRIPTION
DO NOT MERGE UNTIL SECURITY PROBLEMS ARE RESOLVED!

Fixes #734 

This PR is an attempt to provide Windows builds as proposed at #734

Prerequisites:
* chocolatey
* llvm ([Travis uses v9.0.0](https://docs.travis-ci.com/user/reference/windows#pre-installed-chocolatey-packages))
* make (install using `choco install make`)

Build:
```
refreshenv
cmake . -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -G "Unix Makefiles"
cmake --build build --target jsonnetfmt
cmake --build build --target jsonnet
cmake --build build --target run_tests
```

.travis.yml is modified so that archives with executables can be found at directory `upload`

Problems:
* `-pedantic` leads to compiler errors since MSVC libraries use language extensions
* `-std=c++11` leads to compiler errors
* unable to run `setup.py`
* unable to run regression tests (CMake target `run_tests`, file`test_suite/run_tests.sh`)
* [Secrets ARE NOT obfuscated in Travis Windows builds](https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264) (means this PR is unable to merge)

Any support is appreciated.
