### PR TITLE
Fix `std.format` calls in `std.{all,any}`

### DIFF
--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1654,7 +1654,7 @@ limitations under the License.
         true
       else
         local e = arr[idx];
-        assert std.isBoolean(e) : std.format('element "%s" of type %s is not a boolean', e, std.type(e));
+        assert std.isBoolean(e) : 'element "%s" of type %s is not a boolean' % [e, std.type(e)];
         if !e then
           false
         else
@@ -1669,7 +1669,7 @@ limitations under the License.
         false
       else
         local e = arr[idx];
-        assert std.isBoolean(e) : std.format('element "%s" of type %s is not a boolean', e, std.type(e));
+        assert std.isBoolean(e) : 'element "%s" of type %s is not a boolean' % [e, std.type(e)];
         if e then
           true
         else


### PR DESCRIPTION
`std.format` expects 2 positional arguments instead of 3. 

Fixes #1101 