### PR TITLE
[Fixes 1037] Documents the escapeStringXml added in #1038

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -522,6 +522,22 @@ local html = import 'html.libsonnet';
             <code>std.escapeStringJson</code>.
           |||,
         },
+        {
+          name: 'escapeStringXml',
+          params: ['str'],
+          description: |||
+            Convert <code>str</code> to allow it to be embedded in XML (or HTML). The following replacements are made:
+            <pre>
+            {
+              "&lt;": "&amp;lt;",
+              "&gt;": "&amp;gt;",
+              "&amp;": "&amp;amp;",
+              "\&quot;": "&amp;quot;",
+              "&apos;": "&amp;apos;",
+            }
+            </pre>
+          |||,
+        },
       ],
     },
     {

--- a/doc/ref/stdlib.html
+++ b/doc/ref/stdlib.html
@@ -1093,6 +1093,37 @@ title: Standard Library
   </div>
 </div>
 
+<div class="hgroup">
+  <div class="hgroup-inline">
+    <div class="panel">
+      <h4 id="escapeStringXml">
+        std.escapeStringXml(str)
+      </h4>
+    </div>
+    <div style="clear: both"></div>
+  </div>
+</div>
+<div class="hgroup">
+  <div class="hgroup-inline">
+    <div class="panel">
+      <p>
+        Convert <code>str</code> to allow it to be embedded in XML (or HTML). The following replacements are made:
+        <pre>
+        {
+          "&lt;": "&amp;lt;",
+          "&gt;": "&amp;gt;",
+          "&amp;": "&amp;amp;",
+          "\&quot;": "&amp;quot;",
+          "&apos;": "&amp;apos;",
+        }
+        </pre>
+      </p>
+      
+    </div>
+    <div style="clear: both"></div>
+  </div>
+</div>
+
 
 <div class="hgroup">
   <div class="hgroup-inline">


### PR DESCRIPTION
See:
- <https://github.com/google/jsonnet/issues/1037>
- <https://github.com/google/jsonnet/issues/1038>