### PR TITLE
Add #include <cstdint> for gcc-13 builds

### DIFF
--- a/include/libjsonnet++.h
+++ b/include/libjsonnet++.h
@@ -17,6 +17,7 @@ limitations under the License.
 #ifndef CPP_JSONNET_H_
 #define CPP_JSONNET_H_
 
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <map>


### PR DESCRIPTION
See https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes.

This fixes Gentoo bug https://bugs.gentoo.org/875569.