### PR TITLE
Add test case for #942 std.parseYaml and block (pipe)

### DIFF
--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -1500,6 +1500,16 @@ std.assertEqual(
     |||
   ), [1, 2, 3]
 ) &&
+std.assertEqual(
+  std.parseYaml(
+    |||
+      f1: |
+        a
+        b
+      f2: "a\nb\n"
+    |||
+  ), { f1: 'a\nb\n', f2: 'a\nb\n' }
+) &&
 
 std.assertEqual(std.asciiUpper('!@#$%&*()asdfghFGHJKL09876 '), '!@#$%&*()ASDFGHFGHJKL09876 ') &&
 std.assertEqual(std.asciiLower('!@#$%&*()asdfghFGHJKL09876 '), '!@#$%&*()asdfghfghjkl09876 ') &&


### PR DESCRIPTION
std.parseYaml() doesn't handle this properly:

    f1: |
      a
      b

A test case for issue #942