### PR TITLE
Handle JSON parse error

### DIFF
--- a/core/vm.cpp
+++ b/core/vm.cpp
@@ -1585,11 +1585,14 @@ class Interpreter {
 
         std::string value = encode_utf8(static_cast<HeapString *>(args[0].v.h)->value);
 
-        auto j = json::parse(value);
+        try {
+            auto j = json::parse(value);
 
-        bool filled;
-
-        otherJsonToHeap(j, filled, scratch);
+            bool filled;
+            otherJsonToHeap(j, filled, scratch);
+        } catch (const json::parse_error &e) {
+            throw makeError(loc, e.what());
+        }
 
         return nullptr;
     }

--- a/test_suite/error.parse_json.jsonnet
+++ b/test_suite/error.parse_json.jsonnet
@@ -1,0 +1,1 @@
+std.parseJson('broken json')

--- a/test_suite/error.parse_json.jsonnet.golden
+++ b/test_suite/error.parse_json.jsonnet.golden
@@ -1,0 +1,2 @@
+RUNTIME ERROR: [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - invalid literal; last read: 'b'
+	error.parse_json.jsonnet:1:1-29	


### PR DESCRIPTION
Catches `json::parse_error` from the JSON parser and generates corresponding RuntimeError.

Closes #680