### PR TITLE
More flexibile overriding of test results.

### DIFF
--- a/test_cmd/cmd_tests.source
+++ b/test_cmd/cmd_tests.source
@@ -24,7 +24,10 @@ JSONNET_BIN="${JSONNET_BIN:-../jsonnet}"
 JSONNETFMT_BIN="${JSONNETFMT_BIN:-../jsonnetfmt}"
 
 # Used to account for known differences in the two implementations.
+# Deprecated in favor of override dir.
 IMPLEMENTATION="${IMPLEMENTATION:-cpp}"
+
+OVERRIDE_DIR="${OVERRIDE_DIR:-.}"
 
 separator() {
     echo -e "\n-----------------------------\n"
@@ -63,6 +66,13 @@ do_test_aux() {
     STDIN="${TEST}.stdin"
     GOLDEN_STDOUT="${TEST}.golden.stdout"
     GOLDEN_STDERR="${TEST}.golden.stderr"
+
+    if [ -r "${OVERRIDE_DIR}/${GOLDEN_STDOUT}" ] ; then
+        GOLDEN_STDOUT="${OVERRIDE_DIR}/${GOLDEN_STDOUT}"
+    fi
+    if [ -r "${OVERRIDE_DIR}/${GOLDEN_STDERR}" ] ; then
+        GOLDEN_STDERR="${OVERRIDE_DIR}/${GOLDEN_STDERR}"
+    fi
 
     if [ -r "${GOLDEN_STDOUT}.${IMPLEMENTATION}" ] ; then
         GOLDEN_STDOUT="${GOLDEN_STDOUT}.${IMPLEMENTATION}"

--- a/test_cmd/run_cmd_tests.sh
+++ b/test_cmd/run_cmd_tests.sh
@@ -154,4 +154,3 @@ else
     echo "$0: FAILED: $FAILED / $EXECUTED"
     exit 1
 fi
-


### PR DESCRIPTION
We allow implementations to have different error
outputs (for very good reasons). We still want
to share the test suite. So far we had an "implementation"
suffix. This still required all the variants to be put
in this repo. This is inconvenient, because we need to
sync repos on every change which changes stack traces.

This change allows providing an override directory
with alternative test results. In addition to making
work on go-jsonnet easier, it will also allow 3rd party
implementations to use the test suite directly.