### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,9 @@ jsonnet_ext = Extension(
 
 setup(name='jsonnet',
       url='https://jsonnet.org',
+      project_urls={
+        'Source': 'https://github.com/google/jsonnet',
+      },
       description='Python bindings for Jsonnet - The data templating language ',
       license="Apache License 2.0",
       author='David Cunningham',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)