### PR TITLE
Fix Heap-use-after-free in Interpreter::evaluate

### DIFF
--- a/core/vm.cpp
+++ b/core/vm.cpp
@@ -3037,7 +3037,6 @@ class Interpreter {
                 case FRAME_STRING_CONCAT: {
                     const auto &ast = *static_cast<const Binary *>(f.ast);
                     const Value &lhs = stack.top().val;
-                    const Value &rhs = stack.top().val2;
                     UString output;
                     if (lhs.t == Value::STRING) {
                         output.append(static_cast<const HeapString *>(lhs.v.h)->value);
@@ -3045,6 +3044,7 @@ class Interpreter {
                         scratch = lhs;
                         output.append(toString(ast.left->location));
                     }
+                    const Value &rhs = stack.top().val2;
                     if (rhs.t == Value::STRING) {
                         output.append(static_cast<const HeapString *>(rhs.v.h)->value);
                     } else {


### PR DESCRIPTION
This PR addresses a couple of issues found by OSS-Fuzz.

In [vm.cpp:3040](https://github.com/google/jsonnet/blob/2b5c760ef285a6a9f887152e163183911e0e8499/core/vm.cpp#L3040), the reference to `rhs` might be invalidated by the call to `toString` on line [vm.cpp:3046](https://github.com/google/jsonnet/blob/2b5c760ef285a6a9f887152e163183911e0e8499/core/vm.cpp#L3046), as `toString` might (eventually) call `stack.newFrame`. `newFrame` modifies the stack with `vector::emplace_back`, whose documentation includes:

> If the new size() is greater than capacity() then all iterators and references (including the past-the-end iterator) are invalidated. Otherwise only the past-the-end iterator is invalidated.

Moving the `rhs` declaration after the call to `toString` should ensure that we're not holding an invalidated reference. Since `toString` is supposed to return the stack the same size it was at the beginning of the call, moving the `rhs` declaration down should not change the `rhs` value.

Fixes:
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15888
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15970