### PR TITLE
libjsonnet: Make jsonnet_evaluate_*_stream respect jsonnet_string_output 

### DIFF
--- a/core/libjsonnet.cpp
+++ b/core/libjsonnet.cpp
@@ -565,7 +565,8 @@ static char *jsonnet_evaluate_snippet_aux(JsonnetVm *vm, const char *filename, c
                                               vm->gcGrowthTrigger,
                                               vm->nativeCallbacks,
                                               vm->importCallback,
-                                              vm->importCallbackContext);
+                                              vm->importCallbackContext,
+                                              vm->stringOutput);
                 size_t sz = 1;  // final sentinel
                 for (const auto &doc : documents) {
                     sz += doc.length() + 2;  // Add a '\n' as well as sentinel

--- a/core/vm.cpp
+++ b/core/vm.cpp
@@ -3088,7 +3088,7 @@ class Interpreter {
         return r;
     }
 
-    std::vector<std::string> manifestStream(void)
+    std::vector<std::string> manifestStream(bool string)
     {
         std::vector<std::string> r;
         LocationRange loc("During manifestation");
@@ -3113,7 +3113,7 @@ class Interpreter {
                 stack.top().val = scratch;
                 evaluate(thunk->body, stack.size());
             }
-            UString element = manifestJson(tloc, true, U"");
+            UString element = string ? manifestString(tloc) : manifestJson(tloc, true, U"");
             scratch = stack.top().val;
             stack.pop();
             r.push_back(encode_utf8(element));
@@ -3169,7 +3169,7 @@ std::vector<std::string> jsonnet_vm_execute_stream(Allocator *alloc, const AST *
                                                    double gc_min_objects, double gc_growth_trigger,
                                                    const VmNativeCallbackMap &natives,
                                                    JsonnetImportCallback *import_callback,
-                                                   void *ctx)
+                                                   void *ctx, bool string_output)
 {
     Interpreter vm(alloc,
                    ext_vars,
@@ -3180,5 +3180,5 @@ std::vector<std::string> jsonnet_vm_execute_stream(Allocator *alloc, const AST *
                    import_callback,
                    ctx);
     vm.evaluate(ast, 0);
-    return vm.manifestStream();
+    return vm.manifestStream(string_output);
 }

--- a/core/vm.h
+++ b/core/vm.h
@@ -71,7 +71,7 @@ struct VmExt {
  * \param gc_growth_trigger Growth since last garbage collection cycle to trigger a new cycle.
  * \param import_callback A callback to handle imports
  * \param import_callback_ctx Context param for the import callback.
- * \param output_string Whether to expect a string and output it without JSON encoding
+ * \param string_output Whether to expect a string and output it without JSON encoding
  * \throws RuntimeError reports runtime errors in the program.
  * \returns The JSON result in string form.
  */
@@ -95,7 +95,7 @@ std::string jsonnet_vm_execute(Allocator *alloc, const AST *ast,
  * \param gc_growth_trigger Growth since last garbage collection cycle to trigger a new cycle.
  * \param import_callback A callback to handle imports
  * \param import_callback_ctx Context param for the import callback.
- * \param output_string Whether to expect a string and output it without JSON encoding
+ * \param string_output Whether to expect a string and output it without JSON encoding
  * \throws RuntimeError reports runtime errors in the program.
  * \returns A mapping from filename to the JSON strings for that file.
  */
@@ -118,7 +118,7 @@ std::map<std::string, std::string> jsonnet_vm_execute_multi(
  * \param gc_growth_trigger Growth since last garbage collection cycle to trigger a new cycle.
  * \param import_callback A callback to handle imports
  * \param import_callback_ctx Context param for the import callback.
- * \param output_string Whether to expect a string and output it without JSON encoding
+ * \param string_output Whether to expect a string and output it without JSON encoding
  * \throws RuntimeError reports runtime errors in the program.
  * \returns A mapping from filename to the JSON strings for that file.
  */

--- a/core/vm.h
+++ b/core/vm.h
@@ -125,6 +125,6 @@ std::map<std::string, std::string> jsonnet_vm_execute_multi(
 std::vector<std::string> jsonnet_vm_execute_stream(
     Allocator *alloc, const AST *ast, const std::map<std::string, VmExt> &ext, unsigned max_stack,
     double gc_min_objects, double gc_growth_trigger, const VmNativeCallbackMap &natives,
-    JsonnetImportCallback *import_callback, void *import_callback_ctx);
+    JsonnetImportCallback *import_callback, void *import_callback_ctx, bool string_output);
 
 #endif


### PR DESCRIPTION
The current implementation of jsonnet_evaluate_(snippet|file)_stream returns a list of JSON-encoded strings, whether the string_output option is set or not.

This patch corrects this behavior so that the functions return plain strings when the string_output option is set.