### PR TITLE
Add std.isEmpty for string

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -409,6 +409,13 @@ local html = import 'html.libsonnet';
           ],
         },
         {
+          name: 'isEmpty',
+          params: ['str'],
+          description: |||
+            Returns true if the the given string is of zero length.
+          |||,
+        },
+        {
           name: 'asciiUpper',
           params: ['str'],
           description: |||

--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -411,6 +411,7 @@ local html = import 'html.libsonnet';
         {
           name: 'isEmpty',
           params: ['str'],
+          availableSince: 'upcoming',
           description: |||
             Returns true if the the given string is of zero length.
           |||,

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1684,4 +1684,6 @@ limitations under the License.
   sum(arr):: std.foldl(function(a,b)a+b,arr,0),
 
   xor(x, y):: x!=y,
+
+  isEmpty(str):: std.length(str) == 0,
 }

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -1535,4 +1535,7 @@ std.assertEqual(std.sum([1, 2, 3]), 6) &&
 std.assertEqual(std.xor(true, false), true) &&
 std.assertEqual(std.xor(true, true), false) &&
 
+std.assertEqual(std.isEmpty(""), true) &&
+std.assertEqual(std.isEmpty("non-empty string"), false) &&
+
 true


### PR DESCRIPTION
Add `std.isEmpty` to standard library.

PR for go-jsonnet: https://github.com/google/go-jsonnet/pull/678