### PR TITLE
Fix memory leaks in libjsonnet++.cpp

### DIFF
--- a/cpp/libjsonnet++.cpp
+++ b/cpp/libjsonnet++.cpp
@@ -94,12 +94,14 @@ bool Jsonnet::evaluateFile(const std::string& filename, std::string* output)
         return false;
     }
     int error = 0;
-    const char* jsonnet_output = ::jsonnet_evaluate_file(vm_, filename.c_str(), &error);
+    char* jsonnet_output = ::jsonnet_evaluate_file(vm_, filename.c_str(), &error);
     if (error != 0) {
         last_error_.assign(jsonnet_output);
+        jsonnet_realloc(vm_, jsonnet_output, 0);
         return false;
     }
     output->assign(jsonnet_output);
+    jsonnet_realloc(vm_, jsonnet_output, 0);
     return true;
 }
 
@@ -110,13 +112,15 @@ bool Jsonnet::evaluateSnippet(const std::string& filename, const std::string& sn
         return false;
     }
     int error = 0;
-    const char* jsonnet_output =
+    char* jsonnet_output =
         ::jsonnet_evaluate_snippet(vm_, filename.c_str(), snippet.c_str(), &error);
     if (error != 0) {
         last_error_.assign(jsonnet_output);
+        jsonnet_realloc(vm_, jsonnet_output, 0);
         return false;
     }
     output->assign(jsonnet_output);
+    jsonnet_realloc(vm_, jsonnet_output, 0);
     return true;
 }
 
@@ -146,12 +150,14 @@ bool Jsonnet::evaluateFileMulti(const std::string& filename,
         return false;
     }
     int error = 0;
-    const char* jsonnet_output = ::jsonnet_evaluate_file_multi(vm_, filename.c_str(), &error);
+    char* jsonnet_output = ::jsonnet_evaluate_file_multi(vm_, filename.c_str(), &error);
     if (error != 0) {
         last_error_.assign(jsonnet_output);
+        jsonnet_realloc(vm_, jsonnet_output, 0);
         return false;
     }
     parseMultiOutput(jsonnet_output, outputs);
+    jsonnet_realloc(vm_, jsonnet_output, 0);
     return true;
 }
 
@@ -162,13 +168,15 @@ bool Jsonnet::evaluateSnippetMulti(const std::string& filename, const std::strin
         return false;
     }
     int error = 0;
-    const char* jsonnet_output =
+    char* jsonnet_output =
         ::jsonnet_evaluate_snippet_multi(vm_, filename.c_str(), snippet.c_str(), &error);
     if (error != 0) {
         last_error_.assign(jsonnet_output);
+        jsonnet_realloc(vm_, jsonnet_output, 0);
         return false;
     }
     parseMultiOutput(jsonnet_output, outputs);
+    jsonnet_realloc(vm_, jsonnet_output, 0);
     return true;
 }
 


### PR DESCRIPTION
Summary:
This PR intends to fix the memory leaks inside the libjsonnet++.cpp. The memory leaks exist due to the lack of `jsonnet_realloc`, and were reported in the issue https://github.com/google/jsonnet/issues/845.

Tests:
I used valgrind to verify that the fix. 
Before the fix was applied, valgrind finds 5 leaks.
``````
tma@3414-desktop:~/jsonnet$ valgrind --leak-check=yes bazel-bin/cpp/libjsonnet++_test
==19260== Memcheck, a memory error detector
==19260== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==19260== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
==19260== Command: bazel-bin/cpp/libjsonnet++_test
==19260== 
Running main() from gmock_main.cc
[==========] Running 5 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 5 tests from JsonnetTest
[ RUN      ] JsonnetTest.TestEvaluateSnippet
[       OK ] JsonnetTest.TestEvaluateSnippet (6933 ms)
[ RUN      ] JsonnetTest.TestEvaluateInvalidSnippet
[       OK ] JsonnetTest.TestEvaluateInvalidSnippet (6107 ms)
[ RUN      ] JsonnetTest.TestEvaluateFile
[       OK ] JsonnetTest.TestEvaluateFile (6086 ms)
[ RUN      ] JsonnetTest.TestEvaluateInvalidFile
[       OK ] JsonnetTest.TestEvaluateInvalidFile (6106 ms)
[ RUN      ] JsonnetTest.TestAddImportPath
[       OK ] JsonnetTest.TestAddImportPath (9214 ms)
[----------] 5 tests from JsonnetTest (34453 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test case ran. (34493 ms total)
[  PASSED  ] 5 tests.
==19260== 
==19260== HEAP SUMMARY:
==19260==     in use at exit: 72,869 bytes in 6 blocks
==19260==   total heap usage: 1,911,067 allocs, 1,911,061 frees, 114,849,773 bytes allocated
==19260== 
==19260== 15 bytes in 1 blocks are definitely lost in loss record 1 of 6
==19260==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==19260==    by 0x4F73113: jsonnet_realloc (libjsonnet.cpp:693)
==19260==    by 0x4F6FB5F: from_string(JsonnetVm*, std::string const&) (libjsonnet.cpp:47)
==19260==    by 0x4F71CFE: jsonnet_evaluate_snippet_aux(JsonnetVm*, char const*, char const*, int*, (anonymous namespace)::EvalKind) (libjsonnet.cpp:515)
==19260==    by 0x4F72E1B: jsonnet_evaluate_snippet (libjsonnet.cpp:664)
==19260==    by 0x40296B2: jsonnet::Jsonnet::evaluateSnippet(std::string const&, std::string const&, std::string*) (libjsonnet++.cpp:114)
==19260==    by 0x403A87: jsonnet::JsonnetTest_TestEvaluateSnippet_Test::TestBody() (libjsonnet++_test.cpp:44)
==19260==    by 0x414FB99: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2443)
==19260==    by 0x414B9ED: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2479)
==19260==    by 0x4138857: testing::Test::Run() (gtest.cc:2518)
==19260==    by 0x4139088: testing::TestInfo::Run() (gtest.cc:2693)
==19260==    by 0x41396C6: testing::TestCase::Run() (gtest.cc:2811)
==19260== 
==19260== 15 bytes in 1 blocks are definitely lost in loss record 2 of 6
==19260==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==19260==    by 0x4F73113: jsonnet_realloc (libjsonnet.cpp:693)
==19260==    by 0x4F6FB5F: from_string(JsonnetVm*, std::string const&) (libjsonnet.cpp:47)
==19260==    by 0x4F71CFE: jsonnet_evaluate_snippet_aux(JsonnetVm*, char const*, char const*, int*, (anonymous namespace)::EvalKind) (libjsonnet.cpp:515)
==19260==    by 0x4F72A68: jsonnet_evaluate_file_aux(JsonnetVm*, char const*, int*, (anonymous namespace)::EvalKind) (libjsonnet.cpp:634)
==19260==    by 0x4F72B33: jsonnet_evaluate_file (libjsonnet.cpp:640)
==19260==    by 0x4029609: jsonnet::Jsonnet::evaluateFile(std::string const&, std::string*) (libjsonnet++.cpp:97)
==19260==    by 0x404734: jsonnet::JsonnetTest_TestEvaluateFile_Test::TestBody() (libjsonnet++_test.cpp:69)
==19260==    by 0x414FB99: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2443)
==19260==    by 0x414B9ED: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2479)
==19260==    by 0x4138857: testing::Test::Run() (gtest.cc:2518)
==19260==    by 0x4139088: testing::TestInfo::Run() (gtest.cc:2693)
==19260== 
==19260== 15 bytes in 1 blocks are definitely lost in loss record 3 of 6
==19260==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==19260==    by 0x4F73113: jsonnet_realloc (libjsonnet.cpp:693)
==19260==    by 0x4F6FB5F: from_string(JsonnetVm*, std::string const&) (libjsonnet.cpp:47)
==19260==    by 0x4F71CFE: jsonnet_evaluate_snippet_aux(JsonnetVm*, char const*, char const*, int*, (anonymous namespace)::EvalKind) (libjsonnet.cpp:515)
==19260==    by 0x4F72A68: jsonnet_evaluate_file_aux(JsonnetVm*, char const*, int*, (anonymous namespace)::EvalKind) (libjsonnet.cpp:634)
==19260==    by 0x4F72B33: jsonnet_evaluate_file (libjsonnet.cpp:640)
==19260==    by 0x4029609: jsonnet::Jsonnet::evaluateFile(std::string const&, std::string*) (libjsonnet++.cpp:97)
==19260==    by 0x405342: jsonnet::JsonnetTest_TestAddImportPath_Test::TestBody() (libjsonnet++_test.cpp:94)
==19260==    by 0x414FB99: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2443)
==19260==    by 0x414B9ED: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2479)
==19260==    by 0x4138857: testing::Test::Run() (gtest.cc:2518)
==19260==    by 0x4139088: testing::TestInfo::Run() (gtest.cc:2693)
==19260== 
==19260== 60 bytes in 1 blocks are definitely lost in loss record 4 of 6
==19260==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==19260==    by 0x4F73113: jsonnet_realloc (libjsonnet.cpp:693)
==19260==    by 0x4F6FB5F: from_string(JsonnetVm*, std::string const&) (libjsonnet.cpp:47)
==19260==    by 0x4F727B7: jsonnet_evaluate_snippet_aux(JsonnetVm*, char const*, char const*, int*, (anonymous namespace)::EvalKind) (libjsonnet.cpp:614)
==19260==    by 0x4F72E1B: jsonnet_evaluate_snippet (libjsonnet.cpp:664)
==19260==    by 0x40296B2: jsonnet::Jsonnet::evaluateSnippet(std::string const&, std::string const&, std::string*) (libjsonnet++.cpp:114)
==19260==    by 0x404103: jsonnet::JsonnetTest_TestEvaluateInvalidSnippet_Test::TestBody() (libjsonnet++_test.cpp:57)
==19260==    by 0x414FB99: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2443)
==19260==    by 0x414B9ED: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2479)
==19260==    by 0x4138857: testing::Test::Run() (gtest.cc:2518)
==19260==    by 0x4139088: testing::TestInfo::Run() (gtest.cc:2693)
==19260==    by 0x41396C6: testing::TestCase::Run() (gtest.cc:2811)
==19260== 
==19260== 60 bytes in 1 blocks are definitely lost in loss record 5 of 6
==19260==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==19260==    by 0x4F73113: jsonnet_realloc (libjsonnet.cpp:693)
==19260==    by 0x4F6FB5F: from_string(JsonnetVm*, std::string const&) (libjsonnet.cpp:47)
==19260==    by 0x4F727B7: jsonnet_evaluate_snippet_aux(JsonnetVm*, char const*, char const*, int*, (anonymous namespace)::EvalKind) (libjsonnet.cpp:614)
==19260==    by 0x4F72A68: jsonnet_evaluate_file_aux(JsonnetVm*, char const*, int*, (anonymous namespace)::EvalKind) (libjsonnet.cpp:634)
==19260==    by 0x4F72B33: jsonnet_evaluate_file (libjsonnet.cpp:640)
==19260==    by 0x4029609: jsonnet::Jsonnet::evaluateFile(std::string const&, std::string*) (libjsonnet++.cpp:97)
==19260==    by 0x404D12: jsonnet::JsonnetTest_TestEvaluateInvalidFile_Test::TestBody() (libjsonnet++_test.cpp:81)
==19260==    by 0x414FB99: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2443)
==19260==    by 0x414B9ED: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2479)
==19260==    by 0x4138857: testing::Test::Run() (gtest.cc:2518)
==19260==    by 0x4139088: testing::TestInfo::Run() (gtest.cc:2693)
==19260== 
==19260== LEAK SUMMARY:
==19260==    definitely lost: 165 bytes in 5 blocks
==19260==    indirectly lost: 0 bytes in 0 blocks
==19260==      possibly lost: 0 bytes in 0 blocks
==19260==    still reachable: 72,704 bytes in 1 blocks
==19260==         suppressed: 0 bytes in 0 blocks
==19260== Reachable blocks (those to which a pointer was found) are not shown.
==19260== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==19260== 
==19260== For counts of detected and suppressed errors, rerun with: -v
==19260== ERROR SUMMARY: 5 errors from 5 contexts (suppressed: 0 from 0)
``````

After the fix is applied, valgrind finds no leaks
``````
tma@3414-desktop:~/jsonnet$ valgrind --leak-check=yes bazel-bin/cpp/libjsonnet++_test
==20104== Memcheck, a memory error detector
==20104== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==20104== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
==20104== Command: bazel-bin/cpp/libjsonnet++_test
==20104== 
Running main() from gmock_main.cc
[==========] Running 5 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 5 tests from JsonnetTest
[ RUN      ] JsonnetTest.TestEvaluateSnippet
[       OK ] JsonnetTest.TestEvaluateSnippet (6960 ms)
[ RUN      ] JsonnetTest.TestEvaluateInvalidSnippet
[       OK ] JsonnetTest.TestEvaluateInvalidSnippet (6095 ms)
[ RUN      ] JsonnetTest.TestEvaluateFile
[       OK ] JsonnetTest.TestEvaluateFile (6052 ms)
[ RUN      ] JsonnetTest.TestEvaluateInvalidFile
[       OK ] JsonnetTest.TestEvaluateInvalidFile (6050 ms)
[ RUN      ] JsonnetTest.TestAddImportPath
[       OK ] JsonnetTest.TestAddImportPath (9169 ms)
[----------] 5 tests from JsonnetTest (34334 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test case ran. (34375 ms total)
[  PASSED  ] 5 tests.
==20104== 
==20104== HEAP SUMMARY:
==20104==     in use at exit: 72,704 bytes in 1 blocks
==20104==   total heap usage: 1,911,067 allocs, 1,911,066 frees, 114,849,773 bytes allocated
==20104== 
==20104== LEAK SUMMARY:
==20104==    definitely lost: 0 bytes in 0 blocks
==20104==    indirectly lost: 0 bytes in 0 blocks
==20104==      possibly lost: 0 bytes in 0 blocks
==20104==    still reachable: 72,704 bytes in 1 blocks
==20104==         suppressed: 0 bytes in 0 blocks
==20104== Reachable blocks (those to which a pointer was found) are not shown.
==20104== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==20104== 
==20104== For counts of detected and suppressed errors, rerun with: -v
==20104== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
``````