### PR TITLE
split and splitLimit to support multi-character strings

### DIFF
--- a/core/vm.cpp
+++ b/core/vm.cpp
@@ -1466,11 +1466,11 @@ class Interpreter {
         auto &elements = static_cast<HeapArray *>(scratch.v.h)->elements;
         while (test < str->value.size() && (maxsplits == -1 ||
                                             size_t(maxsplits) > elements.size())) {
-            if (c->value[0] == str->value[test]) {
+            if (c->value == str->value.substr(test, c->value.size())) {
                 auto *th = makeHeap<HeapThunk>(idArrayElement, nullptr, 0, nullptr);
                 elements.push_back(th);
                 th->fill(makeString(str->value.substr(start, test - start)));
-                start = test + 1;
+                start = test + c->value.size();
                 test = start;
             } else {
                 ++test;

--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -339,36 +339,46 @@ local html = import 'html.libsonnet';
         {
           name: 'split',
           params: ['str', 'c'],
-          description: |||
-            Split the string <code>str</code> into an array of strings, divided by the single character
-            <code>c</code>.
-          |||,
+          description: [
+            html.p({}, |||
+              Split the string <code>str</code> into an array of strings, divided by the string
+              <code>c</code>.
+            |||),
+            html.p({}, |||
+              Note: Versions up to and including 0.18.0 require <code>c</code> to be a single character.
+            |||),
+          ],
           examples: [
             {
-              input: @'std.split("foo/bar", "/")',
-              output: std.split('foo/bar', '/'),
+              input: @'std.split("foo/_bar", "/_")',
+              output: std.split('foo/_bar', '/_'),
             },
             {
-              input: @'std.split("/foo/", "/")',
-              output: std.split('/foo/', '/'),
+              input: @'std.split("/_foo/_bar", "/_")',
+              output: std.split('/_foo/_bar', '/_'),
             },
           ],
         },
         {
           name: 'splitLimit',
           params: ['str', 'c', 'maxsplits'],
-          description: |||
-            As std.split(str, c) but will stop after <code>maxsplits</code> splits, thereby the largest
-            array it will return has length <code>maxsplits + 1</code>.  A limit of -1 means unlimited.
-          |||,
+          description: [
+            html.p({}, |||
+              As <code>std.split(str, c)</code> but will stop after <code>maxsplits</code> splits, thereby the largest
+              array it will return has length <code>maxsplits + 1</code>. A limit of <code>-1</code> means unlimited.
+            |||),
+            html.p({}, |||
+              Note: Versions up to and including 0.18.0 require <code>c</code> to be a single character.
+            |||),
+          ],
           examples: [
             {
-              input: @'std.splitLimit("foo/bar", "/", 1)',
-              output: std.splitLimit('foo/bar', '/', 1),
+              input: @'std.splitLimit("foo/_bar", "/_", 1)',
+              output: std.splitLimit('foo/_bar', '/_', 1),
             },
             {
-              input: @'std.splitLimit("/foo/bar", "/", 1)',
-              output: std.splitLimit('/foo/bar', '/', 1),
+              input: @'std.splitLimit("/_foo/_bar", "/_", 1)',
+              output: std.splitLimit('/_foo/_bar', '/_', 1),
             },
           ],
         },

--- a/doc/ref/stdlib.html
+++ b/doc/ref/stdlib.html
@@ -785,14 +785,17 @@ title: Standard Library
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        Split the string <code>str</code> into an array of strings, divided by the single character
+        Split the string <code>str</code> into an array of strings, divided by the string
         <code>c</code>.
       </p>
       <p>
-        Example: <code>std.split("foo/bar", "/")</code> yields <code>[ "foo", "bar" ]</code>.
+        Note: Versions up to and including 0.18.0 require <code>c</code> to be a single character.
       </p>
       <p>
-        Example: <code>std.split("/foo/", "/")</code> yields <code>[ "", "foo", "" ]</code>.
+        Example: <code>std.split("foo/_bar", "/_")</code> yields <code>[ "foo", "bar" ]</code>.
+      </p>
+      <p>
+        Example: <code>std.split("/_foo/_bar", "/_")</code> yields <code>[ "", "foo", "bar" ]</code>.
       </p>
     </div>
     <div style="clear: both"></div>
@@ -813,14 +816,17 @@ title: Standard Library
   <div class="hgroup-inline">
     <div class="panel">
       <p>
-        As std.split(str, c) but will stop after <code>maxsplits</code> splits, thereby the largest
-        array it will return has length <code>maxsplits + 1</code>.  A limit of -1 means unlimited.
+        As <code>std.split(str, c)</code> but will stop after <code>maxsplits</code> splits, thereby the largest
+        array it will return has length <code>maxsplits + 1</code>. A limit of <code>-1</code> means unlimited.
       </p>
       <p>
-        Example: <code>std.splitLimit("foo/bar", "/", 1)</code> yields <code>[ "foo", "bar" ]</code>.
+        Note: Versions up to and including 0.18.0 require <code>c</code> to be a single character.
       </p>
       <p>
-        Example: <code>std.splitLimit("/foo/bar", "/", 1)</code> yields <code>[ "", "foo/bar" ]</code>.
+        Example: <code>std.splitLimit("foo/_bar", "/_", 1)</code> yields <code>[ "foo", "bar" ]</code>.
+      </p>
+      <p>
+        Example: <code>std.splitLimit("/_foo/_bar", "/_", 1)</code> yields <code>[ "", "foo/_bar" ]</code>.
       </p>
     </div>
     <div style="clear: both"></div>

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -110,26 +110,27 @@ limitations under the License.
     parse_nat(str, 16),
 
   split(str, c)::
-    assert std.isString(str) : 'std.split first parameter should be a string, got ' + std.type(str);
-    assert std.isString(c) : 'std.split second parameter should be a string, got ' + std.type(c);
-    assert std.length(c) == 1 : 'std.split second parameter should have length 1, got ' + std.length(c);
+    assert std.isString(str) : 'std.split first parameter must be a String, got ' + std.type(str);
+    assert std.isString(c) : 'std.split second parameter must be a String, got ' + std.type(c);
+    assert std.length(c) >= 1 : 'std.split second parameter must have length 1 or greater, got ' + std.length(c);
     std.splitLimit(str, c, -1),
 
   splitLimit(str, c, maxsplits)::
-    assert std.isString(str) : 'std.splitLimit first parameter should be a string, got ' + std.type(str);
-    assert std.isString(c) : 'std.splitLimit second parameter should be a string, got ' + std.type(c);
-    assert std.length(c) == 1 : 'std.splitLimit second parameter should have length 1, got ' + std.length(c);
-    assert std.isNumber(maxsplits) : 'std.splitLimit third parameter should be a number, got ' + std.type(maxsplits);
-    local aux(str, delim, i, arr, v) =
-      local c = str[i];
-      local i2 = i + 1;
-      if i >= std.length(str) then
-        arr + [v]
-      else if c == delim && (maxsplits == -1 || std.length(arr) < maxsplits) then
-        aux(str, delim, i2, arr + [v], '') tailstrict
+    assert std.isString(str) : 'str.splitLimit first parameter must be a String, got ' + std.type(str);
+    assert std.isString(c) : 'str.splitLimit second parameter must be a String, got ' + std.type(c);
+    assert std.length(c) >= 1 : 'std.splitLimit second parameter must have length 1 or greater, got ' + std.length(c);
+    assert std.isNumber(maxsplits) : 'str.splitLimit third parameter must be a Number, got ' + std.type(maxsplits);
+    local strLen = std.length(str);
+    local cLen = std.length(c);
+    local aux(idx, ret, val) =
+      if idx >= strLen then
+        ret + [val]
+      else if str[idx : idx + cLen : 1] == c &&
+              (maxsplits == -1 || std.length(ret) < maxsplits) then
+        aux(idx + cLen, ret + [val], '')
       else
-        aux(str, delim, i2, arr, v + c) tailstrict;
-    aux(str, c, 0, [], ''),
+        aux(idx + 1, ret, val + str[idx]);
+    aux(0, [], ''),
 
   strReplace(str, from, to)::
     assert std.isString(str);

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -480,9 +480,13 @@ std.assertEqual(std.extVar('var2') { x+: 2 }.x, 3) &&
 
 std.assertEqual(std.split('foo/bar', '/'), ['foo', 'bar']) &&
 std.assertEqual(std.split('/foo/', '/'), ['', 'foo', '']) &&
+std.assertEqual(std.split('foo/_bar', '/_'), ['foo', 'bar']) &&
+std.assertEqual(std.split('/_foo/_', '/_'), ['', 'foo', '']) &&
 
 std.assertEqual(std.splitLimit('foo/bar', '/', 1), ['foo', 'bar']) &&
 std.assertEqual(std.splitLimit('/foo/', '/', 1), ['', 'foo/']) &&
+std.assertEqual(std.splitLimit('foo/_bar', '/_', 1), ['foo', 'bar']) &&
+std.assertEqual(std.splitLimit('/_foo/_', '/_', 1), ['', 'foo/_']) &&
 
 local some_toml = {
   key: 'value',


### PR DESCRIPTION
Per https://github.com/google/jsonnet/issues/965, adds the ability to split on multi-character strings. Just a few notes:

- Updated both Jsonnet and underlying C++ code.
- ~~Changed `c` parameter name to `pat` to better match existing semantics of `std.findSubstr()`.~~
- Changed `aux()` signature to only pass required parameters, referring to all others from outside the `local` scope.