### PR TITLE
Add failing test for formatting integer

### DIFF
--- a/test_suite/format.jsonnet
+++ b/test_suite/format.jsonnet
@@ -39,6 +39,7 @@ std.assertEqual(std.format('%c', [std.codepoint('a')]), 'a') &&
 
 // d (also a quick test of i and u)
 std.assertEqual(std.format('thing-%d', [10]), 'thing-10') &&
+std.assertEqual(std.format('thing-%d', [1650391876808854107]), 'thing-1650391876808854107') &&
 std.assertEqual(std.format('thing-%#ld', [10]), 'thing-10') &&
 std.assertEqual(std.format('thing-%d', [-10]), 'thing--10') &&
 std.assertEqual(std.format('thing-%4d', [10]), 'thing-  10') &&


### PR DESCRIPTION
This isn't strictly a pull request. More a demonstration of an issue I am observing.

When formatting some integers using `%d`, I am finding incorrect results for certain inputs.
I added an example failing case in this PR.

I am unfamiliar with this codebase, but I've tracked it down as far as: https://github.com/google/jsonnet/blob/914f636a575f9aef68089ab7de93601eecddd325/stdlib/std.jsonnet#L517-L522

For example:
```
➜  jsonnet -e "local a(n) = (if n == 0 then '' else (a(std.floor(n / 10)) + (n % 10))); a(1650391876808854107)"
"1650391876808854086"
➜  jsonnet -e "local a(n) = (if n == 0 then '' else (a(std.floor(n / 10)) + (n % 10))); a(1650391876808854107) == '1650391876808854107'"
false
```

I couldn't see an issue for this open anywhere; I am happy to open an issue if that is preferred.

I saw https://github.com/google/jsonnet/issues/880, which calls for more extensive testing. Which feels related, but not strictly inclusive of what I am seeing here.