### PR TITLE
fix: std.trim test assertion

### DIFF
--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -1597,6 +1597,6 @@ std.assertEqual(std.trim('already trimmed string'), 'already trimmed string') &&
 std.assertEqual(std.trim('    string with spaces on both ends     '), 'string with spaces on both ends') &&
 std.assertEqual(std.trim('string with newline character at end\n'), 'string with newline character at end') &&
 std.assertEqual(std.trim('string with tabs at end\t\t'), 'string with tabs at end') &&
-std.assertEqual(std.trim('string with other special whitespaces at end\f\r\u0085\u00A0'), 'string with carriage return at end') &&
+std.assertEqual(std.trim('string with other special whitespaces at end\f\r\u0085\u00A0'), 'string with other special whitespaces at end') &&
 
 true


### PR DESCRIPTION
Test suite (regression_test, in the cmake build) was failing due to an incorrect assertion introduced with the `std.trim` function in https://github.com/google/jsonnet/commit/8f1e262c3a91737da998640819572a1f9fd7f0b6
