### PR TITLE
fix cleaning important data.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ OPT ?= -O3
 
 PREFIX ?= /usr/local
 
-CXXFLAGS ?= -g $(OPT) -Wall -Wextra -Woverloaded-virtual -pedantic -std=c++0x -fPIC
+CXXFLAGS ?= -g $(OPT) -Wall -Wextra -Woverloaded-virtual -pedantic -std=c++0x -fPIC -fno-builtin-memset
 CXXFLAGS += -Iinclude -Ithird_party/md5 -Ithird_party/json
 CFLAGS ?= -g $(OPT) -Wall -Wextra -pedantic -std=c99 -fPIC
 CFLAGS += -Iinclude


### PR DESCRIPTION
in your project in the md5.cpp file on line 245, data cleansing is present. The specified procedure can be optimized by the compiler according to
```
Notes
memset may be optimized away (under the as-if rules) if the object modified by this function is not accessed again for the rest of its lifetime (e.g. gcc bug 8537). For that reason, this function cannot be used to scrub memory (e.g. to fill an array that stored a password with zeroes). This optimization is prohibited for memset_s: it is guaranteed to perform the memory write. Third-party solutions for that include FreeBSD explicit_bzero or Microsoft SecureZeroMemory.
```
https://en.cppreference.com/w/c/string/byte/memset

with that in mind, I suggest adding the -fno-builtin-memset flag to eliminate this.