### PR TITLE
Use HTTPS links

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1,4 +1,4 @@
 Before we can merge your pull request, we need you to sign either the Google individual or corporate
 contributor license agreement (CLA), unless you are a Google employee, intern, or contractor.
 
-Please see http://jsonnet.org/contributing.html for more information.
+Please see https://jsonnet.org/learning/community.html#license for more information.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Build Status](https://travis-ci.org/google/jsonnet.svg?branch=master)](https://travis-ci.org/google/jsonnet)
 
 For an introduction to Jsonnet and documentation,
-[visit our website](http://jsonnet.org).
+[visit our website](https://jsonnet.org).
 
 This respositiory contains the original implementation. You can also try [go-jsonnet](https://github.com/google/go-jsonnet), a newer implementation which in some cases is orders of magnitude faster.
 
-Visit our [discussion forum](https://groups.google.com/forum/#!forum/jsonnet).
+Visit our [discussion forum](https://groups.google.com/g/jsonnet).
 
 ## Packages
 
@@ -112,7 +112,7 @@ cmake --build build --target run_tests
 
 ## Contributing
 
-See the [contributing page](http://jsonnet.org/contributing.html) on our website.
+See the [contributing page](https://jsonnet.org/learning/community.html#license) on our website.
 
 
 ## Developing Jsonnet

--- a/case_studies/fractal/appserv/templates/page.html
+++ b/case_studies/fractal/appserv/templates/page.html
@@ -2,8 +2,8 @@
 
 {% block instructions %}
 
-The <a href="http://en.wikipedia.org/wiki/Mandelbrot_set">Mandelbrot set</a> is a beautiful
-fractal popularized by <a href="http://en.wikipedia.org/wiki/Benoit_Mandelbrot">Benoit
+The <a href="https://en.wikipedia.org/wiki/Mandelbrot_set">Mandelbrot set</a> is a beautiful
+fractal popularized by <a href="https://en.wikipedia.org/wiki/Benoit_Mandelbrot">Benoit
 Mandelbrot</a>.  Explore it by clicking to zoom in, and shift+clicking to zoom out.  Take a look at
 other peoples' discoveries below, or add your own!
 

--- a/case_studies/fractal/lib/cassandra.libsonnet
+++ b/case_studies/fractal/lib/cassandra.libsonnet
@@ -137,7 +137,7 @@ local packer = import "packer.libsonnet";
 
         aptKeyUrls+: ["https://www.apache.org/dist/cassandra/KEYS"],
         aptRepoLines+: {
-            cassandra: "deb http://www.apache.org/dist/cassandra/debian 21x main",
+            cassandra: "deb https://www.apache.org/dist/cassandra/debian 21x main",
         },
         aptPackages+: ["cassandra"],
 

--- a/case_studies/micro_fractal/appserv/templates/page.html
+++ b/case_studies/micro_fractal/appserv/templates/page.html
@@ -2,8 +2,8 @@
 
 {% block instructions %}
 
-The <a href="http://en.wikipedia.org/wiki/Mandelbrot_set">Mandelbrot set</a> is a beautiful
-fractal popularized by <a href="http://en.wikipedia.org/wiki/Benoit_Mandelbrot">Benoit B.
+The <a href="https://en.wikipedia.org/wiki/Mandelbrot_set">Mandelbrot set</a> is a beautiful
+fractal popularized by <a href="https://en.wikipedia.org/wiki/Benoit_Mandelbrot">Benoit B.
 Mandelbrot</a>.  Explore it by clicking to zoom in, and shift+clicking to zoom out.  Take a look at
 other peoples' discoveries below, or add your own!
 

--- a/case_studies/micromanage/lib/mmlib/v0.1.2/amis/ubuntu.libsonnet
+++ b/case_studies/micromanage/lib/mmlib/v0.1.2/amis/ubuntu.libsonnet
@@ -1,6 +1,6 @@
 // Connect to machines using the username "ubuntu" and -i yourkey.pem
 
-// Source: http://cloud-images.ubuntu.com/locator/ec2/
+// Source: https://cloud-images.ubuntu.com/locator/ec2/
 // There is a URL to get a JSON dump but I've lost it.
 
 local regions(amis) = std.set([a[0] for a in amis]);

--- a/case_studies/micromanage/lib/mmlib/v0.1.2/db/cassandra.libsonnet
+++ b/case_studies/micromanage/lib/mmlib/v0.1.2/db/cassandra.libsonnet
@@ -170,7 +170,7 @@ local service_google = import '../service/google.libsonnet';
       StandardRootImage+: {
         aptKeyUrls+: ['https://www.apache.org/dist/cassandra/KEYS'],
         aptRepoLines+: {
-          cassandra: 'deb http://www.apache.org/dist/cassandra/debian 311x main',
+          cassandra: 'deb https://www.apache.org/dist/cassandra/debian 311x main',
         },
         aptPackages+: ['cassandra'],
 

--- a/core/lexer.cpp
+++ b/core/lexer.cpp
@@ -211,7 +211,7 @@ Token::Kind lex_get_keyword_kind(const std::string &identifier)
 std::string lex_number(const char *&c, const std::string &filename, const Location &begin)
 {
     // This function should be understood with reference to the linked image:
-    // http://www.json.org/number.gif
+    // https://www.json.org/img/number.png
 
     // Note, we deviate from the json.org documentation as follows:
     // There is no reason to lex negative numbers as atomic tokens, it is better to parse them

--- a/core/parser.cpp
+++ b/core/parser.cpp
@@ -39,7 +39,7 @@ std::string jsonnet_unparse_number(double v)
     } else {
         // See "What Every Computer Scientist Should Know About Floating-Point Arithmetic"
         // Theorem 15
-        // http://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
+        // https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
         ss << std::setprecision(17);
         ss << v;
     }

--- a/doc/_layouts/base.html
+++ b/doc/_layouts/base.html
@@ -103,9 +103,9 @@
         <a href="/articles/comparisons.html">Comparisons</a>
       </div>
     </div>
-    <a id=groupsmark class=header-element href="https://groups.google.com/forum/#!forum/jsonnet"></a>
-    <a id=githubmark class=header-element href="http://github.com/google/jsonnet"></a>
-    <a id=gomark class=header-element href="http://github.com/google/go-jsonnet"></a>
+    <a id=groupsmark class=header-element href="https://groups.google.com/g/jsonnet"></a>
+    <a id=githubmark class=header-element href="https://github.com/google/jsonnet"></a>
+    <a id=gomark class=header-element href="https://github.com/google/go-jsonnet"></a>
   </div>
 </div>
 

--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -584,7 +584,7 @@ local html = import 'html.libsonnet';
           params: ['ini'],
           description: [
             html.p({}, |||
-                Convert the given structure to a string in <a href="http://en.wikipedia.org/wiki/INI_file">INI format</a>. This
+                Convert the given structure to a string in <a href="https://en.wikipedia.org/wiki/INI_file">INI format</a>. This
                 allows using Jsonnet's
                 object model to build a configuration to be consumed by an application expecting an INI
                 file. The data is in the form of a set of sections, each containing a key/value mapping.

--- a/doc/articles/comparisons.html
+++ b/doc/articles/comparisons.html
@@ -235,7 +235,7 @@ title: Comparisons
         structure, and importing from other files.  However it is a long way from the expressiveness
         of the object-oriented semantics of Jsonnet, and it also does not have the ability to do
         arithmetic beyond substituting values into strings.  Finally, coil binds variables according
-        to <a href="http://en.wikipedia.org/wiki/Scope_(computer_science)#Dynamic_scoping">dynamic
+        to <a href="https://en.wikipedia.org/wiki/Scope_(computer_science)#Dynamic_scope">dynamic
         scoping rules</a>, which have long been discredited because they quickly make code very
         difficult to understand.  Jsonnet uses static scoping, like almost all mainstream languages.
       </p>
@@ -255,8 +255,8 @@ title: Comparisons
       </p>
       <p>
         Finally, there are a number of other configuration languages that have grown to be used by a
-        range of applications.  For example <a href="http://en.wikipedia.org/wiki/INI_file">INI
-        files</a> or <a href="http://httpd.apache.org/docs/2.2/configuring.html">Apache config
+        range of applications.  For example <a href="https://en.wikipedia.org/wiki/INI_file">INI
+        files</a> or <a href="https://httpd.apache.org/docs/2.2/configuring.html">Apache config
         files</a>.  Typically these offer few features beyond simple JSON and provide very little
         functionality when compared to Jsonnet.
       </p>

--- a/doc/articles/design.html
+++ b/doc/articles/design.html
@@ -35,7 +35,7 @@ title: Language Design
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        <a href="http://www.json.org">JSON</a> has emerged as the defacto standard for communication
+        <a href="https://www.json.org">JSON</a> has emerged as the defacto standard for communication
         of structured data, both between machines and at the human / machine boundary.  However, in
         large quantities JSON can be unwieldy for humans, especially when duplication needs to be
         kept in sync between different parts of the data structure.  Many people address this by
@@ -67,7 +67,7 @@ title: Language Design
         <li>
           <b>Modularity</b>:  As configurations grow, it must be possible to manage the complexity
           using standard techniques for <a
-          href="http://dl.acm.org/citation.cfm?id=808431">programming in the large</a>.
+          href="https://dl.acm.org/doi/10.1145/800027.808431">programming in the large</a>.
           Configurations may span many files and many developers.  Errors should provide stack
           traces that describe the nested context.
         </li>
@@ -181,7 +181,7 @@ title: Language Design
         Jsonnet is Turing-complete as it is possible to write non-terminating programs.
         Configurations should always terminate, so ideally we would consider non-termination as an
         error.  However, doing so in general is <a
-        href="http://en.wikipedia.org/wiki/Halting_problem">impossible</a> and even when constrained
+        href="https://en.wikipedia.org/wiki/Halting_problem">impossible</a> and even when constrained
         to practical use cases, it remains impractical.  Typical approaches for enforcing
         termination either restrict the language (e.g. to primitive recursion), which makes some
         programs impossible / difficult to write, or, alternatively, require the programmer to
@@ -218,7 +218,7 @@ title: Language Design
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Modern <a href="http://en.wikipedia.org/wiki/Type_system">type systems</a> typically either
+        Modern <a href="https://en.wikipedia.org/wiki/Type_system">type systems</a> typically either
         require annotations, use type inference, or are dynamic.  The former two approaches have two
         advantages: Firstly, some errors can be detected before execution (some correct programs are
         also rejected).  Secondly, they can be implemented more efficiently since the additional
@@ -261,7 +261,7 @@ title: Language Design
         existing data.  Most modern object-oriented languages distinguish between classes and
         objects.  Classes can be extended, or instantiated into objects, and objects cannot be
         extended.  However some are <a
-        href="http://en.wikipedia.org/wiki/Prototype-based_programming">prototype-based</a>, where
+        href="https://en.wikipedia.org/wiki/Prototype-based_programming">prototype-based</a>, where
         the concept of class and object are essentially fused.  In Jsonnet, we decided to use the
         latter form because JSON does not have classes, and it's simpler to only have one concept
         instead of two.
@@ -307,7 +307,7 @@ title: Language Design
       </p>
       <p>
         Furthermore, the property of <a
-        href="http://en.wikipedia.org/wiki/Referential_transparency_(computer_science)">referential
+        href="https://en.wikipedia.org/wiki/Referential_transparency">referential
         transparency</a> essentially extends the hermeticity property into submodules of the Jsonnet
         code itself, which means that different parts of the code cannot interfere with each other
         and everything composes in a very predictable way.  In a language whose purpose is simply to

--- a/doc/articles/fractal.1.html
+++ b/doc/articles/fractal.1.html
@@ -43,8 +43,8 @@ makefile: https://github.com/google/jsonnet/blob/master/case_studies/fractal/Mak
         application (a Mandelbrot viewer).  Jsonnet centralizes configuration files for the various
         application software, database schemas and initial data sets, system configuration files,
         package manifests, software build configurations, image configurations (<a
-        href="http://www.packer.io/">Packer</a>) and cloud resources / connectivity (<a
-        href="http://www.terraform.io/">Terraform</a>).  Although the running example is deployed on
+        href="https://www.packer.io/">Packer</a>) and cloud resources / connectivity (<a
+        href="https://www.terraform.io/">Terraform</a>).  Although the running example is deployed on
         <a href="https://cloud.google.com">Google Cloud Platform</a> and uses specific application
         software, Jsonnet can be used to generate configuration for any application and (via Packer
         &amp; Terraform) a wide range of cloud providers.

--- a/doc/articles/fractal.2.html
+++ b/doc/articles/fractal.2.html
@@ -226,7 +226,7 @@ makefile: https://github.com/google/jsonnet/blob/master/case_studies/fractal/Mak
       <p>
         In Jsonnet we use JSON as the canonical data model and convert to other formats as needed.
         An example of this is the uWSGI configuration, an <a
-        href="http://en.wikipedia.org/wiki/INI_file">INI</a> file, which is specified in Jsonnet
+        href="https://en.wikipedia.org/wiki/INI_file">INI</a> file, which is specified in Jsonnet
         under the <code>uwsgiConf</code> field in <code>GcpDebianNginxUwsgiFlaskImage</code>.  The
         JSON version is converted to INI by the call to <code>std.manifestIni</code> (documented <a
         href="/docs/stdlib.html">here</a>) in the provisioner immediately below it.  Representing
@@ -317,7 +317,7 @@ makefile: https://github.com/google/jsonnet/blob/master/case_studies/fractal/Mak
         href="https://github.com/hashicorp/hcl">HCL</a> (a more concise form of JSON).  This
         provides a data structure that specifies the resources required, but the model also has a
         few computational features:  Firstly, the structure has 'variables' which can be resolved by
-        <a href="http://en.wikipedia.org/wiki/String_interpolation">string interpolation</a> within
+        <a href="https://en.wikipedia.org/wiki/String_interpolation">string interpolation</a> within
         the resources.  Also, all resources are also extended with a <tt>count</tt> parameter for
         creating <i>n</i> replicas of that resource, and finally there is some support for importing
         'modules', i.e., another Terraform configuration of resources (perhaps written by a third

--- a/doc/index.html
+++ b/doc/index.html
@@ -29,7 +29,7 @@ title: The Data Templating Language
         <tr>
           <td>
             <p>
-              A simple extension of <a href="http://json.org/">JSON</a><br>
+              A simple extension of <a href="https://json.org/">JSON</a><br>
             </p>
             <ul>
               <li>Open source (Apache 2.0)</li>
@@ -283,7 +283,7 @@ title: The Data Templating Language
     <div class=panel>
       <p class=padded>
         The name Jsonnet is a portmanteau of JSON and <a
-        href="http://en.wikipedia.org/wiki/Sonnet"><i>sonnet</i></a>, pronounced "jay sonnet".  It
+        href="https://en.wikipedia.org/wiki/Sonnet"><i>sonnet</i></a>, pronounced "jay sonnet".  It
         began life early 2014 as a 20% project and was launched on Aug 6.  The design is influenced
         by several configuration languages internal to Google, and embodies years of experience
         configuring some of the world's most complex IT systems.  Jsonnet is now used by many

--- a/doc/learning/getting_started.html
+++ b/doc/learning/getting_started.html
@@ -266,7 +266,7 @@ local
     <div class="panel">
       <p>
         The C++ implementation can be compiled with <a
-        href="http://kripken.github.io/emscripten-site/">emscripten</a> to produce a JavaScript
+        href="https://emscripten.org/">emscripten</a> to produce a JavaScript
         implementation of Jsonnet.  This is how we implement the interactive demos on this site.  A
         native implementation of Jsonnet in JavaScript would probably be faster.  In fact, a
         GopherJs transpile of the Go Jsonnet implementation may work better as well.  However, the
@@ -275,7 +275,7 @@ local
 
       <p>
         To compile it, first <a
-        href="http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html">install
+        href="https://emscripten.org/docs/getting_started/downloads.html">install
         </a> emscripten and ensure em++ and emcc are in your path.  Then make libjsonnet.js.
       </p>
 

--- a/doc/learning/tutorial.html
+++ b/doc/learning/tutorial.html
@@ -846,7 +846,7 @@ title: Tutorial
         So far, every example has used a literal object on the right hand side of the
         <code>+</code>.  This is consistent with the majority of object-oriented languages. But
         Jsonnet is more general in that is has <a
-        href="http://www.bracha.org/oopsla90.pdf">mixins</a>.  A Mixin allows you to take some
+        href="https://www.bracha.org/oopsla90.pdf">mixins</a>.  A Mixin allows you to take some
         "overrides" and instead of just applying them to an existing object to get a new object, you
         can pass them around as a first class value and apply them to any object you want.  The
         following example shows mixins being used to modify cocktails in a general way:

--- a/doc/ref/bindings.html
+++ b/doc/ref/bindings.html
@@ -85,7 +85,7 @@ title: Bindings
 
       <p>
         The API is documented in <a
-        href="http://github.com/google/jsonnet/blob/master/include/libjsonnet.h">libjsonnet.h</a>.
+        href="https://github.com/google/jsonnet/blob/master/include/libjsonnet.h">libjsonnet.h</a>.
         It is built with 'make libjsonnet.so'.  It is used by the python bindings, the Jsonnet
         commandline tool, as well as a couple of simpler tests.  Search for #include "libjsonnet.h".
       </p>

--- a/doc/ref/spec.html
+++ b/doc/ref/spec.html
@@ -94,8 +94,8 @@ div.rules {
         The specification is intended to be terse, precise, and illuminate all the subtleties and
         edge cases in order to allow fully-compatible language reimplementations and tools.  The
         specification employs some standard theoretical computer science techniques, namely <a
-        href="http://en.wikipedia.org/wiki/Type_systems">type systems</a> and <a
-        href="http://en.wikipedia.org/wiki/Operational_semantics">big step operational
+        href="https://en.wikipedia.org/wiki/Type_system">type systems</a> and <a
+        href="https://en.wikipedia.org/wiki/Operational_semantics">big step operational
         semantics</a>.  If you just want to write Jsonnet code (not build a Jsonnet interpreter or
         tool), you don't need to read this.  You should read the <a
         href="/learning/tutorial.html">tutorial</a> and <a href="/ref/language.html">reference</a> .
@@ -141,7 +141,7 @@ div.rules {
         </li>
         <li>
           <p>
-            <i>number</i>: As defined by <a href="http://json.org/">JSON</a> but without the leading
+            <i>number</i>: As defined by <a href="https://json.org/">JSON</a> but without the leading
             minus.
           </p>
         </li>
@@ -1882,7 +1882,7 @@ div.rules {
     <div class="panel">
       <p>
         The rules for capture-avoiding variable substitution [<i>e</i>/<i>id</i>] are an
-        extension of those in the <a href="http://en.wikipedia.org/wiki/Lambda_calculus">lambda
+        extension of those in the <a href="https://en.wikipedia.org/wiki/Lambda_calculus">lambda
         calculus</a>.
       </p>
     </div>

--- a/doc/ref/stdlib.html
+++ b/doc/ref/stdlib.html
@@ -1228,7 +1228,7 @@ title: Standard Library
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Convert the given structure to a string in <a href="http://en.wikipedia.org/wiki/INI_file">INI format</a>. This
+        Convert the given structure to a string in <a href="https://en.wikipedia.org/wiki/INI_file">INI format</a>. This
         allows using Jsonnet's
         object model to build a configuration to be consumed by an application expecting an INI
         file. The data is in the form of a set of sections, each containing a key/value mapping.

--- a/include/libjsonnet++.h
+++ b/include/libjsonnet++.h
@@ -33,7 +33,7 @@ class Jsonnet {
     ~Jsonnet();
 
     /// Return the version string of the Jsonnet interpreter.  Conforms to
-    /// semantic versioning http://semver.org/. If this does not match
+    /// semantic versioning https://semver.org/. If this does not match
     /// LIB_JSONNET_VERSION then there is a mismatch between header and compiled
     /// library.
     static std::string version();

--- a/include/libjsonnet.h
+++ b/include/libjsonnet.h
@@ -34,7 +34,7 @@ limitations under the License.
 #define LIB_JSONNET_VERSION "v0.17.0"
 
 /** Return the version string of the Jsonnet interpreter.  Conforms to semantic versioning
- * http://semver.org/ If this does not match LIB_JSONNET_VERSION then there is a mismatch between
+ * https://semver.org/ If this does not match LIB_JSONNET_VERSION then there is a mismatch between
  * header and compiled library.
  */
 const char *jsonnet_version(void);


### PR DESCRIPTION
Change existing links from HTTP to HTTPS (where supported). Additionally replace some of the links with their current redirect target.