### PR TITLE
language.html.md - a missing comma

### DIFF
--- a/doc/ref/language.html.md
+++ b/doc/ref/language.html.md
@@ -154,7 +154,7 @@ func(21)
 The arguments are **not** evaluated when a function is called. They are passed lazily and evaluated only when used. This allows expressing things which in other languages require built-in functionality or macros, such as short-circuit boolean operations:
 ```
 local and3(a, b, c) = a && b && c;
-and3(true, false, error "this one is never evaluated")
+and3(true, false, error, "this one is never evaluated")
 ```
 
 Functions in Jsonnet are [referentially transparent](https://en.wikipedia.org/wiki/Referential_transparency), meaning that any function call can be replaced with its definition, without changing the meaning of the program. Therefore, in some sense, functions in Jsonnet are [hygienic macros](https://en.wikipedia.org/wiki/Hygienic_macro). For example consider the following snippet:

--- a/doc/ref/language.html.md
+++ b/doc/ref/language.html.md
@@ -151,11 +151,13 @@ local func(x) = x * 2;
 func(21)
 ```
 
-The arguments are **not** evaluated when a function is called. They are passed lazily and evaluated only when used. This allows expressing things which in other languages require built-in functionality or macros, such as short-circuit boolean operations:
+The arguments are **not** evaluated when a function is called. They are passed lazily and evaluated only when used. This allows expressing things which in other languages require built-in functionality or macros, such as short-circuit boolean operations. 
 ```
 local and3(a, b, c) = a && b && c;
-and3(true, false, error, "this one is never evaluated")
+and3(true, false, error "this one is never evaluated")
 ```
+The expression `error "message"` raises an error with the provided message string. Thus, in this example, the values for `a` and `b` are evaluated because they are required to compute `a && b`. However, since `a && b` is `false` - there is no need to evaluate the value for `c` and the error is never thrown.
+
 
 Functions in Jsonnet are [referentially transparent](https://en.wikipedia.org/wiki/Referential_transparency), meaning that any function call can be replaced with its definition, without changing the meaning of the program. Therefore, in some sense, functions in Jsonnet are [hygienic macros](https://en.wikipedia.org/wiki/Hygienic_macro). For example consider the following snippet:
 

--- a/doc/ref/language.html.md
+++ b/doc/ref/language.html.md
@@ -151,7 +151,7 @@ local func(x) = x * 2;
 func(21)
 ```
 
-The arguments are **not** evaluated when a function is called. They are passed lazily and evaluated only when used. This allows expressing things which in other languages require built-in functionality or macros, such as short-circuit boolean operations. 
+The arguments are **not** evaluated when a function is called. They are passed lazily and evaluated only when used. This allows expressing things which in other languages require built-in functionality or macros, such as short-circuit boolean operations:
 ```
 local and3(a, b, c) = a && b && c;
 and3(true, false, error "this one is never evaluated")


### PR DESCRIPTION
feels like a syntax error to me...

**EDITED**:

Wait with this. The problem here is that `error` notation is used before it is explained, breaking the reading.
I'll need to propose something different...

**Re-EDITED**:
OK. I finished reading all the doc. There is no explanation of this notation...
does it mean to demonstrate that the expression is not evaluated even as a precompile step?
if so - I suggest to add a clarification about it...

Tell me how to proceed, I'll update the PR