### PR TITLE
Not a templating language

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: The Data Templating Language
+title: A Functional Data Rendering Language
 ---
 
 <div class=hgroup>
@@ -11,7 +11,7 @@ title: The Data Templating Language
           <td><img id=big-logo src=img/isologo.svg></td>
           <td class=side-text>
             <p>
-              A data templating language<br>
+              A data rendering language<br>
               for app and tool developers
             </p>
             <ul>


### PR DESCRIPTION
The website describes Jsonnet as a "templating language". For a broader definition of "templating", this is correct. However, with templating tools such as Jinja or Helm around that treat structured data as flat text files, the term suggests that Jsonnet is less powerful than it is.

This suggestion arose from a conversation with a colleague who refused to use "another templating language". I'm suggesting this description harms Jsonnet, by limiting it.

Other possible descriptions:
* a purely functional language (with OO features)
* A powerful DSL for elegant description of JSON data
* A powerful data rendering language
