### PR TITLE
Fix for #1072: Fix format with general format type.

### DIFF
--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -657,7 +657,7 @@ limitations under the License.
           error 'Format required number at '
                 + i + ', got ' + std.type(val)
         else
-          local exponent = std.floor(std.log(std.abs(val)) / std.log(10));
+          local exponent = if val != 0 then std.floor(std.log(std.abs(val)) / std.log(10)) else 0;
           if exponent < -4 || exponent >= fpprec then
             render_float_sci(val,
                              zp,

--- a/test_suite/format.jsonnet
+++ b/test_suite/format.jsonnet
@@ -216,6 +216,8 @@ std.assertEqual(std.format('%.1f', [1.95555]), '2.0') &&
 std.assertEqual(std.format('%.4f', [0.99995]), '1.0000') &&
 
 // g
+
+std.assertEqual(std.format('%g', [0]), '0') &&
 std.assertEqual(std.format('%#.3g', [1000000001]), '1.00e+09') &&
 std.assertEqual(std.format('%#.3g', [1100]), '1.10e+03') &&
 std.assertEqual(std.format('%#.3g', [1.1]), '1.10') &&
@@ -249,6 +251,7 @@ std.assertEqual(std.format('%10.5g', [110]), '       110') &&
 std.assertEqual(std.format('%10.5g', [1.1]), '       1.1') &&
 
 // G
+std.assertEqual(std.format('%G', [0]), '0') &&
 std.assertEqual(std.format('%#.3G', [1000000001]), '1.00E+09') &&
 std.assertEqual(std.format('%#.3G', [1100]), '1.10E+03') &&
 std.assertEqual(std.format('%#.3G', [1.1]), '1.10') &&


### PR DESCRIPTION
This PR fixes format when using the general format type and passing a value of 0 like that

`jsonnet -e "std.format('%g', [0])"`

or

`jsonnet -e "'%g' % 0"`

It basically adds a safeguard when calculating the exponent for the given value. 0 has to be treated differently as log is not undefined for 0.