### PR TITLE
Add a missing header.

### DIFF
--- a/core/formatter.cpp
+++ b/core/formatter.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include <algorithm>
 #include <set>
 #include <typeinfo>
+#include <uchar.h>
 
 #include "formatter.h"
 #include "lexer.h"

--- a/core/unicode.h
+++ b/core/unicode.h
@@ -17,6 +17,8 @@ limitations under the License.
 #ifndef JSONNET_UNICODE_H
 #define JSONNET_UNICODE_H
 
+#include <uchar.h>
+
 /** Substituted when a unicode translation format encoding error is encountered. */
 #define JSONNET_CODEPOINT_ERROR 0xfffd
 #define JSONNET_CODEPOINT_MAX 0x110000

--- a/core/vm.cpp
+++ b/core/vm.cpp
@@ -16,10 +16,10 @@ limitations under the License.
 
 #include <cassert>
 #include <cmath>
-
 #include <memory>
 #include <set>
 #include <string>
+#include <uchar.h>
 
 #include "desugarer.h"
 #include "json.h"


### PR DESCRIPTION
Some users reported problems with compiling the project. It seems like on some platforms we need to explicitly include a header which is not needed for the ones we test on. I have no way to reproduce, but hopefully that will fix it.

Thanks to @prazek for the tip about what might be wrong.