### PR TITLE
feat: document std.match in standard library

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -388,6 +388,14 @@ local html = import 'html.libsonnet';
           |||,
         },
         {
+          name: 'match',
+          params: ['str', 'pat'],
+          availableSince: 'upcoming',
+          description: |||
+            Matches the given <code>str</code> using <code>pat</code> as regexp pattern and returns an array of the matches.
+          |||,
+        },
+        {
           name: 'equalsIgnoreCase',
           params: ['str1', 'str2'],
           availableSince: 'upcoming',

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1785,4 +1785,6 @@ limitations under the License.
   sha3(str):: go_only_function,
 
   trim(str):: std.stripChars(str, ' \t\n\f\r\u0085\u00A0'),
+
+  match(str, pat):: go_only_function,
 }


### PR DESCRIPTION
Add documentation for `std.match` function in standard library

go-jsonnet PR: https://github.com/google/go-jsonnet/pull/715