### PR TITLE
[Website] Fix docs for std.rstripChars

### DIFF
--- a/doc/ref/stdlib.html
+++ b/doc/ref/stdlib.html
@@ -606,7 +606,7 @@ title: Standard Library
   <div class="hgroup-inline">
     <div class="panel">
       <em>Available since version 0.15.0.</em>
-      <p>Removes characters <code>chars</code> from the beginning and from the end of <code>str</code>.</p>
+      <p>Removes characters <code>chars</code> from the end of <code>str</code>.</p>
       <p>
         Example: <code>std.rstripChars(" test test test     ", " ")</code> yields <code>" test test test"</code>.
       </p>


### PR DESCRIPTION
From what looks like to be a cut-and-paste error, `std.rstripChars` is
documented as removing chars from the beginning and end of a string,
which should just be the end.