### PR TITLE
Add std.xnor for 2 booleans

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -1445,6 +1445,13 @@ local html = import 'html.libsonnet';
             Returns the xor of the two given booleans.
           |||,
         },
+        {
+          name: 'xnor',
+          params: ['x', 'y'],
+          description: |||
+            Returns the xnor of the two given booleans.
+          |||,
+        },
       ],
     },
     {

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1684,4 +1684,6 @@ limitations under the License.
   sum(arr):: std.foldl(function(a,b)a+b,arr,0),
 
   xor(x, y):: x!=y,
+
+  xnor(x, y):: x==y,
 }

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -1535,4 +1535,7 @@ std.assertEqual(std.sum([1, 2, 3]), 6) &&
 std.assertEqual(std.xor(true, false), true) &&
 std.assertEqual(std.xor(true, true), false) &&
 
+std.assertEqual(std.xnor(true, false), false) &&
+std.assertEqual(std.xnor(true, true), true) &&
+
 true


### PR DESCRIPTION
Add `std.xnor` to standard library.

PR for go-jsonnet: [google/go-jsonnet#677](https://github.com/google/go-jsonnet/pull/677)
