### PR TITLE
docs(std.extVar): extvars don't have to be strings, fix the docs.

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -29,7 +29,7 @@ local html = import 'html.libsonnet';
           name: 'extVar',
           params: ['x'],
           availableSince: '0.10.0',
-          description: 'If an external variable with the given name was defined, return its string value. Otherwise, raise an error.',
+          description: 'If an external variable with the given name was defined, return its value. Otherwise, raise an error.',
         },
       ],
     },

--- a/doc/ref/spec.html
+++ b/doc/ref/spec.html
@@ -2847,7 +2847,7 @@ div.rules {
         Finally, the function <code>std.native(x)</code> takes a string and returns a function
         configured by the user in a custom execution environment, thus its semantics cannot be
         formally described here.  The function <code>std.extVar(x)</code> also takes a string and
-        returns the value bound to that external variable (always a string) at the time the Jsonnet
+        returns the value bound to that external variable at the time the Jsonnet
         environment was created.
       </p>
     </div>


### PR DESCRIPTION
The docs say that ext vars can only have strings values, which is not true. Both the implementation and the tutorial say otherwise :)

Fix that.
