### PR TITLE
Add tailstrict to std *stripChars functions

### DIFF
--- a/benchmarks/bench.09.jsonnet
+++ b/benchmarks/bench.09.jsonnet
@@ -1,0 +1,8 @@
+// This string must be longer than max stack frames
+local veryLongString = std.join('', std.repeat(['e'], 510));
+
+std.assertEqual(std.stripChars(veryLongString + 'ok' + veryLongString, 'e'), 'ok') &&
+std.assertEqual(std.lstripChars(veryLongString + 'ok', 'e'), 'ok') &&
+std.assertEqual(std.rstripChars('ok' + veryLongString, 'e'), 'ok') &&
+
+true

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -56,14 +56,14 @@ limitations under the License.
 
   lstripChars(str, chars)::
     if std.length(str) > 0 && std.member(chars, str[0]) then
-      std.lstripChars(str[1:], chars)
+      std.lstripChars(str[1:], chars) tailstrict
     else
       str,
 
   rstripChars(str, chars)::
     local len = std.length(str);
     if len > 0 && std.member(chars, str[len - 1]) then
-      std.rstripChars(str[:len - 1], chars)
+      std.rstripChars(str[:len - 1], chars) tailstrict
     else
       str,
 


### PR DESCRIPTION
Current implementation will fail with `max stack frames exceeded` for provided simple test cases. This PR fixes that by adding the tail recursion flag. I think this was just missing.

Sadly, testing the stack limit is very time consuming. I think it could be ok to drop the provided tests too. Times on my machine (`time make test` after `make`):

 * `make test  39.70s user 5.38s system 99% cpu 45.507 total` for original tests
 * `make test  52.49s user 5.02s system 99% cpu 57.874 total` for only `rstripChars`
 * `make test  81.86s user 5.35s system 99% cpu 1:27.63 total` for both (the provided commit)