### PR TITLE
Add Github Action to create release and linux binary associated

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -1,0 +1,52 @@
+on:
+  push:
+    ankor-main
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout self repo
+        uses: actions/checkout@v3
+
+      - name: Cache build
+        uses: actions/cache@v3
+        id: cache_build
+        with:
+          path: .
+          key: build-${{ hashFiles('include/libjsonnet.h') }}
+          restore-keys: |
+            build-${{ hashFiles('include/libjsonnet.h') }}
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(grep '#define.*LIB_JSONNET_VERSION' include/libjsonnet.h | head -n 1 | cut -f 2 -d '"' | sed 's/^v//g')
+          echo "::set-output name=version::${VERSION}"
+
+      - name: Build
+        id: build
+        run: |
+          make -j dist
+
+      - name: Create Release
+        id: release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          release_name: v${{ steps.version.outputs.version }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release.outputs.upload_url }}
+          asset_path: jsonnet-bin.tar.gz
+          asset_name: jsonnet-bin-v${{ steps.version.outputs.version }}-linux.tar.gz
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
This simple change adds a Github action to create, on any new jsonnet version, a Github release with a jsonnet binary for linux associated.