### PR TITLE
add support for yaml streams to website conversion tool

### DIFF
--- a/doc/js/demo.js
+++ b/doc/js/demo.js
@@ -440,7 +440,7 @@ function yaml_conv_demo(input_id, textarea_id, filename, output_id) {
   let process_func = function(
         main_file, input_files_content, last_selected, last_scroll, add_textarea_and_tab) {
     let content = input_files_content[main_file];
-    let parsed_yaml = jsyaml.load(content);
+    let parsed_yaml = jsyaml.loadAll(content);
     let yaml_json = JSON.stringify(parsed_yaml, null, 2);
     let jsonnet_str = jsonnet_fmt_snippet_wrapped(filename, yaml_json)
     jsonnet_str = jsonnet_str.replace(/\n$/, '');


### PR DESCRIPTION
The conversion tool https://jsonnet.org/articles/kubernetes.html is a great way to quickly convert Kubernetes yaml manifests to Jsonnet, but it doesn't work with a yaml document streams with multiple objects.

You get `YAMLException: expected a single document in the stream, but found more` .

This tiny change allows the website conversion tool to accept yaml document streams containing multiple Kubernetes objects