### PR TITLE
feat: Add support for bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,12 @@
+module(name = "jsonnet", version = "0.0.0")
+
+bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest")
+
+register_toolchains("//platform_defs:default_python3_toolchain")
+
+build_defs = use_extension("//tools/build_defs:extensions.bzl", "build_defs")
+use_repo(
+    build_defs,
+    "default_python3_headers",
+    "io_bazel_rules_jsonnet",
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,12 +1,14 @@
 module(name = "jsonnet", version = "0.0.0")
 
-bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest")
-
-register_toolchains("//platform_defs:default_python3_toolchain")
-
 build_defs = use_extension("//tools/build_defs:extensions.bzl", "build_defs")
 use_repo(
     build_defs,
     "default_python3_headers",
     "io_bazel_rules_jsonnet",
 )
+
+register_toolchains("//platform_defs:default_python3_toolchain")
+
+# Dev dependencies
+
+bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest", dev_dependency = True)

--- a/tools/build_defs/extensions.bzl
+++ b/tools/build_defs/extensions.bzl
@@ -1,0 +1,16 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load(":python_repo.bzl", "python_headers")
+
+def _impl(repository_ctx):
+    git_repository(
+         name = "io_bazel_rules_jsonnet",
+         commit = "ad2b4204157ddcf7919e8bd210f607f8a801aa7f",
+         remote = "https://github.com/bazelbuild/rules_jsonnet.git",
+         shallow_since = "1556260764 +0200",
+    )
+
+    python_headers(name = "default_python3_headers")
+
+build_defs = module_extension(
+    implementation = _impl,
+)


### PR DESCRIPTION
This PR adds a MODULE.bazel file which allows other repositories to import this one as a bzlmod module.
I don't know how Google handles publishing to the Bazel Central Registry, so I haven't made any attempt at that.

I've added a module extension to grab rules_jsonnet, as it isn't available yet as a module, and to create the python header repository.

All tests are successful when run with `--enable_bzlmod`, and running jsonnet/jsonnetfmt from //cmd succeeds.

I've also made a similar PR for go-jsonnet, which depends on this bzlmod module. That PR can be found here: https://github.com/google/go-jsonnet/pull/698