### PR TITLE
Implement std.objectValues and std.objectValuesAll

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -81,6 +81,13 @@ local html = import 'html.libsonnet';
           |||,
         },
         {
+          name: 'objectValues',
+          params: ['o'],
+          description: |||
+            Returns an array of the values in the given object. Does not include hidden fields.
+          |||,
+        },
+        {
           name: 'objectHasAll',
           params: ['o', 'f'],
           description: |||
@@ -92,6 +99,13 @@ local html = import 'html.libsonnet';
           params: ['o'],
           description: |||
             As <code>std.objectFields</code> but also includes hidden fields.
+          |||,
+        },
+        {
+          name: 'objectValuesAll',
+          params: ['o'],
+          description: |||
+            As <code>std.objectValues</code> but also includes hidden fields.
           |||,
         },
         {

--- a/doc/ref/stdlib.html
+++ b/doc/ref/stdlib.html
@@ -207,6 +207,28 @@ title: Standard Library
 <div class="hgroup">
   <div class="hgroup-inline">
     <div class="panel">
+      <h4 id="objectValues">
+        std.objectValues(o)
+      </h4>
+    </div>
+    <div style="clear: both"></div>
+  </div>
+</div>
+<div class="hgroup">
+  <div class="hgroup-inline">
+    <div class="panel">
+      <p>
+        Returns an array of the values in the given object. Does not include hidden fields.
+      </p>
+      
+    </div>
+    <div style="clear: both"></div>
+  </div>
+</div>
+
+<div class="hgroup">
+  <div class="hgroup-inline">
+    <div class="panel">
       <h4 id="objectHasAll">
         std.objectHasAll(o, f)
       </h4>
@@ -241,6 +263,28 @@ title: Standard Library
     <div class="panel">
       <p>
         As <code>std.objectFields</code> but also includes hidden fields.
+      </p>
+      
+    </div>
+    <div style="clear: both"></div>
+  </div>
+</div>
+
+<div class="hgroup">
+  <div class="hgroup-inline">
+    <div class="panel">
+      <h4 id="objectValuesAll">
+        std.objectValuesAll(o)
+      </h4>
+    </div>
+    <div style="clear: both"></div>
+  </div>
+</div>
+<div class="hgroup">
+  <div class="hgroup-inline">
+    <div class="panel">
+      <p>
+        As <code>std.objectValues</code> but also includes hidden fields.
       </p>
       
     </div>

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -39,7 +39,7 @@ limitations under the License.
     assert std.isString(str) : 'substr first parameter should be a string, got ' + std.type(str);
     assert std.isNumber(from) : 'substr second parameter should be a string, got ' + std.type(from);
     assert std.isNumber(len) : 'substr third parameter should be a string, got ' + std.type(len);
-    assert len >=0 : 'substr third parameter should be greater than zero, got ' + len;
+    assert len >= 0 : 'substr third parameter should be greater than zero, got ' + len;
     std.join('', std.makeArray(std.max(0, std.min(len, std.length(str) - from)), function(i) str[i + from])),
 
   startsWith(a, b)::
@@ -112,13 +112,13 @@ limitations under the License.
   split(str, c)::
     assert std.isString(str) : 'std.split first parameter should be a string, got ' + std.type(str);
     assert std.isString(c) : 'std.split second parameter should be a string, got ' + std.type(c);
-    assert std.length(c) == 1 :  'std.split second parameter should have length 1, got ' + std.length(c);
+    assert std.length(c) == 1 : 'std.split second parameter should have length 1, got ' + std.length(c);
     std.splitLimit(str, c, -1),
 
   splitLimit(str, c, maxsplits)::
     assert std.isString(str) : 'std.splitLimit first parameter should be a string, got ' + std.type(str);
     assert std.isString(c) : 'std.splitLimit second parameter should be a string, got ' + std.type(c);
-    assert std.length(c) == 1 :  'std.splitLimit second parameter should have length 1, got ' + std.length(c);
+    assert std.length(c) == 1 : 'std.splitLimit second parameter should have length 1, got ' + std.length(c);
     assert std.isNumber(maxsplits) : 'std.splitLimit third parameter should be a number, got ' + std.type(maxsplits);
     local aux(str, delim, i, arr, v) =
       local c = str[i];
@@ -183,9 +183,9 @@ limitations under the License.
 
   repeat(what, count)::
     local joiner =
-      if std.isString(what) then ""
+      if std.isString(what) then ''
       else if std.isArray(what) then []
-      else error "std.repeat first argument must be an array or a string";
+      else error 'std.repeat first argument must be an array or a string';
     std.join(joiner, std.makeArray(count, function(i) what)),
 
   slice(indexable, index, end, step)::
@@ -226,7 +226,7 @@ limitations under the License.
       std.count(arr, x) > 0
     else if std.isString(arr) then
       std.length(std.findSubstr(x, arr)) > 0
-    else error "std.member first argument must be an array or a string",
+    else error 'std.member first argument must be an array or a string',
 
   count(arr, x):: std.length(std.filter(function(v) v == x, arr)),
 
@@ -839,7 +839,7 @@ limitations under the License.
       if a < b then a else b,
 
   clamp(x, minVal, maxVal)::
-    if x  < minVal then minVal
+    if x < minVal then minVal
     else if x > maxVal then maxVal
     else x,
 
@@ -1300,6 +1300,12 @@ limitations under the License.
 
   objectHasAll(o, f)::
     std.objectHasEx(o, f, true),
+
+  objectValues(o)::
+    [o[k] for k in std.objectFields(o)],
+
+  objectValuesAll(o)::
+    [o[k] for k in std.objectFieldsAll(o)],
 
   equals(a, b)::
     local ta = std.type(a);

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -156,6 +156,18 @@ std.assertEqual(std.objectFields({ x::: 1 } { x: 1 }), ['x']) &&
 std.assertEqual(std.objectFields({ x::: 1 } { x:: 1 }), []) &&
 std.assertEqual(std.objectFields({ x::: 1 } { x::: 1 }), ['x']) &&
 
+std.assertEqual(std.objectValues({}), []) &&
+std.assertEqual(std.objectValues({ x: 1, y: 2 }), [1, 2]) &&
+std.assertEqual(std.objectValues({ x: 1 } { x: 1 }), [1]) &&
+std.assertEqual(std.objectValues({ x: 1 } { x:: 1 }), []) &&
+std.assertEqual(std.objectValues({ x: 1 } { x::: 1 }), [1]) &&
+std.assertEqual(std.objectValues({ x:: 1 } { x: 1 }), []) &&
+std.assertEqual(std.objectValues({ x:: 1 } { x:: 1 }), []) &&
+std.assertEqual(std.objectValues({ x:: 1 } { x::: 1 }), [1]) &&
+std.assertEqual(std.objectValues({ x::: 1 } { x: 1 }), [1]) &&
+std.assertEqual(std.objectValues({ x::: 1 } { x:: 1 }), []) &&
+std.assertEqual(std.objectValues({ x::: 1 } { x::: 1 }), [1]) &&
+
 
 std.assertEqual(std.toString({ a: 1, b: 2 }), '{"a": 1, "b": 2}') &&
 std.assertEqual(std.toString({}), '{ }') &&


### PR DESCRIPTION
Hello friends!

This PR adds two helper functions for extracting an array of values from an object. This was not impossible before (hence the implementations are in jsonnet), but I think it is worth having a 'first class' implementation - for further evidence, it is a [very](https://lodash.com/docs/4.17.15#values) [common](https://ramdajs.com/docs/#values) [feature](https://clojuredocs.org/clojure.core/vals) of data transformation libraries.

It was mentioned in [this comment](https://github.com/google/jsonnet/issues/543#issuecomment-693248735).