### PR TITLE
Any all optimization

### DIFF
--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1608,11 +1608,18 @@ limitations under the License.
     if !std.isArray(arr) then
       error 'any() parameter should be an array, got ' + std.type(arr)
     else
-      local or = function(x, y)
-        if !std.isBoolean(y) then
-          error std.format('element "%s" of type %s is not a boolean', y, std.type(y))
-        else x || y;
-      std.foldl(or, arr, false),
+      local arrLen = std.length(arr);
+      local aux(idx) =
+        local e = arr[idx];
+        if idx >= arrLen then
+          false
+        else if !std.isBoolean(e) then
+          error std.format('element "%s" of type %s is not a boolean', e, std.type(e))
+        else if e then
+          true
+        else
+          aux(idx + 1) tailstrict;
+      aux(0),
 
   // Three way comparison.
   // TODO(sbarzowski): consider exposing and documenting it properly

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1599,11 +1599,19 @@ limitations under the License.
     if !std.isArray(arr) then
       error 'all() parameter should be an array, got ' + std.type(arr)
     else
-      local and = function(x, y)
-        if !std.isBoolean(y) then
-          error std.format('element "%s" of type %s is not a boolean', y, std.type(y))
-        else x && y;
-      std.foldl(and, arr, true),
+      local arrLen = std.length(arr);
+      local aux(idx) =
+        local e = arr[idx];
+        if idx >= arrLen then
+          true
+        else if !std.isBoolean(e) then
+          error std.format('element "%s" of type %s is not a boolean', e, std.type(e))
+        else if !e then
+          false
+        else
+          aux(idx + 1) tailstrict;
+      aux(0),
+
   any(arr)::
     if !std.isArray(arr) then
       error 'any() parameter should be an array, got ' + std.type(arr)

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1601,15 +1601,16 @@ limitations under the License.
     else
       local arrLen = std.length(arr);
       local aux(idx) =
-        local e = arr[idx];
         if idx >= arrLen then
           true
-        else if !std.isBoolean(e) then
-          error std.format('element "%s" of type %s is not a boolean', e, std.type(e))
-        else if !e then
-          false
         else
-          aux(idx + 1) tailstrict;
+          local e = arr[idx];
+          if !std.isBoolean(e) then
+            error std.format('element "%s" of type %s is not a boolean', e, std.type(e))
+          else if !e then
+            false
+          else
+            aux(idx + 1) tailstrict;
       aux(0),
 
   any(arr)::
@@ -1618,15 +1619,16 @@ limitations under the License.
     else
       local arrLen = std.length(arr);
       local aux(idx) =
-        local e = arr[idx];
         if idx >= arrLen then
           false
-        else if !std.isBoolean(e) then
-          error std.format('element "%s" of type %s is not a boolean', e, std.type(e))
-        else if e then
-          true
         else
-          aux(idx + 1) tailstrict;
+          local e = arr[idx];
+          if !std.isBoolean(e) then
+            error std.format('element "%s" of type %s is not a boolean', e, std.type(e))
+          else if e then
+            true
+          else
+            aux(idx + 1) tailstrict;
       aux(0),
 
   // Three way comparison.

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1596,40 +1596,34 @@ limitations under the License.
       std.filter(function(i) arr[i] == value, std.range(0, std.length(arr) - 1)),
 
   all(arr)::
-    if !std.isArray(arr) then
-      error 'all() parameter should be an array, got ' + std.type(arr)
-    else
-      local arrLen = std.length(arr);
-      local aux(idx) =
-        if idx >= arrLen then
-          true
-        else
-          local e = arr[idx];
-          if !std.isBoolean(e) then
-            error std.format('element "%s" of type %s is not a boolean', e, std.type(e))
-          else if !e then
-            false
-          else
-            aux(idx + 1) tailstrict;
-      aux(0),
-
-  any(arr)::
-    if !std.isArray(arr) then
-      error 'any() parameter should be an array, got ' + std.type(arr)
-    else
-      local arrLen = std.length(arr);
-      local aux(idx) =
-        if idx >= arrLen then
+    assert std.isArray(arr) : 'all() parameter should be an array, got ' + std.type(arr);
+    local arrLen = std.length(arr);
+    local aux(idx) =
+      if idx >= arrLen then
+        true
+      else
+        local e = arr[idx];
+        assert std.isBoolean(e) : std.format('element "%s" of type %s is not a boolean', e, std.type(e));
+        if !e then
           false
         else
-          local e = arr[idx];
-          if !std.isBoolean(e) then
-            error std.format('element "%s" of type %s is not a boolean', e, std.type(e))
-          else if e then
-            true
-          else
-            aux(idx + 1) tailstrict;
-      aux(0),
+          aux(idx + 1) tailstrict;
+    aux(0),
+
+  any(arr)::
+    assert std.isArray(arr) : 'any() parameter should be an array, got ' + std.type(arr);
+    local arrLen = std.length(arr);
+    local aux(idx) =
+      if idx >= arrLen then
+        false
+      else
+        local e = arr[idx];
+        assert std.isBoolean(e) : std.format('element "%s" of type %s is not a boolean', e, std.type(e));
+        if e then
+          true
+        else
+          aux(idx + 1) tailstrict;
+    aux(0),
 
   // Three way comparison.
   // TODO(sbarzowski): consider exposing and documenting it properly


### PR DESCRIPTION
`std.any()` and `std.all()` iterate over all items in their input when it can be short circuited. This has large speed gains when working with large lists:

<details>
  <summary><code>std.any()</code></summary>

```shell
# Before code change
$ time echo 'std.any(std.map(function(x) false, std.range(0, 100000)) + [true])' | bazel run -c opt //cmd:jsonnet 2> /dev/null -- -
true

real    0m3.775s
user    0m3.626s
sys     0m0.070s

$ time echo 'std.any([true] + std.map(function(x) false, std.range(0, 100000)))' | bazel run -c opt //cmd:jsonnet 2> /dev/null -- -
true

real    0m3.820s
user    0m3.676s
sys     0m0.061s


# After code change
$ time echo 'std.any(std.map(function(x) false, std.range(0, 100000)) + [true])' | bazel run -c opt //cmd:jsonnet 2> /dev/null -- -
true

real    0m3.306s
user    0m3.196s
sys     0m0.031s

$ time echo 'std.any([true] + std.map(function(x) false, std.range(0, 100000)))' | bazel run -c opt //cmd:jsonnet 2> /dev/null -- -
true

real    0m0.190s
user    0m0.099s
sys     0m0.011s
```
</details>

<details>
  <summary><code>std.all()</code></summary>

```shell
# Before code change
$ time echo 'std.all(std.map(function(x) true, std.range(0, 100000)) + [false])' | bazel run -c opt //cmd:jsonnet 2> /dev/null -- -
false

real    0m3.865s
user    0m3.757s
sys     0m0.031s

$ time echo 'std.all([false] + std.map(function(x) true, std.range(0, 100000)))' | bazel run -c opt //cmd:jsonnet 2> /dev/null -- -
false

real    0m3.896s
user    0m3.765s
sys     0m0.060s


# After code change
$ time echo 'std.all([false] + std.map(function(x) true, std.range(0, 100000)))' | bazel run -c opt //cmd:jsonnet 2> /dev/null -- -
false

real    0m0.180s
user    0m0.102s
sys     0m0.010s

$ time echo 'std.all(std.map(function(x) true, std.range(0, 100000)) + [false])' | bazel run -c opt //cmd:jsonnet 2> /dev/null -- -
false

real    0m3.408s
user    0m3.280s
sys     0m0.051s
```
</details>