### PR TITLE
Change com_google_googletest to a non-dev dependency in MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,7 @@
 module(name = "jsonnet", version = "0.0.0")
 
+bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest")
+
 build_defs = use_extension("//tools/build_defs:extensions.bzl", "build_defs")
 use_repo(
     build_defs,
@@ -8,7 +10,3 @@ use_repo(
 )
 
 register_toolchains("//platform_defs:default_python3_toolchain")
-
-# Dev dependencies
-
-bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest", dev_dependency = True)


### PR DESCRIPTION
I had to patch the MODULE.bazel file as part of publishing to BCR (https://github.com/bazelbuild/bazel-central-registry/pull/667), as some targets failed to build when googletest was marked as a dev dependency. I think it would be possible to get around this by limiting which parts of this repo are built by the BCR presubmit checks. Making googletest a normal dependency seems like the better option, as it will allow the presubmit checks to be more thorough.