### PR TITLE
feat: implement std.contains

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -1421,6 +1421,16 @@ local html = import 'html.libsonnet';
             |||,
           ]),
         },
+        {
+          name: 'contains',
+          params: ['arr', 'elem'],
+          availableSince: 'upcoming',
+          description: html.paragraphs([
+            |||
+              Return true if given <code>elem</code> is present in <code>arr</code>, false otherwise.
+            |||,
+          ]),
+        },
       ],
     },
     {

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1710,4 +1710,6 @@ limitations under the License.
   round(x):: std.floor(x + 0.5),
 
   isEmpty(str):: std.length(str) == 0,
+
+  contains(arr, elem):: std.any([e == elem for e in arr]),
 }

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -1556,4 +1556,7 @@ std.assertEqual(std.round(1.5), 2) &&
 std.assertEqual(std.isEmpty(''), true) &&
 std.assertEqual(std.isEmpty('non-empty string'), false) &&
 
+std.contains(std.contains([1, 2, 3], 2), true) &&
+std.contains(std.contains([1, 2, 3], "foo"), false) &&
+
 true


### PR DESCRIPTION
Implement `std.contains` function in standard library

go-jsonnet PR: https://github.com/google/go-jsonnet/pull/691