### PR TITLE
Add std.xor for 2 booleans in standard library

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -1435,6 +1435,19 @@ local html = import 'html.libsonnet';
       ],
     },
     {
+      name: 'Booleans',
+      id: 'booleans',
+      fields: [
+        {
+          name: 'xor',
+          params: ['x', 'y'],
+          description: |||
+            Returns the xor of the two given booleans.
+          |||,
+        },
+      ],
+    },
+    {
       name: 'JSON Merge Patch',
       id: 'json_merge_patch',
       fields: [

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1682,4 +1682,6 @@ limitations under the License.
   __array_greater_or_equal(arr1, arr2):: std.__compare_array(arr1, arr2) >= 0,
 
   sum(arr):: std.foldl(function(a,b)a+b,arr,0),
+
+  xor(x, y):: x!=y,
 }

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -1532,4 +1532,7 @@ std.assertEqual(std.all([]), true) &&
 
 std.assertEqual(std.sum([1, 2, 3]), 6) &&
 
+std.assertEqual(std.xor(true, false), true) &&
+std.assertEqual(std.xor(true, true), false) &&
+
 true


### PR DESCRIPTION
Add `std.xor` to standard library.

PR for go-jsonnet: [googe/go-jsonnet#676](https://github.com/google/go-jsonnet/pull/676)