### PR TITLE
docs: remove double http:// in link

### DIFF
--- a/doc/articles/kubernetes.html
+++ b/doc/articles/kubernetes.html
@@ -76,7 +76,7 @@ title: Kubernetes
           work with Kubernetes.
         </li>
         <li>
-          <a href="https://https://github.com/jsonnet-libs/k8s">jsonnet-libs/k8s</a>
+          <a href="https://github.com/jsonnet-libs/k8s">jsonnet-libs/k8s</a>
           generator produces over 30 Jsonnet Kubernetes libraries and counting, with most
           notably the <a href="https://jsonnet-libs.github.io/k8s-libsonnet/">k8s-libsonnet</a> library
           as the succesor of ksonnet-lib.


### PR DESCRIPTION
I made a typo here.