### PR TITLE
typo: keyword be "late => keyword is "late

### DIFF
--- a/doc/learning/tutorial.html
+++ b/doc/learning/tutorial.html
@@ -820,7 +820,7 @@ title: Tutorial
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        The key to making Jsonnet object-oriented is that the <code>self</code> keyword be "late
+        The key to making Jsonnet object-oriented is that the <code>self</code> keyword is "late
         bound".  In other words, <code>self.foo</code> can have its meaning altered by overriding it
         on the right hand side of a <code>+</code>.  This would not be the case in a simple "object
         merge" semantics of <code>+</code>, where <code>self.foo</code> would be fully evaluated to


### PR DESCRIPTION
Small typo in the tutorial