### PR TITLE
feat: implement objectRemoveKey

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -71,83 +71,6 @@ local html = import 'html.libsonnet';
           |||,
         },
         {
-          name: 'get',
-          params: ['o', 'f', 'default=null', 'inc_hidden=true'],
-          availableSince: '0.18.0',
-          description: |||
-            Returns the object's field if it exists or default value otherwise.
-            <code>inc_hidden</code> controls whether to include hidden fields.
-          |||,
-        },
-        {
-          name: 'objectHas',
-          params: ['o', 'f'],
-          availableSince: '0.10.0',
-          description: |||
-            Returns <code>true</code> if the given object has the field (given as a string), otherwise
-            <code>false</code>. Raises an error if the arguments are not object and string
-            respectively. Returns false if the field is hidden.
-          |||,
-        },
-        {
-          name: 'objectFields',
-          params: ['o'],
-          availableSince: '0.10.0',
-          description: |||
-            Returns an array of strings, each element being a field from the given object. Does not include
-            hidden fields.
-          |||,
-        },
-        {
-          name: 'objectValues',
-          params: ['o'],
-          availableSince: '0.17.0',
-          description: |||
-            Returns an array of the values in the given object. Does not include hidden fields.
-          |||,
-        },
-        {
-          name: 'objectKeysValues',
-          params: ['o'],
-          availableSince: '0.20.0',
-          description: |||
-            Returns an array of objects from the given object, each object having two fields: 
-            <code>key</code> (string) and <code>value</code> (object). Does not include hidden fields.
-          |||,
-        },
-        {
-          name: 'objectHasAll',
-          params: ['o', 'f'],
-          availableSince: '0.10.0',
-          description: |||
-            As <code>std.objectHas</code> but also includes hidden fields.
-          |||,
-        },
-        {
-          name: 'objectFieldsAll',
-          params: ['o'],
-          availableSince: '0.10.0',
-          description: |||
-            As <code>std.objectFields</code> but also includes hidden fields.
-          |||,
-        },
-        {
-          name: 'objectValuesAll',
-          params: ['o'],
-          availableSince: '0.17.0',
-          description: |||
-            As <code>std.objectValues</code> but also includes hidden fields.
-          |||,
-        },
-        {
-          name: 'objectKeysValuesAll',
-          params: ['o'],
-          availableSince: '0.20.0',
-          description: |||
-            As <code>std.objectKeysValues</code> but also includes hidden fields.
-          |||,
-        },
-        {
           name: 'prune',
           params: ['a'],
           availableSince: '0.10.0',
@@ -155,16 +78,6 @@ local html = import 'html.libsonnet';
             Recursively remove all "empty" members of <code>a</code>. "Empty" is defined as zero
             length `arrays`, zero length `objects`, or `null` values.
             The argument <code>a</code> may have any type.
-          |||,
-        },
-        {
-          name: 'mapWithKey',
-          params: ['func', 'obj'],
-          availableSince: '0.10.0',
-          description: |||
-            Apply the given function to all fields of the given object, also passing
-            the field name. The function <code>func</code> is expected to take the
-            field name as the first parameter and the field value as the second.
           |||,
         },
       ],
@@ -1511,6 +1424,107 @@ local html = import 'html.libsonnet';
           availableSince: '0.10.0',
           description: |||
             Returns <code>true</code> if x is a member of array, otherwise <code>false</code>.
+          |||,
+        },
+      ],
+    },
+    {
+      name: 'Objects',
+      id: 'objects',
+      fields: [
+        {
+          name: 'get',
+          params: ['o', 'f', 'default=null', 'inc_hidden=true'],
+          availableSince: '0.18.0',
+          description: |||
+            Returns the object's field if it exists or default value otherwise.
+            <code>inc_hidden</code> controls whether to include hidden fields.
+          |||,
+        },
+        {
+          name: 'objectHas',
+          params: ['o', 'f'],
+          availableSince: '0.10.0',
+          description: |||
+            Returns <code>true</code> if the given object has the field (given as a string), otherwise
+            <code>false</code>. Raises an error if the arguments are not object and string
+            respectively. Returns false if the field is hidden.
+          |||,
+        },
+        {
+          name: 'objectFields',
+          params: ['o'],
+          availableSince: '0.10.0',
+          description: |||
+            Returns an array of strings, each element being a field from the given object. Does not include
+            hidden fields.
+          |||,
+        },
+        {
+          name: 'objectValues',
+          params: ['o'],
+          availableSince: '0.17.0',
+          description: |||
+            Returns an array of the values in the given object. Does not include hidden fields.
+          |||,
+        },
+        {
+          name: 'objectKeysValues',
+          params: ['o'],
+          availableSince: '0.20.0',
+          description: |||
+            Returns an array of objects from the given object, each object having two fields: 
+            <code>key</code> (string) and <code>value</code> (object). Does not include hidden fields.
+          |||,
+        },
+        {
+          name: 'objectHasAll',
+          params: ['o', 'f'],
+          availableSince: '0.10.0',
+          description: |||
+            As <code>std.objectHas</code> but also includes hidden fields.
+          |||,
+        },
+        {
+          name: 'objectFieldsAll',
+          params: ['o'],
+          availableSince: '0.10.0',
+          description: |||
+            As <code>std.objectFields</code> but also includes hidden fields.
+          |||,
+        },
+        {
+          name: 'objectValuesAll',
+          params: ['o'],
+          availableSince: '0.17.0',
+          description: |||
+            As <code>std.objectValues</code> but also includes hidden fields.
+          |||,
+        },
+        {
+          name: 'objectKeysValuesAll',
+          params: ['o'],
+          availableSince: '0.20.0',
+          description: |||
+            As <code>std.objectKeysValues</code> but also includes hidden fields.
+          |||,
+        },
+        {
+          name: 'objectRemoveKey',
+          params: ['obj', 'key'],
+          availableSince: 'upcoming',
+          description: |||
+            Returns a new object after removing the given key from object.
+          |||,
+        },
+        {
+          name: 'mapWithKey',
+          params: ['func', 'obj'],
+          availableSince: '0.10.0',
+          description: |||
+            Apply the given function to all fields of the given object, also passing
+            the field name. The function <code>func</code> is expected to take the
+            field name as the first parameter and the field value as the second.
           |||,
         },
       ],

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1724,4 +1724,10 @@ limitations under the License.
   isEmpty(str):: std.length(str) == 0,
 
   contains(arr, elem):: std.any([e == elem for e in arr]),
+  
+  objectRemoveKey(obj, key):: {
+    [k]: obj[k],
+    for k in std.objectFields(obj)
+    if k != key
+  },
 }

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -1559,7 +1559,9 @@ std.assertEqual(std.round(1.5), 2) &&
 std.assertEqual(std.isEmpty(''), true) &&
 std.assertEqual(std.isEmpty('non-empty string'), false) &&
 
-std.contains(std.contains([1, 2, 3], 2), true) &&
-std.contains(std.contains([1, 2, 3], "foo"), false) &&
+std.assertEqual(std.contains([1, 2, 3], 2), true) &&
+std.assertEqual(std.contains([1, 2, 3], "foo"), false) &&
+
+std.assertEqual(std.objectRemoveKey({ foo: 1, bar: 2, baz: 3 }, 'foo'), { bar: 2, baz: 3 }) &&
 
 true


### PR DESCRIPTION
Implemented `std.objectRemoveKey` method to remove a key from a object

PR for go-jsonnet: https://github.com/google/go-jsonnet/pull/686