### PR TITLE
feat: Add crypto functions to stdlib

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -1612,6 +1612,58 @@ local html = import 'html.libsonnet';
             Encodes the given value into an MD5 string.
           |||,
         },
+        {
+          name: 'sha1',
+          params: ['s'],
+          availableSince: 'upcoming',
+          description: [
+            html.p({}, |||
+              Encodes the given value into an SHA1 string.
+            |||),
+            html.p({}, |||
+              This function is only available in Go version of jsonnet.
+            |||),
+          ],
+        },
+        {
+          name: 'sha256',
+          params: ['s'],
+          availableSince: 'upcoming',
+          description: [
+            html.p({}, |||
+              Encodes the given value into an SHA256 string.
+            |||),
+            html.p({}, |||
+              This function is only available in Go version of jsonnet.
+            |||),
+          ],
+        },
+        {
+          name: 'sha512',
+          params: ['s'],
+          availableSince: 'upcoming',
+          description: [
+            html.p({}, |||
+              Encodes the given value into an SHA512 string.
+            |||),
+            html.p({}, |||
+              This function is only available in Go version of jsonnet.
+            |||),
+          ],
+        },
+        {
+          name: 'sha3',
+          params: ['s'],
+          availableSince: 'upcoming',
+          description: [
+            html.p({}, |||
+              Encodes the given value into an SHA3 string.
+            |||),
+            html.p({}, |||
+              This function is only available in Go version of jsonnet.
+            |||),
+          ],
+        },
       ],
     },
     {

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -25,6 +25,8 @@ limitations under the License.
   local std = self,
   local id = function(x) x,
 
+  local go_only_function = error 'This function is only supported in go version of jsonnet. See https://github.com/google/go-jsonnet',
+
   isString(v):: std.type(v) == 'string',
   isNumber(v):: std.type(v) == 'number',
   isBoolean(v):: std.type(v) == 'boolean',
@@ -1759,4 +1761,9 @@ limitations under the License.
     for k in std.objectFields(obj)
     if k != key
   },
+
+  sha1(str):: go_only_function,
+  sha256(str):: go_only_function,
+  sha512(str):: go_only_function,
+  sha3(str):: go_only_function,
 }


### PR DESCRIPTION
Update doc with more crypto functions. Implemented `std.sha1`, `std.sha256`, `std.sha512`, `std.sha3` functions as go only functions.

go-jsonnet PR: https://github.com/google/go-jsonnet/pull/699