### PR TITLE
stdlib: Support bare identifiers for YAML

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -759,7 +759,7 @@ local html = import 'html.libsonnet';
         },
         {
           name: 'manifestYamlDoc',
-          params: ['value', 'indent_array_in_object=false'],
+          params: ['value', 'indent_array_in_object=false', 'quote_keys=true'],
           description: [
               html.p({}, |||
                   Convert the given value to a YAML form. Note that <code>std.manifestJson</code> could also
@@ -800,11 +800,15 @@ local html = import 'html.libsonnet';
                 The <code>indent_array_in_object</code> param adds additional indentation which some people
                 may find easier to read.
               |||),
+              html.p({}, |||
+                The <code>quote_keys</code> parameter controls whether YAML identifiers are always quoted
+                or only when necessary.
+              |||),
           ],
         },
         {
           name: 'manifestYamlStream',
-          params: ['value', 'indent_array_in_object=false', 'c_document_end=false'],
+          params: ['value', 'indent_array_in_object=false', 'c_document_end=false', 'quote_keys=true'],
           description: [
             html.p({}, |||
                 Given an array of values, emit a YAML "stream", which is a sequence of documents separated
@@ -833,7 +837,8 @@ local html = import 'html.libsonnet';
             |||),
 
             html.p({}, |||
-              The <code>indent_array_in_object</code> param is the same as in <code>manifestYamlDoc</code>.
+              The <code>indent_array_in_object</code> and <code>quote_keys</code> params are the
+              same as in <code>manifestYamlDoc</code>.
             |||),
             html.p({}, |||
               The <code>c_document_end</code> param adds the optional terminating <code>...</code>.

--- a/doc/css/doc.css
+++ b/doc/css/doc.css
@@ -40,7 +40,7 @@ div.header2 {
 }
 
 div.panel {
-  width: 640px;
+  width: 770px;
   margin: 8px auto;
   text-align: justify;
 }

--- a/doc/ref/stdlib.html
+++ b/doc/ref/stdlib.html
@@ -792,7 +792,7 @@ title: Standard Library
         Example: <code>std.splitLimit("foo/bar", "/", 1)</code> yields <code>[ "foo", "bar" ]</code>.
       </p>
       <p>
-        Example: <code>std.splitLimit("/foo/", "/", 1)</code> yields <code>[ "foo", "bar" ]</code>.
+        Example: <code>std.splitLimit("/foo/bar", "/", 1)</code> yields <code>[ "", "foo/bar" ]</code>.
       </p>
     </div>
     <div style="clear: both"></div>
@@ -1415,7 +1415,7 @@ e = {"f1": False, "f2": 42}</pre>
   <div class="hgroup-inline">
     <div class="panel">
       <h4 id="manifestYamlDoc">
-        std.manifestYamlDoc(value, indent_array_in_object=false)
+        std.manifestYamlDoc(value, indent_array_in_object=false, quote_keys=true)
       </h4>
     </div>
     <div style="clear: both"></div>
@@ -1459,6 +1459,10 @@ e = {"f1": False, "f2": 42}</pre>
         The <code>indent_array_in_object</code> param adds additional indentation which some people
         may find easier to read.
       </p>
+      <p>
+        The <code>quote_keys</code> parameter controls whether YAML identifiers are always quoted
+        or only when necessary.
+      </p>
       
     </div>
     <div style="clear: both"></div>
@@ -1469,7 +1473,7 @@ e = {"f1": False, "f2": 42}</pre>
   <div class="hgroup-inline">
     <div class="panel">
       <h4 id="manifestYamlStream">
-        std.manifestYamlStream(value, indent_array_in_object=false, c_document_end=false)
+        std.manifestYamlStream(value, indent_array_in_object=false, c_document_end=false, quote_keys=true)
       </h4>
     </div>
     <div style="clear: both"></div>
@@ -1497,7 +1501,8 @@ e = {"f1": False, "f2": 42}</pre>
 []
 ...</pre>
       <p>
-        The <code>indent_array_in_object</code> param is the same as in <code>manifestYamlDoc</code>.
+        The <code>indent_array_in_object</code> and <code>quote_keys</code> params are the
+        same as in <code>manifestYamlDoc</code>.
       </p>
       <p>
         The <code>c_document_end</code> param adds the optional terminating <code>...</code>.

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -614,6 +614,12 @@ local bare_yaml_quoted = {
   '2002-12-14': 'date',
 };
 local bare_yaml_unquoted = {
+  '0X_0a_74_ae': 'BARE_KEY',
+  '__-0X_0a_74_ae': 'BARE_KEY',
+  '-0B1010_0111_0100_1010_1110': 'BARE_KEY',
+  '__-0B1010_0111_0100_1010_1110': 'BARE_KEY',
+  x: 'BARE_KEY',
+  b: 'BARE_KEY',
   just_letters_underscores: 'BARE_KEY',
   'just-letters-dashes': 'BARE_KEY',
   'jsonnet.org/k8s-label-like': 'BARE_KEY',
@@ -1030,6 +1036,7 @@ std.assertEqual(
     "---": "triple dash key"
     "-.inf": "negative infinity"
     "-0.1_0_0": "negative float"
+    -0B1010_0111_0100_1010_1110: "BARE_KEY"
     "-0b1010_0111_0100_1010_1110": "binary"
     "-0x_0A_74_AE": "negative hexadecimal"
     "-190:20:30": "negative sexagesimal"
@@ -1043,6 +1050,7 @@ std.assertEqual(
     ".NaN": "not a number"
     ".inf": "positive infinity"
     "02472256": "octal"
+    0X_0a_74_ae: "BARE_KEY"
     "0b1010_0111_0100_1010_1110": "binary"
     "0x_0A_74_AE": "hexadecimal"
     1-234-567-8901: "BARE_KEY"
@@ -1067,6 +1075,9 @@ std.assertEqual(
     "On": "boolean true"
     "True": "boolean true"
     "Yes": "boolean true"
+    __-0B1010_0111_0100_1010_1110: "BARE_KEY"
+    __-0X_0a_74_ae: "BARE_KEY"
+    b: "BARE_KEY"
     jsonnet.org/k8s-label-like: "BARE_KEY"
     just-letters-dashes: "BARE_KEY"
     just_letters_underscores: "BARE_KEY"
@@ -1075,6 +1086,7 @@ std.assertEqual(
     "off": "boolean false"
     "on": "boolean true"
     "true": "boolean true"
+    x: "BARE_KEY"
     "y": "boolean true"
     "yes": "boolean true"
     "~": "null key"
@@ -1136,11 +1148,17 @@ std.assertEqual(
     "yes": "boolean true"
     "~": "null key"
     ---
+    -0B1010_0111_0100_1010_1110: "BARE_KEY"
+    0X_0a_74_ae: "BARE_KEY"
     1-234-567-8901: "BARE_KEY"
     192.168.0.1: "BARE_KEY"
+    __-0B1010_0111_0100_1010_1110: "BARE_KEY"
+    __-0X_0a_74_ae: "BARE_KEY"
+    b: "BARE_KEY"
     jsonnet.org/k8s-label-like: "BARE_KEY"
     just-letters-dashes: "BARE_KEY"
     just_letters_underscores: "BARE_KEY"
+    x: "BARE_KEY"
     ...
   |||
 ) &&

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -561,6 +561,67 @@ local some_json = {
   '"': null,
 };
 
+local bare_yaml_quoted = {
+  '685230': 'canonical',
+  '+685_230': 'decimal',
+  '02472256': 'octal',
+  '-1_0': 'negative integer',
+  '-0.1_0_0': 'negative float',
+  '0x_0A_74_AE': 'hexadecimal',
+  '-0x_0A_74_AE': 'negative hexadecimal',
+  '0b1010_0111_0100_1010_1110': 'binary',
+  '-0b1010_0111_0100_1010_1110': 'binary',
+  '190:20:30': 'sexagesimal',
+  '-190:20:30': 'negative sexagesimal',
+  '6.8523015e+5': 'canonical',
+  '6.8523015e-5': 'canonical',
+  '-6.8523015e+5': 'negative canonical',
+  '685.230_15e+03': 'exponential',
+  '-685.230_15e+03': 'negative exponential',
+  '-685.230_15e-03': 'negative w/ negative exponential',
+  '-685.230_15E-03': 'negative w/ negative exponential',
+  '685_230.15': 'fixed',
+  '-685_230.15': 'negative fixed',
+  '190:20:30.15': 'sexagesimal',
+  '-190:20:30.15': 'negative sexagesimal',
+  '-.inf': 'negative infinity',
+  '.inf': 'positive infinity',
+  '+.inf': 'positive infinity',
+  '.NaN': 'not a number',
+  y: 'boolean true',
+  yes: 'boolean true',
+  Yes: 'boolean true',
+  True: 'boolean true',
+  'true': 'boolean true',
+  on: 'boolean true',
+  On: 'boolean true',
+  NO: 'boolean false',
+  n: 'boolean false',
+  N: 'boolean false',
+  off: 'boolean false',
+  OFF: 'boolean false',
+  'null': 'null word',
+  NULL: 'null word capital',
+  Null: 'null word',
+  '~': 'null key',
+  '': 'empty key',
+  '-': 'invalid bare key',
+  '---': 'triple dash key',
+  '2001-12-15T02:59:43.1Z': 'canonical',
+  '2001-12-14t21:59:43.10-05:00': 'valid iso8601',
+  '2001-12-14 21:59:43.10 -5': 'space separated',
+  '2001-12-15 2:59:43.10': 'no time zone (Z)',
+  '2002-12-14': 'date',
+};
+local bare_yaml_unquoted = {
+  just_letters_underscores: 'BARE_KEY',
+  'just-letters-dashes': 'BARE_KEY',
+  'jsonnet.org/k8s-label-like': 'BARE_KEY',
+  '192.168.0.1': 'BARE_KEY',
+  '1-234-567-8901': 'BARE_KEY',
+};
+local bare_yaml_test = bare_yaml_quoted + bare_yaml_unquoted;
+
 std.assertEqual(
   std.manifestJsonEx(some_json, '    ') + '\n',
   |||
@@ -617,6 +678,16 @@ std.assertEqual(
   std.manifestJsonMinified(some_json),
   '{"\\"":null,"arr":[[[]]],"emptyArray":[],"emptyObject":{},"objectInArray":[{"f":3}],'
   + '"x":[1,2,3,true,false,null,"string\\nstring\\n"],"y":{"a":1,"b":2,"c":[1,2]}}'
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc([{ x: [1, 2, 3] }], quote_keys=false) + '\n',
+  |||
+    - x:
+      - 1
+      - 2
+      - 3
+  |||
 ) &&
 
 std.assertEqual(
@@ -681,6 +752,21 @@ std.assertEqual(
 ) &&
 
 std.assertEqual(
+  std.manifestYamlDoc({ x: [[[1, { f: 3, g: [1, 2] }, 1]]] }, quote_keys=false) + '\n',
+  |||
+    x:
+    -
+      -
+        - 1
+        - f: 3
+          g:
+          - 1
+          - 2
+        - 1
+  |||
+) &&
+
+std.assertEqual(
   std.manifestYamlDoc('hello\nworld\n') + '\n',
   |||
     |
@@ -702,6 +788,15 @@ std.assertEqual(
   std.manifestYamlDoc({ f: 'hello\nworld\n' }) + '\n',
   |||
     "f": |
+      hello
+      world
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc({ f: 'hello\nworld\n' }, quote_keys=false) + '\n',
+  |||
+    f: |
       hello
       world
   |||
@@ -738,9 +833,49 @@ std.assertEqual(
 ) &&
 
 std.assertEqual(
+  std.manifestYamlDoc(some_json, quote_keys=false) + '\n',
+  |||
+    "\"": null
+    arr:
+    -
+      - []
+    emptyArray: []
+    emptyObject: {}
+    objectInArray:
+    - f: 3
+    x:
+    - 1
+    - 2
+    - 3
+    - true
+    - false
+    - null
+    - |
+      string
+      string
+    "y":
+      a: 1
+      b: 2
+      c:
+      - 1
+      - 2
+  |||
+) &&
+
+std.assertEqual(
   std.manifestYamlDoc([{ x: [1, 2, 3] }], indent_array_in_object=true) + '\n',
   |||
     - "x":
+        - 1
+        - 2
+        - 3
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc([{ x: [1, 2, 3] }], indent_array_in_object=true, quote_keys=false) + '\n',
+  |||
+    - x:
         - 1
         - 2
         - 3
@@ -856,6 +991,161 @@ std.assertEqual(
 ) &&
 
 std.assertEqual(
+  std.manifestYamlDoc(some_json, indent_array_in_object=true, quote_keys=false) + '\n',
+  |||
+    "\"": null
+    arr:
+      -
+        - []
+    emptyArray: []
+    emptyObject: {}
+    objectInArray:
+      - f: 3
+    x:
+      - 1
+      - 2
+      - 3
+      - true
+      - false
+      - null
+      - |
+        string
+        string
+    "y":
+      a: 1
+      b: 2
+      c:
+        - 1
+        - 2
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc(bare_yaml_test, quote_keys=false) + '\n',
+  |||
+    "": "empty key"
+    "+.inf": "positive infinity"
+    "+685_230": "decimal"
+    "-": "invalid bare key"
+    "---": "triple dash key"
+    "-.inf": "negative infinity"
+    "-0.1_0_0": "negative float"
+    "-0b1010_0111_0100_1010_1110": "binary"
+    "-0x_0A_74_AE": "negative hexadecimal"
+    "-190:20:30": "negative sexagesimal"
+    "-190:20:30.15": "negative sexagesimal"
+    "-1_0": "negative integer"
+    "-6.8523015e+5": "negative canonical"
+    "-685.230_15E-03": "negative w/ negative exponential"
+    "-685.230_15e+03": "negative exponential"
+    "-685.230_15e-03": "negative w/ negative exponential"
+    "-685_230.15": "negative fixed"
+    ".NaN": "not a number"
+    ".inf": "positive infinity"
+    "02472256": "octal"
+    "0b1010_0111_0100_1010_1110": "binary"
+    "0x_0A_74_AE": "hexadecimal"
+    1-234-567-8901: "BARE_KEY"
+    "190:20:30": "sexagesimal"
+    "190:20:30.15": "sexagesimal"
+    192.168.0.1: "BARE_KEY"
+    "2001-12-14 21:59:43.10 -5": "space separated"
+    "2001-12-14t21:59:43.10-05:00": "valid iso8601"
+    "2001-12-15 2:59:43.10": "no time zone (Z)"
+    "2001-12-15T02:59:43.1Z": "canonical"
+    "2002-12-14": "date"
+    "6.8523015e+5": "canonical"
+    "6.8523015e-5": "canonical"
+    "685.230_15e+03": "exponential"
+    "685230": "canonical"
+    "685_230.15": "fixed"
+    "N": "boolean false"
+    "NO": "boolean false"
+    "NULL": "null word capital"
+    "Null": "null word"
+    "OFF": "boolean false"
+    "On": "boolean true"
+    "True": "boolean true"
+    "Yes": "boolean true"
+    jsonnet.org/k8s-label-like: "BARE_KEY"
+    just-letters-dashes: "BARE_KEY"
+    just_letters_underscores: "BARE_KEY"
+    "n": "boolean false"
+    "null": "null word"
+    "off": "boolean false"
+    "on": "boolean true"
+    "true": "boolean true"
+    "y": "boolean true"
+    "yes": "boolean true"
+    "~": "null key"
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlStream([bare_yaml_quoted, bare_yaml_unquoted], quote_keys=false),
+  |||
+    ---
+    "": "empty key"
+    "+.inf": "positive infinity"
+    "+685_230": "decimal"
+    "-": "invalid bare key"
+    "---": "triple dash key"
+    "-.inf": "negative infinity"
+    "-0.1_0_0": "negative float"
+    "-0b1010_0111_0100_1010_1110": "binary"
+    "-0x_0A_74_AE": "negative hexadecimal"
+    "-190:20:30": "negative sexagesimal"
+    "-190:20:30.15": "negative sexagesimal"
+    "-1_0": "negative integer"
+    "-6.8523015e+5": "negative canonical"
+    "-685.230_15E-03": "negative w/ negative exponential"
+    "-685.230_15e+03": "negative exponential"
+    "-685.230_15e-03": "negative w/ negative exponential"
+    "-685_230.15": "negative fixed"
+    ".NaN": "not a number"
+    ".inf": "positive infinity"
+    "02472256": "octal"
+    "0b1010_0111_0100_1010_1110": "binary"
+    "0x_0A_74_AE": "hexadecimal"
+    "190:20:30": "sexagesimal"
+    "190:20:30.15": "sexagesimal"
+    "2001-12-14 21:59:43.10 -5": "space separated"
+    "2001-12-14t21:59:43.10-05:00": "valid iso8601"
+    "2001-12-15 2:59:43.10": "no time zone (Z)"
+    "2001-12-15T02:59:43.1Z": "canonical"
+    "2002-12-14": "date"
+    "6.8523015e+5": "canonical"
+    "6.8523015e-5": "canonical"
+    "685.230_15e+03": "exponential"
+    "685230": "canonical"
+    "685_230.15": "fixed"
+    "N": "boolean false"
+    "NO": "boolean false"
+    "NULL": "null word capital"
+    "Null": "null word"
+    "OFF": "boolean false"
+    "On": "boolean true"
+    "True": "boolean true"
+    "Yes": "boolean true"
+    "n": "boolean false"
+    "null": "null word"
+    "off": "boolean false"
+    "on": "boolean true"
+    "true": "boolean true"
+    "y": "boolean true"
+    "yes": "boolean true"
+    "~": "null key"
+    ---
+    1-234-567-8901: "BARE_KEY"
+    192.168.0.1: "BARE_KEY"
+    jsonnet.org/k8s-label-like: "BARE_KEY"
+    just-letters-dashes: "BARE_KEY"
+    just_letters_underscores: "BARE_KEY"
+    ...
+  |||
+) &&
+
+std.assertEqual(
   std.manifestYamlStream([some_json, some_json, {}, [], 3, '"']),
   |||
     ---
@@ -906,6 +1196,71 @@ std.assertEqual(
       "a": 1
       "b": 2
       "c":
+      - 1
+      - 2
+    ---
+    {}
+    ---
+    []
+    ---
+    3
+    ---
+    "\""
+    ...
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlStream([some_json, some_json, {}, [], 3, '"'], quote_keys=false),
+  |||
+    ---
+    "\"": null
+    arr:
+    -
+      - []
+    emptyArray: []
+    emptyObject: {}
+    objectInArray:
+    - f: 3
+    x:
+    - 1
+    - 2
+    - 3
+    - true
+    - false
+    - null
+    - |
+      string
+      string
+    "y":
+      a: 1
+      b: 2
+      c:
+      - 1
+      - 2
+    ---
+    "\"": null
+    arr:
+    -
+      - []
+    emptyArray: []
+    emptyObject: {}
+    objectInArray:
+    - f: 3
+    x:
+    - 1
+    - 2
+    - 3
+    - true
+    - false
+    - null
+    - |
+      string
+      string
+    "y":
+      a: 1
+      b: 2
+      c:
       - 1
       - 2
     ---


### PR DESCRIPTION
Adds a new keyword argument to `manifestYamlDoc` and
`manifestYamlStream` named `quote_keys` that when set to `false` any
identifier without special characters will be rendered without quotes.

`quote_keys` is default `true` in all cases to keep the default behavior
matching what it is today.  This way the new behavior is strictly
opt-in.