### PR TITLE
feat: implement std.round

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -183,6 +183,7 @@ local html = import 'html.libsonnet';
               <ul><code>std.asin(x)</code></ul>
               <ul><code>std.acos(x)</code></ul>
               <ul><code>std.atan(x)</code></ul>
+              <ul><code>std.round(x)</code></ul>
           </ul>
           <p>
               The function <code>std.mod(a, b)</code> is what the % operator is desugared to. It performs

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1692,4 +1692,6 @@ limitations under the License.
   xor(x, y):: x!=y,
 
   xnor(x, y):: x==y,
+
+  round(x):: std.floor(x + 0.5),
 }

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -1550,4 +1550,7 @@ std.assertEqual(std.xor(true, true), false) &&
 std.assertEqual(std.xnor(true, false), false) &&
 std.assertEqual(std.xnor(true, true), true) &&
 
+std.assertEqual(std.round(1.2), 1) &&
+std.assertEqual(std.round(1.5), 2) &&
+
 true


### PR DESCRIPTION
Add `std.round` function in standard library.

PR for go-jsonnet: https://github.com/google/go-jsonnet/pull/683