### PR TITLE
POC for #196 - Relax computed importstr

### DIFF
--- a/core/desugarer.cpp
+++ b/core/desugarer.cpp
@@ -34,7 +34,7 @@ struct BuiltinDecl {
     std::vector<UString> params;
 };
 
-static unsigned long max_builtin = 37;
+static unsigned long max_builtin = 38;
 BuiltinDecl jsonnet_builtin_decl(unsigned long builtin)
 {
     switch (builtin) {
@@ -76,6 +76,7 @@ BuiltinDecl jsonnet_builtin_decl(unsigned long builtin)
         case 35: return {U"parseJson", {U"str"}};
         case 36: return {U"encodeUTF8", {U"str"}};
         case 37: return {U"decodeUTF8", {U"arr"}};
+        case 38: return {U"importstrDyn", {U"str"}};
         default:
             std::cerr << "INTERNAL ERROR: Unrecognized builtin function: " << builtin << std::endl;
             std::abort();


### PR DESCRIPTION
Adds a new builtin function (importstrDyn) that accept a computed string.

I did not modified the importstr logic itself as I don't understand well
enough how the parser is working. Of course, it would better if importstr could be modified to accept any computed string.

With `test.jsonnet`

```
{
  a: {
    b: "dyn",
    c1: importstr "file-dyn.txt",
    c2: std.importstrDyn("file-dyn.txt"),
    c3: std.importstrDyn("file-%s.txt" % self.b),
  },
}
```

and with `file-dyn.txt`

```
>> 42
```

Executing `$ jsonnet test.jsonnet` outputs 

```
{
   "a": {
      "b": "dyn",
      "c1": ">> 42",
      "c2": ">> 42",
      "c3": ">> 42"
   }
}
```

Hopefully, this PR will trigger new discussions and maybe the addition of such a feature. I really don't see how this would diminish the hermiticity (not more than extVar or tla IMO) nor how it would prevents static analysis. 