### PR TITLE
feat: implement std.sum

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -1308,6 +1308,16 @@ local html = import 'html.libsonnet';
             |||,
           ]),
         },
+        {
+          name: 'sum',
+          params: ['arr'],
+          availableSince: 'v0.19.2',
+          description: html.paragraphs([
+            |||
+              Return sum of all element in <code>arr</code>.
+            |||,
+          ]),
+        },
       ],
     },
     {

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1681,4 +1681,5 @@ limitations under the License.
   __array_less_or_equal(arr1, arr2):: std.__compare_array(arr1, arr2) <= 0,
   __array_greater_or_equal(arr1, arr2):: std.__compare_array(arr1, arr2) >= 0,
 
+  sum(arr):: std.foldl(function(a,b)a+b,arr,0),
 }

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -1530,4 +1530,6 @@ std.assertEqual(std.all([true, false]), false) &&
 std.assertEqual(std.all([true, true]), true) &&
 std.assertEqual(std.all([]), true) &&
 
+std.assertEqual(std.sum([1, 2, 3]), 6) &&
+
 true


### PR DESCRIPTION
Add `std.sum` function in standard library.

PR for go-jsonnet: https://github.com/google/go-jsonnet/pull/669