### PR TITLE
Docs: Fix link to Turing Archive from the Design Rationale

### DIFF
--- a/doc/articles/design.html
+++ b/doc/articles/design.html
@@ -186,8 +186,8 @@ title: Language Design
         termination either restrict the language (e.g. to primitive recursion), which makes some
         programs impossible / difficult to write, or, alternatively, require the programmer to
         provide evidence that the program terminates, via some sort of annotation / <a
-        href="http://www.turingarchive.org/browse.php/B/8">energy function</a>.  Both of these make
-        the programmer's life more difficult.
+        href="https://turingarchive.kings.cam.ac.uk/publications-lectures-and-talks-amtb/amt-b-8"
+        >energy function</a>.  Both of these make the programmer's life more difficult.
       </p>
       <p>
         Furthermore, non-Turing complete languages can take arbitrary CPU or RAM by running


### PR DESCRIPTION
The URL http://www.turingarchive.org/browse.php/B/8 no longer resolves. The Wayback Machine indicates that before it stopped working entirely, it became a redirect to https://turingarchive.kings.cam.ac.uk/browse.php/B/8. That URL is also dead, but does at least get to The Turing Digital Archive, from where it is possible to manually find the relevant archived notes at a new URL: https://turingarchive.kings.cam.ac.uk/publications-lectures-and-talks-amtb/amt-b-8