### PR TITLE
feat: implement std.minArray

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -1421,6 +1421,16 @@ local html = import 'html.libsonnet';
             |||,
           ]),
         },
+        {
+          name: 'minArray',
+          params: ['arr'],
+          availableSince: 'upcoming',
+          description: html.paragraphs([
+            |||
+              Return min of all element in <code>arr</code>.
+            |||,
+          ]),
+        },
       ],
     },
     {

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1703,6 +1703,20 @@ limitations under the License.
 
   sum(arr):: std.foldl(function(a, b) a + b, arr, 0),
 
+  minArray(arr):: 
+    local len1 = std.length(arr);
+    if len1 == 0 
+      error 'std.minArr Array has no element.';
+    local minVal = arr[0];
+    local aux(i) =
+      if i < minLen then
+        local cmpRes = std.__compare(minVal, arr[i]);
+        if cmpRes > 0 then
+          minVal = cmpRes
+        else
+          aux(i + 1) tailstrict
+    aux(1),
+
   xor(x, y):: x != y,
 
   xnor(x, y):: x == y,

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -1544,6 +1544,9 @@ std.assertEqual(std.all([]), true) &&
 
 std.assertEqual(std.sum([1, 2, 3]), 6) &&
 
+std.assertEqual(std.minArray([1, 2, 3]), 1) &&
+std.assertEqual(std.minArray(['1', '2', '3']), '1') &&
+
 std.assertEqual(std.xor(true, false), true) &&
 std.assertEqual(std.xor(true, true), false) &&
 


### PR DESCRIPTION
Add `std.minArray` function in standard library.

PR for go-jsonnet: https://github.com/google/go-jsonnet/pull/685