### PR TITLE
Fix jsonnetfmt --debug-desugaring

### DIFF
--- a/core/ast.h
+++ b/core/ast.h
@@ -586,7 +586,7 @@ struct LiteralNumber : public AST {
 /** Represents JSON strings. */
 struct LiteralString : public AST {
     UString value;
-    enum TokenKind { SINGLE, DOUBLE, BLOCK, VERBATIM_SINGLE, VERBATIM_DOUBLE };
+    enum TokenKind { SINGLE, DOUBLE, BLOCK, VERBATIM_SINGLE, VERBATIM_DOUBLE, RAW_DESUGARED };
     TokenKind tokenKind;
     std::string blockIndent;      // Only contains ' ' and '\t'.
     std::string blockTermIndent;  // Only contains ' ' and '\t'.

--- a/core/desugarer.cpp
+++ b/core/desugarer.cpp
@@ -119,12 +119,12 @@ class Desugarer {
 
     LiteralString *str(const UString &s)
     {
-        return make<LiteralString>(E, EF, s, LiteralString::DOUBLE, "", "");
+        return make<LiteralString>(E, EF, s, LiteralString::RAW_DESUGARED, "", "");
     }
 
     LiteralString *str(const LocationRange &loc, const UString &s)
     {
-        return make<LiteralString>(loc, EF, s, LiteralString::DOUBLE, "", "");
+        return make<LiteralString>(loc, EF, s, LiteralString::RAW_DESUGARED, "", "");
     }
 
     LiteralNull *null(void)
@@ -851,12 +851,13 @@ class Desugarer {
             // Nothing to do.
 
         } else if (auto *ast = dynamic_cast<LiteralString *>(ast_)) {
-            if ((ast->tokenKind != LiteralString::BLOCK) &&
+            if ((ast->tokenKind != LiteralString::RAW_DESUGARED) &&
+                (ast->tokenKind != LiteralString::BLOCK) &&
                 (ast->tokenKind != LiteralString::VERBATIM_DOUBLE) &&
                 (ast->tokenKind != LiteralString::VERBATIM_SINGLE)) {
                 ast->value = jsonnet_string_unescape(ast->location, ast->value);
             }
-            ast->tokenKind = LiteralString::DOUBLE;
+            ast->tokenKind = LiteralString::RAW_DESUGARED;
             ast->blockIndent.clear();
 
         } else if (dynamic_cast<const LiteralNull *>(ast_)) {

--- a/core/formatter.cpp
+++ b/core/formatter.cpp
@@ -490,6 +490,7 @@ class Unparser {
             o << ast->originalString;
 
         } else if (auto *ast = dynamic_cast<const LiteralString *>(ast_)) {
+            assert(ast->tokenKind != LiteralString::RAW_DESUGARED);
             if (ast->tokenKind == LiteralString::DOUBLE) {
                 o << "\"";
                 o << encode_utf8(ast->value);
@@ -647,6 +648,7 @@ class EnforceStringStyle : public FmtPass {
     EnforceStringStyle(Allocator &alloc, const FmtOpts &opts) : FmtPass(alloc, opts) {}
     void visit(LiteralString *lit)
     {
+        assert(lit->tokenKind != LiteralString::RAW_DESUGARED);
         if (lit->tokenKind == LiteralString::BLOCK)
             return;
         if (lit->tokenKind == LiteralString::VERBATIM_DOUBLE)
@@ -1881,6 +1883,7 @@ class FixIndentation {
             column += ast->originalString.length();
 
         } else if (auto *ast = dynamic_cast<LiteralString *>(ast_)) {
+            assert(ast->tokenKind != LiteralString::RAW_DESUGARED);
             if (ast->tokenKind == LiteralString::DOUBLE) {
                 column += 2 + ast->value.length();  // Include quotes
             } else if (ast->tokenKind == LiteralString::SINGLE) {


### PR DESCRIPTION
The desugaring step handles string backslash escape sequences, but it puts the result back into the same AST elements that the input strings came from. When formatting, these strings need to be re-escaped to turn them into printable string literals.