### PR TITLE
Fix double definition of libname 'std.std.clamp/3'

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -167,7 +167,7 @@ local html = import 'html.libsonnet';
       ],
       fields: [
         {
-          name: 'std.clamp',
+          name: 'clamp',
           params: ['x', 'minVal', 'maxVal'],
           availableSince: '0.15.0',
           description: |||


### PR DESCRIPTION
26th July 2021
https://jsonnet.org/ref/stdlib.html reads: 

```
std.std.clamp(x, minVal, maxVal)
Available since version 0.15.0.
```

Should read: 
```
std.clamp(x, minVal, maxVal)
Available since version 0.15.0.
```