### PR TITLE
Link libjsonnet++ to libjsonnet

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -10,7 +10,7 @@ set(LIBJSONNETPP_SOURCE
 
 add_library(libjsonnet++ SHARED ${LIBJSONNETPP_HEADERS} ${LIBJSONNETPP_SOURCE})
 add_dependencies(libjsonnet++ jsonnet)
-# target_link_libraries(libjsonnet libjsonnet)
+target_link_libraries(libjsonnet++ libjsonnet)
 
 # CMake prepends CMAKE_SHARED_LIBRARY_PREFIX to shared libraries, so without
 # this step the output would be |liblibjsonnet|.


### PR DESCRIPTION
to awoid linker errors (for example, ld on Windows says: cpp/libjsonnet++.cpp:104:(.text+0x74c): undefined reference to `jsonnet_realloc'...).