### PR TITLE
Add official OSI name in the license metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ jsonnet_ext = Extension(
 setup(name='jsonnet',
       url='https://jsonnet.org',
       description='Python bindings for Jsonnet - The data templating language ',
+      license="Apache License 2.0",
       author='David Cunningham',
       author_email='dcunnin@google.com',
       version=get_version(),


### PR DESCRIPTION
This makes it easier for automatic license checkers to verify the license of this package.