### PR TITLE
cmake: Specify INTERFACE include directories for libraries

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -48,6 +48,8 @@ install(TARGETS libjsonnet
 	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 	PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+target_include_directories(libjsonnet INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 
 if (BUILD_STATIC_LIBS)
     # Static library for jsonnet command-line tool.
@@ -56,6 +58,8 @@ if (BUILD_STATIC_LIBS)
     target_link_libraries(libjsonnet_static md5 nlohmann_json::nlohmann_json)
     set_target_properties(libjsonnet_static PROPERTIES OUTPUT_NAME jsonnet)
     install(TARGETS libjsonnet_static DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+    target_include_directories(libjsonnet_static INTERFACE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 endif()
 
 if (BUILD_SHARED_BINARIES OR NOT BUILD_STATIC_LIBS)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -22,6 +22,8 @@ install(TARGETS libjsonnet++
 	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 	PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+target_include_directories(libjsonnet++ INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 
 if (BUILD_STATIC_LIBS)
     # Static library for jsonnet command-line tool.
@@ -30,6 +32,8 @@ if (BUILD_STATIC_LIBS)
     target_link_libraries(libjsonnet++_static libjsonnet_static)
     set_target_properties(libjsonnet++_static PROPERTIES OUTPUT_NAME jsonnet++)
     install(TARGETS libjsonnet++_static DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+    target_include_directories(libjsonnet++_static INTERFACE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 endif()
 
 if (BUILD_SHARED_BINARIES OR NOT BUILD_STATIC_LIBS)


### PR DESCRIPTION
Specify INTERFACE include directories for the libraries so that the libraries' dependent targets can use the proper include directory automatically.

This is useful when Jsonnet is used as a subproject in a CMake tree. A target that links to libjsonnet will be configured to use the proper include directory without explicit `target_include_directories`. This has an advantage that the consumer need not to know the internal directory layout of the Jsonnet tree.
```cmake
add_executable(my-project ...)
add_subdirectory(path/to/jsonnet EXCLUDE_FROM_ALL)
target_link_libraries(my-project libjsonnet)
# target_include_directories(my-project PRIVATE path/to/jsonnet/include)
```