### PR TITLE
Add objectKeysValues, objectKeysValuesAll

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -98,6 +98,15 @@ local html = import 'html.libsonnet';
           |||,
         },
         {
+          name: 'objectKeysValues',
+          params: ['o'],
+          availableSince: 'upcoming',
+          description: |||
+            Returns an array of objects from the given object, each object having two fields: 
+            <code>key</code> (string) and <code>value</code> (object). Does not include hidden fields.
+          |||,
+        },
+        {
           name: 'objectHasAll',
           params: ['o', 'f'],
           description: |||
@@ -117,6 +126,14 @@ local html = import 'html.libsonnet';
           availableSince: '0.17.0',
           description: |||
             As <code>std.objectValues</code> but also includes hidden fields.
+          |||,
+        },
+        {
+          name: 'objectKeysValuesAll',
+          params: ['o'],
+          availableSince: 'upcoming',
+          description: |||
+            As <code>std.objectKeysValues</code> but also includes hidden fields.
           |||,
         },
         {

--- a/doc/ref/stdlib.html
+++ b/doc/ref/stdlib.html
@@ -262,6 +262,34 @@ title: Standard Library
 <div class="hgroup">
   <div class="hgroup-inline">
     <div class="panel">
+      <h4 id="objectKeysValues">
+        std.objectKeysValues(o)
+      </h4>
+    </div>
+    <div style="clear: both"></div>
+  </div>
+</div>
+<div class="hgroup">
+  <div class="hgroup-inline">
+    <div class="panel">
+      <p>
+        <em>
+          Available in upcoming release.
+        </em>
+      </p>
+      <p>
+        Returns an array of objects from the given object, each object having two fields: 
+        <code>key</code> (string) and <code>value</code> (object). Does not include hidden fields.
+      </p>
+      
+    </div>
+    <div style="clear: both"></div>
+  </div>
+</div>
+
+<div class="hgroup">
+  <div class="hgroup-inline">
+    <div class="panel">
       <h4 id="objectHasAll">
         std.objectHasAll(o, f)
       </h4>
@@ -323,6 +351,33 @@ title: Standard Library
       </p>
       <p>
         As <code>std.objectValues</code> but also includes hidden fields.
+      </p>
+      
+    </div>
+    <div style="clear: both"></div>
+  </div>
+</div>
+
+<div class="hgroup">
+  <div class="hgroup-inline">
+    <div class="panel">
+      <h4 id="objectKeysValuesAll">
+        std.objectKeysValuesAll(o)
+      </h4>
+    </div>
+    <div style="clear: both"></div>
+  </div>
+</div>
+<div class="hgroup">
+  <div class="hgroup-inline">
+    <div class="panel">
+      <p>
+        <em>
+          Available in upcoming release.
+        </em>
+      </p>
+      <p>
+        As <code>std.objectKeysValues</code> but also includes hidden fields.
       </p>
       
     </div>
@@ -2344,6 +2399,33 @@ e = {"f1": False, "f2": 42}</pre>
   </div>
 </div>
 
+<div class="hgroup">
+  <div class="hgroup-inline">
+    <div class="panel">
+      <h4 id="sum">
+        std.sum(arr)
+      </h4>
+    </div>
+    <div style="clear: both"></div>
+  </div>
+</div>
+<div class="hgroup">
+  <div class="hgroup-inline">
+    <div class="panel">
+      <p>
+        <em>
+          Available since version v0.19.2.
+        </em>
+      </p>
+      <p>
+        Return sum of all element in <code>arr</code>.
+      </p>
+      
+    </div>
+    <div style="clear: both"></div>
+  </div>
+</div>
+
 
 <div class="hgroup">
   <div class="hgroup-inline">
@@ -2596,6 +2678,40 @@ e = {"f1": False, "f2": 42}</pre>
     <div class="panel">
       <p>
         Encodes the given value into an MD5 string.
+      </p>
+      
+    </div>
+    <div style="clear: both"></div>
+  </div>
+</div>
+
+
+<div class="hgroup">
+  <div class="hgroup-inline">
+    <div class="panel">
+      <h3 id="booleans">
+        Booleans
+      </h3>
+    </div>
+    <div style="clear: both"></div>
+  </div>
+</div>
+
+<div class="hgroup">
+  <div class="hgroup-inline">
+    <div class="panel">
+      <h4 id="xor">
+        std.xor(x, y)
+      </h4>
+    </div>
+    <div style="clear: both"></div>
+  </div>
+</div>
+<div class="hgroup">
+  <div class="hgroup-inline">
+    <div class="panel">
+      <p>
+        Returns the xor of the two given booleans.
       </p>
       
     </div>

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1539,6 +1539,12 @@ limitations under the License.
   objectValuesAll(o)::
     [o[k] for k in std.objectFieldsAll(o)],
 
+  objectKeysValues(o)::
+    [{ key: k, value: o[k] } for k in std.objectFields(o)],
+
+  objectKeysValuesAll(o)::
+    [{ key: k, value: o[k] } for k in std.objectFieldsAll(o)],
+
   equals(a, b)::
     local ta = std.type(a);
     local tb = std.type(b);

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -168,6 +168,18 @@ std.assertEqual(std.objectValues({ x::: 1 } { x: 1 }), [1]) &&
 std.assertEqual(std.objectValues({ x::: 1 } { x:: 1 }), []) &&
 std.assertEqual(std.objectValues({ x::: 1 } { x::: 1 }), [1]) &&
 
+std.assertEqual(std.objectKeysValues({}), []) &&
+std.assertEqual(std.objectKeysValues({ x: 1, y: 2 }), [{ key: 'x', value: 1 }, { key: 'y', value: 2 }]) &&
+std.assertEqual(std.objectKeysValues({ x: 1 } { x: 1 }), [{ key: 'x', value: 1 }]) &&
+std.assertEqual(std.objectKeysValues({ x: 1 } { x:: 1 }), []) &&
+std.assertEqual(std.objectKeysValues({ x: 1 } { x::: 1 }), [{ key: 'x', value: 1 }]) &&
+std.assertEqual(std.objectKeysValues({ x:: 1 } { x: 1 }), []) &&
+std.assertEqual(std.objectKeysValues({ x:: 1 } { x:: 1 }), []) &&
+std.assertEqual(std.objectKeysValues({ x:: 1 } { x::: 1 }), [{ key: 'x', value: 1 }]) &&
+std.assertEqual(std.objectKeysValues({ x::: 1 } { x: 1 }), [{ key: 'x', value: 1 }]) &&
+std.assertEqual(std.objectKeysValues({ x::: 1 } { x:: 1 }), []) &&
+std.assertEqual(std.objectKeysValues({ x::: 1 } { x::: 1 }), [{ key: 'x', value: 1 }]) &&
+
 std.assertEqual(std.get({ x: 1, y: 2 }, 'x', 5), 1) &&
 std.assertEqual(std.get({ x: 1, y: 2 }, 'z', 5), 5) &&
 std.assertEqual(std.get({ x: 1, y: 2 }, 'z'), null) &&


### PR DESCRIPTION
This PR adds two helper functions for extracting an array of objects with keys and values from an object. It's a simple function but I think it's worth putting into the stdlib given its appearance in numerous feature requests https://github.com/google/jsonnet/issues/865, https://github.com/google/jsonnet/issues/543