### PR TITLE
feat: allow negative index/end on std.slice

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -1240,6 +1240,10 @@ local html = import 'html.libsonnet';
               input: 'std.slice("jsonnet", 0, 4, 1)',
               output: std.slice('jsonnet', 0, 4, 1),
             },
+            {
+              input: 'std.slice("jsonnet", -3, null, null)',
+              output: std.slice('jsonnet', -3, null, null),
+            },
           ],
         },
         {

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -212,7 +212,7 @@ limitations under the License.
           then 0
           else
             if index < 0
-            then std.length(indexable) + index
+            then std.max(0, std.length(indexable) + index)
             else index,
         end:
           if end == null

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -208,18 +208,27 @@ limitations under the License.
       {
         indexable: indexable,
         index:
-          if index == null then 0
-          else index,
+          if index == null
+          then 0
+          else
+            if index < 0
+            then std.length(indexable) + index
+            else index,
         end:
-          if end == null then std.length(indexable)
-          else end,
+          if end == null
+          then std.length(indexable)
+          else
+            if end < 0
+            then std.length(indexable) + end
+            else end,
         step:
-          if step == null then 1
+          if step == null
+          then 1
           else step,
         length: std.length(indexable),
         type: std.type(indexable),
       };
-    assert invar.index >= 0 && invar.end >= 0 && invar.step >= 0 : 'got [%s:%s:%s] but negative index, end, and steps are not supported' % [invar.index, invar.end, invar.step];
+    assert invar.step >= 0 : 'got [%s:%s:%s] but negative steps are not supported' % [invar.index, invar.end, invar.step];
     assert step != 0 : 'got %s but step must be greater than 0' % step;
     assert std.isString(indexable) || std.isArray(indexable) : 'std.slice accepts a string or an array, but got: %s' % std.type(indexable);
     local build(slice, cur) =

--- a/test_suite/slice.sugar.jsonnet
+++ b/test_suite/slice.sugar.jsonnet
@@ -108,6 +108,18 @@ local arrCases = [
     input: arr[-1:-1],
     output: [],
   },
+  {
+    input: arr[-6:3],
+    output: [0, 1, 2],
+  },
+  {
+    input: arr[-100:3],
+    output: [0, 1, 2],
+  },
+  {
+    input: arr[-100:-90],
+    output: [],
+  },
 ];
 
 local strCases = [
@@ -197,6 +209,18 @@ local strCases = [
   },
   {
     input: str[-1:-1],
+    output: '',
+  },
+  {
+    input: str[-6:3],
+    output: '012',
+  },
+  {
+    input: str[-100:3],
+    output: '012',
+  },
+  {
+    input: str[-100:-90],
     output: '',
   },
 ];

--- a/test_suite/slice.sugar.jsonnet
+++ b/test_suite/slice.sugar.jsonnet
@@ -92,7 +92,22 @@ local arrCases = [
     input: (arr)[2:1000],
     output: [2, 3, 4, 5],
   },
-
+  {
+    input: arr[-2:],
+    output: [4, 5],
+  },
+  {
+    input: arr[:-3],
+    output: [0, 1, 2],
+  },
+  {
+    input: arr[-3:-1],
+    output: [3, 4],
+  },
+  {
+    input: arr[-1:-1],
+    output: [],
+  },
 ];
 
 local strCases = [
@@ -167,6 +182,22 @@ local strCases = [
   {
     input: (str)[2:1000],
     output: '2345',
+  },
+  {
+    input: str[-2:],
+    output: '45',
+  },
+  {
+    input: str[:-3],
+    output: '012',
+  },
+  {
+    input: str[-3:-1],
+    output: '34',
+  },
+  {
+    input: str[-1:-1],
+    output: '',
   },
 ];
 

--- a/test_suite/slice.sugar.jsonnet.fmt.golden
+++ b/test_suite/slice.sugar.jsonnet.fmt.golden
@@ -92,7 +92,34 @@ local arrCases = [
     input: (arr)[2:1000],
     output: [2, 3, 4, 5],
   },
-
+  {
+    input: arr[-2:],
+    output: [4, 5],
+  },
+  {
+    input: arr[:-3],
+    output: [0, 1, 2],
+  },
+  {
+    input: arr[-3:-1],
+    output: [3, 4],
+  },
+  {
+    input: arr[-1:-1],
+    output: [],
+  },
+  {
+    input: arr[-6:3],
+    output: [0, 1, 2],
+  },
+  {
+    input: arr[-100:3],
+    output: [0, 1, 2],
+  },
+  {
+    input: arr[-100:-90],
+    output: [],
+  },
 ];
 
 local strCases = [
@@ -167,6 +194,34 @@ local strCases = [
   {
     input: (str)[2:1000],
     output: '2345',
+  },
+  {
+    input: str[-2:],
+    output: '45',
+  },
+  {
+    input: str[:-3],
+    output: '012',
+  },
+  {
+    input: str[-3:-1],
+    output: '34',
+  },
+  {
+    input: str[-1:-1],
+    output: '',
+  },
+  {
+    input: str[-6:3],
+    output: '012',
+  },
+  {
+    input: str[-100:3],
+    output: '012',
+  },
+  {
+    input: str[-100:-90],
+    output: '',
   },
 ];
 


### PR DESCRIPTION
I found myself implementing this elsewhere and figured it'd be easy to support in stdlib.

I ran `make test`, it succeeded for my changes but had unrelated failures, we might want to fix that in a separate PR.