### PR TITLE
Reformat everything (all C and C++ code) and enable format checks in GitHub workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,9 +17,6 @@ jobs:
   check_code_format:
     name: Check code formatting
     runs-on: 'ubuntu-20.04'
-    # The code currently doesn't pass formatting.
-    # Enable this workflow job once it does, to detect regressions.
-    if: false
     steps:
       - uses: actions/checkout@v4
       - name: Check clang-format (make test-formatting)

--- a/cmd/jsonnet.cpp
+++ b/cmd/jsonnet.cpp
@@ -17,7 +17,6 @@ limitations under the License.
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
-
 #include <exception>
 #include <fstream>
 #include <iostream>
@@ -104,12 +103,7 @@ struct JsonnetConfig {
     bool evalStream;
     std::string evalMultiOutputDir;
 
-    JsonnetConfig()
-        : filenameIsCode(false),
-          evalMulti(false),
-          evalStream(false)
-    {
-    }
+    JsonnetConfig() : filenameIsCode(false), evalMulti(false), evalStream(false) {}
 };
 
 bool get_var_val(const std::string &var_val, std::string &var, std::string &val)
@@ -130,7 +124,8 @@ bool get_var_val(const std::string &var_val, std::string &var, std::string &val)
     return true;
 }
 
-bool get_var_file(const std::string &var_file, const std::string &imp, std::string &var, std::string &val)
+bool get_var_file(const std::string &var_file, const std::string &imp, std::string &var,
+                  std::string &val)
 {
     size_t eq_pos = var_file.find_first_of('=', 0);
     if (eq_pos == std::string::npos) {
@@ -215,7 +210,7 @@ static ArgStatus process_args(int argc, const char **argv, JsonnetConfig *config
         } else if (arg == "-E" || arg == "--var" || arg == "--env") {
             // TODO(dcunnin): Delete this in a future release.
             std::cerr << "WARNING: jsonnet eval -E, --var and --env are deprecated,"
-                        << " please use -V or --ext-str." << std::endl;
+                      << " please use -V or --ext-str." << std::endl;
             std::string var, val;
             if (!get_var_val(next_arg(i, args), var, val))
                 return ARG_FAILURE;
@@ -228,7 +223,7 @@ static ArgStatus process_args(int argc, const char **argv, JsonnetConfig *config
         } else if (arg == "-F" || arg == "--file") {
             // TODO(dcunnin): Delete this in a future release.
             std::cerr << "WARNING: jsonnet eval -F and --file are deprecated,"
-                        << " please use --ext-str-file." << std::endl;
+                      << " please use --ext-str-file." << std::endl;
             std::string var, val;
             if (!get_var_file(next_arg(i, args), "importstr", var, val))
                 return ARG_FAILURE;
@@ -241,7 +236,7 @@ static ArgStatus process_args(int argc, const char **argv, JsonnetConfig *config
         } else if (arg == "--code-var" || arg == "--code-env") {
             // TODO(dcunnin): Delete this in a future release.
             std::cerr << "WARNING: jsonnet eval --code-var and --code-env are deprecated,"
-                        << " please use --ext-code." << std::endl;
+                      << " please use --ext-code." << std::endl;
             std::string var, val;
             if (!get_var_val(next_arg(i, args), var, val))
                 return ARG_FAILURE;
@@ -254,7 +249,7 @@ static ArgStatus process_args(int argc, const char **argv, JsonnetConfig *config
         } else if (arg == "--code-file") {
             // TODO(dcunnin): Delete this in a future release.
             std::cerr << "WARNING: jsonnet eval --code-file is deprecated,"
-                        << " please use --ext-code-file." << std::endl;
+                      << " please use --ext-code-file." << std::endl;
             std::string var, val;
             if (!get_var_file(next_arg(i, args), "import", var, val))
                 return ARG_FAILURE;
@@ -303,8 +298,7 @@ static ArgStatus process_args(int argc, const char **argv, JsonnetConfig *config
                 return ARG_FAILURE;
             }
             if (v < 0) {
-                std::cerr << "ERROR: invalid --gc-growth-trigger \"" << num << "\""
-                            << std::endl;
+                std::cerr << "ERROR: invalid --gc-growth-trigger \"" << num << "\"" << std::endl;
                 return ARG_FAILURE;
             }
             jsonnet_gc_growth_trigger(vm, v);
@@ -525,8 +519,8 @@ int main(int argc, const char **argv)
             output = jsonnet_evaluate_snippet_stream(
                 vm, config.inputFiles[0].c_str(), input.c_str(), &error);
         } else {
-            output = jsonnet_evaluate_snippet(
-                vm, config.inputFiles[0].c_str(), input.c_str(), &error);
+            output =
+                jsonnet_evaluate_snippet(vm, config.inputFiles[0].c_str(), input.c_str(), &error);
         }
 
         if (error) {

--- a/cmd/jsonnetfmt.cpp
+++ b/cmd/jsonnetfmt.cpp
@@ -17,7 +17,6 @@ limitations under the License.
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
-
 #include <exception>
 #include <fstream>
 #include <iostream>
@@ -79,12 +78,7 @@ struct JsonnetConfig {
     bool fmtInPlace;
     bool fmtTest;
 
-    JsonnetConfig()
-        : filenameIsCode(false),
-          fmtInPlace(false),
-          fmtTest(false)
-    {
-    }
+    JsonnetConfig() : filenameIsCode(false), fmtInPlace(false), fmtTest(false) {}
 };
 
 enum ArgStatus {
@@ -123,8 +117,8 @@ static ArgStatus process_args(int argc, const char **argv, JsonnetConfig *config
         } else if (arg == "--") {
             // All subsequent args are not options.
             while ((++i) < args.size())
-                remaining_args.push_back(args[i]);          
-            break;  
+                remaining_args.push_back(args[i]);
+            break;
         } else if (arg == "-i" || arg == "--in-place") {
             config->fmtInPlace = true;
         } else if (arg == "--test") {
@@ -139,8 +133,7 @@ static ArgStatus process_args(int argc, const char **argv, JsonnetConfig *config
         } else if (arg == "--max-blank-lines") {
             long l = strtol_check(next_arg(i, args));
             if (l < 0) {
-                std::cerr << "ERROR: invalid --max-blank-lines value: " << l << ""
-                            << std::endl;
+                std::cerr << "ERROR: invalid --max-blank-lines value: " << l << "" << std::endl;
                 return ARG_FAILURE;
             }
             jsonnet_fmt_max_blank_lines(vm, l);
@@ -153,8 +146,7 @@ static ArgStatus process_args(int argc, const char **argv, JsonnetConfig *config
             } else if (val == "l") {
                 jsonnet_fmt_comment(vm, 'l');
             } else {
-                std::cerr << "ERROR: invalid --comment-style value: " << val
-                            << std::endl;
+                std::cerr << "ERROR: invalid --comment-style value: " << val << std::endl;
                 return ARG_FAILURE;
             }
         } else if (arg == "--string-style") {
@@ -166,8 +158,7 @@ static ArgStatus process_args(int argc, const char **argv, JsonnetConfig *config
             } else if (val == "l") {
                 jsonnet_fmt_string(vm, 'l');
             } else {
-                std::cerr << "ERROR: invalid --string-style value: " << val
-                            << std::endl;
+                std::cerr << "ERROR: invalid --string-style value: " << val << std::endl;
                 return ARG_FAILURE;
             }
         } else if (arg == "--pad-arrays") {
@@ -242,8 +233,7 @@ int main(int argc, const char **argv)
                         return EXIT_FAILURE;
                     }
                     if (config.filenameIsCode) {
-                        std::cerr << "ERROR: cannot use --in-place with --exec"
-                                    << std::endl;
+                        std::cerr << "ERROR: cannot use --in-place with --exec" << std::endl;
                         jsonnet_destroy(vm);
                         return EXIT_FAILURE;
                     }
@@ -294,8 +284,7 @@ int main(int argc, const char **argv)
                 return EXIT_FAILURE;
             }
 
-            output = jsonnet_fmt_snippet(
-                vm, config.inputFiles[0].c_str(), input.c_str(), &error);
+            output = jsonnet_fmt_snippet(vm, config.inputFiles[0].c_str(), input.c_str(), &error);
 
             if (error) {
                 std::cerr << output;

--- a/cmd/utils.cpp
+++ b/cmd/utils.cpp
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include "utils.h"
+
 #include <fstream>
 #include <iostream>
-
-#include "utils.h"
 
 long strtol_check(const std::string &str)
 {
@@ -97,8 +97,7 @@ void change_special_filename(bool filename_is_code, std::string *filename)
     }
 }
 
-bool read_input(
-    bool filename_is_code, std::string *filename, std::string *input)
+bool read_input(bool filename_is_code, std::string *filename, std::string *input)
 {
     bool ok;
     if (filename_is_code) {
@@ -144,4 +143,3 @@ bool write_output_file(const char *output, const std::string &output_file)
     }
     return true;
 }
-

--- a/cmd/utils.h
+++ b/cmd/utils.h
@@ -24,7 +24,7 @@ limitations under the License.
  */
 long strtol_check(const std::string &str);
 
-/** Advances i and returns args[i]. 
+/** Advances i and returns args[i].
  * Exits the program if args is not large enough.
  */
 std::string next_arg(unsigned &i, const std::vector<std::string> &args);
@@ -40,8 +40,7 @@ void change_special_filename(bool filename_is_code, std::string *filename);
 
 /** Gets Jsonnet code from any source into the input buffer and changes
  * the filename if it's not an actual filename (e.g. "-"). */
-bool read_input(
-    bool filename_is_code, std::string *filename, std::string *input);
+bool read_input(bool filename_is_code, std::string *filename, std::string *input);
 
 /** Writes the output text to the specified output file.
  */

--- a/core/ast.h
+++ b/core/ast.h
@@ -19,7 +19,6 @@ limitations under the License.
 
 #include <cassert>
 #include <cstdlib>
-
 #include <iostream>
 #include <list>
 #include <map>
@@ -959,7 +958,7 @@ class Allocator {
 
    public:
     template <class T, class... Args>
-    T *make(Args &&... args)
+    T *make(Args &&...args)
     {
         auto r = new T(std::forward<Args>(args)...);
         allocated.push_back(r);
@@ -1003,9 +1002,9 @@ class Allocator {
 namespace {
 
 // Precedences used by various compilation units are defined here.
-const int APPLY_PRECEDENCE = 2;         // Function calls and indexing.
-const int UNARY_PRECEDENCE = 4;         // Logical and bitwise negation, unary + -
-const int MAX_PRECEDENCE = 15;          // higher than any other precedence
+const int APPLY_PRECEDENCE = 2;  // Function calls and indexing.
+const int UNARY_PRECEDENCE = 4;  // Logical and bitwise negation, unary + -
+const int MAX_PRECEDENCE = 15;   // higher than any other precedence
 
 /** These are the binary operator precedences, unary precedence is given by
  * UNARY_PRECEDENCE.

--- a/core/desugarer.cpp
+++ b/core/desugarer.cpp
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include <cassert>
+#include "desugarer.h"
 
 #include <algorithm>
+#include <cassert>
 
 #include "ast.h"
-#include "desugarer.h"
 #include "lexer.h"
 #include "parser.h"
 #include "pass.h"
@@ -102,7 +102,7 @@ class Desugarer {
     Allocator *alloc;
 
     template <class T, class... Args>
-    T *make(Args &&... args)
+    T *make(Args &&...args)
     {
         return alloc->make<T>(std::forward<Args>(args)...);
     }
@@ -407,7 +407,8 @@ class Desugarer {
         return super_vars;
     }
 
-    AST* makeArrayComprehension(ArrayComprehension *ast) {
+    AST *makeArrayComprehension(ArrayComprehension *ast)
+    {
         int n = ast->specs.size();
         AST *zero = make<LiteralNumber>(E, EF, "0.0");
         AST *one = make<LiteralNumber>(E, EF, "1.0");
@@ -439,7 +440,7 @@ class Desugarer {
             var(_aux[last_for]),
             EF,
             ArgParams{{make<Binary>(E, EF, var(_i[last_for]), EF, BOP_PLUS, one), EF},
-                {make<Binary>(E, EF, var(_r), EF, BOP_PLUS, singleton(ast->body)), EF}},
+                      {make<Binary>(E, EF, var(_r), EF, BOP_PLUS, singleton(ast->body)), EF}},
             false,  // trailingComma
             EF,
             EF,
@@ -460,13 +461,13 @@ class Desugarer {
                     var(_aux[prev_for]),
                     EF,
                     ArgParams{{
-                        make<Binary>(E, EF, var(_i[prev_for]), EF, BOP_PLUS, one),
-                            EF,
-                            },
-                      {
-                        var(_r),
-                            EF,
-                            }},
+                                  make<Binary>(E, EF, var(_i[prev_for]), EF, BOP_PLUS, one),
+                                  EF,
+                              },
+                              {
+                                  var(_r),
+                                  EF,
+                              }},
                     false,  // trailingComma
                     EF,
                     EF,
@@ -477,12 +478,12 @@ class Desugarer {
             }
             switch (spec.kind) {
                 case ComprehensionSpec::IF: {
-                  /*
-                    if [[[...cond...]]] then
-                    [[[...in...]]]
-                    else
-                    [[[...out...]]]
-                  */
+                    /*
+                      if [[[...cond...]]] then
+                      [[[...in...]]]
+                      else
+                      [[[...out...]]]
+                    */
                     in = make<Conditional>(ast->location,
                                            EF,
                                            spec.expr,
@@ -509,42 +510,41 @@ class Desugarer {
                         ast->location,
                         EF,
                         Local::Binds{
-                          bind(_l, spec.expr),  // Need to check expr is an array
-                              bind(_aux[i],
-                                   make<Function>(
-                                       ast->location,
-                                       EF,
-                                       EF,
-                                       ArgParams{{EF, _i[i], EF}, {EF, _r, EF}},
-                                       false,  // trailingComma
-                                       EF,
-                                       make<Conditional>(ast->location,
-                                                         EF,
-                                                         make<Binary>(E,
-                                                                      EF,
-                                                                      var(_i[i]),
-                                                                      EF,
-                                                                      BOP_GREATER_EQ,
-                                                                      length(var(_l))),
-                                                         EF,
-                                                         out,
-                                                         EF,
-                                                         make<Local>(
-                                                             ast->location,
-                                                             EF,
-                                                             singleBind(spec.var,
-                                                                        make<Index>(E,
-                                                                                    EF,
-                                                                                    var(_l),
-                                                                                    EF,
-                                                                                    false,
-                                                                                    var(_i[i]),
-                                                                                    EF,
-                                                                                    nullptr,
-                                                                                    EF,
-                                                                                    nullptr,
-                                                                                    EF)),
-                                                             in))))},
+                            bind(_l, spec.expr),  // Need to check expr is an array
+                            bind(
+                                _aux[i],
+                                make<Function>(
+                                    ast->location,
+                                    EF,
+                                    EF,
+                                    ArgParams{{EF, _i[i], EF}, {EF, _r, EF}},
+                                    false,  // trailingComma
+                                    EF,
+                                    make<Conditional>(
+                                        ast->location,
+                                        EF,
+                                        make<Binary>(
+                                            E, EF, var(_i[i]), EF, BOP_GREATER_EQ, length(var(_l))),
+                                        EF,
+                                        out,
+                                        EF,
+                                        make<Local>(
+                                            ast->location,
+                                            EF,
+                                            singleBind(
+                                                spec.var,
+                                                make<Index>(E,
+                                                            EF,
+                                                            var(_l),
+                                                            EF,
+                                                            false,
+                                                            var(_i[i]),
+                                                            EF,
+                                                            nullptr,
+                                                            EF,
+                                                            nullptr,
+                                                            EF)),
+                                            in))))},
                         make<Conditional>(
                             ast->location,
                             EF,
@@ -555,13 +555,13 @@ class Desugarer {
                                 EF,
                                 var(_aux[i]),
                                 EF,
-                                ArgParams{{zero, EF},
-                                  {
-                                    i == 0 ? make<Array>(
-                                        E, EF, Array::Elements{}, false, EF)
-                                        : static_cast<AST *>(var(_r)),
+                                ArgParams{
+                                    {zero, EF},
+                                    {
+                                        i == 0 ? make<Array>(E, EF, Array::Elements{}, false, EF)
+                                               : static_cast<AST *>(var(_r)),
                                         EF,
-                                        }},
+                                    }},
                                 false,  // trailingComma
                                 EF,
                                 EF,
@@ -576,7 +576,8 @@ class Desugarer {
         return in;
     }
 
-    AST* makeObject(Object *ast, unsigned obj_level) {
+    AST *makeObject(Object *ast, unsigned obj_level)
+    {
         // Hidden variable to allow outer/top binding.
         if (obj_level == 0) {
             const Identifier *hidden_var = id(U"$");
@@ -599,7 +600,7 @@ class Desugarer {
             }
         }
 
-        AST* retval = make<DesugaredObject>(ast->location, new_asserts, new_fields);
+        AST *retval = make<DesugaredObject>(ast->location, new_asserts, new_fields);
         if (svs.size() > 0) {
             Local::Binds binds;
             for (const auto &pair : svs) {
@@ -617,7 +618,8 @@ class Desugarer {
         return retval;
     }
 
-    AST* makeObjectComprehension(ObjectComprehension *ast, unsigned obj_level) {
+    AST *makeObjectComprehension(ObjectComprehension *ast, unsigned obj_level)
+    {
         // Hidden variable to allow outer/top binding.
         if (obj_level == 0) {
             const Identifier *hidden_var = id(U"$");
@@ -911,7 +913,8 @@ class Desugarer {
         }
     }
 
-    DesugaredObject *stdlibAST(std::string filename) {
+    DesugaredObject *stdlibAST(std::string filename)
+    {
         // Now, implement the std library by wrapping in a local construct.
         Tokens tokens = jsonnet_lex("std.jsonnet", STD_CODE);
         AST *std_ast = jsonnet_parse(alloc, tokens);
@@ -931,9 +934,9 @@ class Desugarer {
                 params.push_back(id(p));
             auto name = str(decl.name);
             auto fn = make<BuiltinFunction>(E, encode_utf8(decl.name), params);
-            auto field = std::find_if(fields.begin(), fields.end(),
-                [=](const DesugaredObject::Field& f) {
-                    return static_cast<LiteralString*>(f.name)->value == decl.name;
+            auto field =
+                std::find_if(fields.begin(), fields.end(), [=](const DesugaredObject::Field &f) {
+                    return static_cast<LiteralString *>(f.name)->value == decl.name;
                 });
             if (field != fields.end()) {
                 field->body = fn;
@@ -941,8 +944,7 @@ class Desugarer {
                 fields.emplace_back(ObjectField::HIDDEN, name, fn);
             }
         }
-        fields.emplace_back(
-            ObjectField::HIDDEN, str(U"thisFile"), str(decode_utf8(filename)));
+        fields.emplace_back(ObjectField::HIDDEN, str(U"thisFile"), str(decode_utf8(filename)));
         return std_obj;
     }
 
@@ -1004,7 +1006,8 @@ class Desugarer {
     }
 };
 
-DesugaredObject *makeStdlibAST(Allocator *alloc, std::string filename) {
+DesugaredObject *makeStdlibAST(Allocator *alloc, std::string filename)
+{
     Desugarer desugarer(alloc);
     return desugarer.stdlibAST(filename);
 }

--- a/core/formatter.cpp
+++ b/core/formatter.cpp
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include "formatter.h"
+
 #include <algorithm>
 #include <set>
 #include <typeinfo>
 
-#include "formatter.h"
 #include "lexer.h"
 #include "pass.h"
 #include "string_utils.h"
@@ -71,7 +72,8 @@ static AST *left_recursive_deep(AST *ast_)
  * \param separate_token If the last fodder was an interstitial, whether a space should follow it.
  * \param final Whether fodder is the last one in
  */
-void fodder_fill(std::ostream &o, const Fodder &fodder, bool space_before, bool separate_token, bool final)
+void fodder_fill(std::ostream &o, const Fodder &fodder, bool space_before, bool separate_token,
+                 bool final)
 {
     unsigned last_indent = 0;
     size_t index = 0;
@@ -505,7 +507,8 @@ class Unparser {
                     o << ast->blockIndent;
                 for (const char32_t *cp = ast->value.c_str(); *cp != U'\0'; ++cp) {
                     // Formatter always outputs in unix mode.
-                    if (*cp == '\r') continue;
+                    if (*cp == '\r')
+                        continue;
                     std::string utf8;
                     encode_utf8(*cp, utf8);
                     o << utf8;
@@ -790,7 +793,8 @@ void remove_initial_newlines(AST *ast)
         f.erase(f.begin());
 }
 
-void remove_extra_trailing_newlines(Fodder &final_fodder) {
+void remove_extra_trailing_newlines(Fodder &final_fodder)
+{
     if (!final_fodder.empty()) {
         final_fodder.back().blanks = 0;
     }
@@ -951,7 +955,8 @@ class PrettyFieldNames : public FmtPass {
     bool isIdentifier(const UString &str)
     {
         // Identifiers cannot be zero-length.
-        if (str.length() == 0) return false;
+        if (str.length() == 0)
+            return false;
 
         bool first = true;
         for (char32_t c : str) {
@@ -1918,11 +1923,10 @@ class FixIndentation {
 
         } else if (auto *ast = dynamic_cast<Object *>(ast_)) {
             column++;  // '{'
-            const Fodder &first_fodder = ast->fields.size() == 0
-                                             ? ast->closeFodder
-                                             : ast->fields[0].kind == ObjectField::FIELD_STR
-                                                   ? open_fodder(ast->fields[0].expr1)
-                                                   : ast->fields[0].fodder1;
+            const Fodder &first_fodder = ast->fields.size() == 0 ? ast->closeFodder
+                                         : ast->fields[0].kind == ObjectField::FIELD_STR
+                                             ? open_fodder(ast->fields[0].expr1)
+                                             : ast->fields[0].fodder1;
             Indent new_indent = newIndent(first_fodder, indent, column + (opts.padObjects ? 1 : 0));
 
             fields(ast->fields, new_indent, opts.padObjects);
@@ -1959,11 +1963,10 @@ class FixIndentation {
         } else if (auto *ast = dynamic_cast<ObjectComprehension *>(ast_)) {
             column++;  // '{'
             unsigned start_column = column;
-            const Fodder &first_fodder = ast->fields.size() == 0
-                                             ? ast->closeFodder
-                                             : ast->fields[0].kind == ObjectField::FIELD_STR
-                                                   ? open_fodder(ast->fields[0].expr1)
-                                                   : ast->fields[0].fodder1;
+            const Fodder &first_fodder = ast->fields.size() == 0 ? ast->closeFodder
+                                         : ast->fields[0].kind == ObjectField::FIELD_STR
+                                             ? open_fodder(ast->fields[0].expr1)
+                                             : ast->fields[0].fodder1;
             Indent new_indent =
                 newIndent(first_fodder, indent, start_column + (opts.padObjects ? 1 : 0));
 

--- a/core/json.h
+++ b/core/json.h
@@ -17,11 +17,11 @@ limitations under the License.
 #ifndef JSONNET_JSON_H
 #define JSONNET_JSON_H
 
+#include <libjsonnet.h>
+
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <libjsonnet.h>
 
 struct JsonnetJsonValue {
     enum Kind {

--- a/core/lexer.cpp
+++ b/core/lexer.cpp
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include <cassert>
+#include "lexer.h"
 
+#include <cassert>
 #include <map>
 #include <sstream>
 #include <string>
 
-#include "lexer.h"
 #include "static_error.h"
 #include "unicode.h"
 
@@ -171,7 +171,8 @@ static bool is_symbol(char c)
     return false;
 }
 
-bool allowed_at_end_of_operator(char c) {
+bool allowed_at_end_of_operator(char c)
+{
     switch (c) {
         case '+':
         case '-':
@@ -704,7 +705,8 @@ Tokens jsonnet_lex(const std::string &filename, const char *input)
                     // Text block
                     if (*c == '|' && *(c + 1) == '|' && *(c + 2) == '|') {
                         c += 3;  // Skip the "|||".
-                        while (is_horz_ws(*c)) ++c;  // Chomp whitespace at end of line.
+                        while (is_horz_ws(*c))
+                            ++c;  // Chomp whitespace at end of line.
                         if (*c != '\n') {
                             auto msg = "text block syntax requires new line after |||.";
                             throw StaticError(filename, begin, msg);

--- a/core/lexer.h
+++ b/core/lexer.h
@@ -19,7 +19,6 @@ limitations under the License.
 
 #include <cassert>
 #include <cstdlib>
-
 #include <iostream>
 #include <list>
 #include <sstream>

--- a/core/lexer_test.cpp
+++ b/core/lexer_test.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include "lexer.h"
 
 #include <list>
+
 #include "gtest/gtest.h"
 
 namespace jsonnet::internal {

--- a/core/libjsonnet.cpp
+++ b/core/libjsonnet.cpp
@@ -17,7 +17,6 @@ limitations under the License.
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
-
 #include <exception>
 #include <fstream>
 #include <iostream>
@@ -33,31 +32,32 @@ extern "C" {
 #include "formatter.h"
 #include "json.h"
 #include "parser.h"
-#include "static_analysis.h"
-#include "vm.h"
 #include "pass.h"
+#include "static_analysis.h"
 #include "string_utils.h"
+#include "vm.h"
 
 namespace {
 using ::jsonnet::internal::Allocator;
 using ::jsonnet::internal::AST;
+using ::jsonnet::internal::CompilerPass;
 using ::jsonnet::internal::FmtOpts;
 using ::jsonnet::internal::Fodder;
 using ::jsonnet::internal::jsonnet_lex;
 using ::jsonnet::internal::jsonnet_string_escape;
+using ::jsonnet::internal::LiteralString;
 using ::jsonnet::internal::RuntimeError;
 using ::jsonnet::internal::StaticError;
 using ::jsonnet::internal::Tokens;
 using ::jsonnet::internal::VmExt;
 using ::jsonnet::internal::VmNativeCallback;
 using ::jsonnet::internal::VmNativeCallbackMap;
-using ::jsonnet::internal::CompilerPass;
-using ::jsonnet::internal::LiteralString;
 
 // Used in fmtDebugDesugaring mode to ensure the AST can be pretty-printed.
 class ReEscapeStrings : public CompilerPass {
     using CompilerPass::visit;
-  public:
+
+   public:
     ReEscapeStrings(Allocator &alloc) : CompilerPass(alloc) {}
     void visit(LiteralString *lit)
     {

--- a/core/parser.cpp
+++ b/core/parser.cpp
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include "parser.h"
+
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
-
 #include <iomanip>
 #include <list>
 #include <memory>
@@ -28,7 +29,6 @@ limitations under the License.
 #include "ast.h"
 #include "desugarer.h"
 #include "lexer.h"
-#include "parser.h"
 #include "static_error.h"
 
 namespace jsonnet::internal {
@@ -897,8 +897,7 @@ class Parser {
                 return alloc->make<Local>(span(begin, body), begin.fodder, binds, body);
             }
 
-            default:
-            return nullptr;
+            default: return nullptr;
         }
     }
 
@@ -909,7 +908,8 @@ class Parser {
     {
         AST *ast = maybeParseGreedy();
         // There cannot be an operator after a greedy parse.
-        if (ast != nullptr) return ast;
+        if (ast != nullptr)
+            return ast;
 
         // If we get here, we could be parsing an infix construct.
 
@@ -925,7 +925,6 @@ class Parser {
     AST *parseInfix(AST *lhs, const Token &begin, unsigned max_precedence)
     {
         while (true) {
-
             BinaryOp bop = BOP_PLUS;
             unsigned op_precedence = 0;
 
@@ -950,9 +949,7 @@ class Parser {
                 case Token::DOT:
                 case Token::BRACKET_L:
                 case Token::PAREN_L:
-                case Token::BRACE_L:
-                    op_precedence = APPLY_PRECEDENCE;
-                    break;
+                case Token::BRACE_L: op_precedence = APPLY_PRECEDENCE; break;
 
                 default:
                     // This happens when we reach EOF or the terminating token of an outer context.
@@ -1031,12 +1028,8 @@ class Parser {
                 case Token::DOT: {
                     Token field_id = popExpect(Token::IDENTIFIER);
                     const Identifier *id = alloc->makeIdentifier(field_id.data32());
-                    lhs = alloc->make<Index>(span(begin, field_id),
-                                             EMPTY_FODDER,
-                                             lhs,
-                                             op.fodder,
-                                             field_id.fodder,
-                                             id);
+                    lhs = alloc->make<Index>(
+                        span(begin, field_id), EMPTY_FODDER, lhs, op.fodder, field_id.fodder, id);
                     break;
                 }
                 case Token::PAREN_L: {
@@ -1044,12 +1037,14 @@ class Parser {
                     bool got_comma;
                     Token end = parseArgs(args, "function argument", got_comma);
                     bool got_named = false;
-                    for (const auto& arg : args) {
+                    for (const auto &arg : args) {
                         if (arg.id != nullptr) {
                             got_named = true;
                         } else {
                             if (got_named) {
-                                throw StaticError(arg.expr->location, "Positional argument after a named argument is not allowed");
+                                throw StaticError(
+                                    arg.expr->location,
+                                    "Positional argument after a named argument is not allowed");
                             }
                         }
                     }
@@ -1109,11 +1104,11 @@ class Parser {
         //
         //
 
-/*
-        // Allocate this on the heap to control stack growth.
-        std::unique_ptr<Token> begin_(new Token(peek()));
-        const Token &begin = *begin_;
-*/
+        /*
+                // Allocate this on the heap to control stack growth.
+                std::unique_ptr<Token> begin_(new Token(peek()));
+                const Token &begin = *begin_;
+        */
     }
 };
 

--- a/core/parser_test.cpp
+++ b/core/parser_test.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include "parser.h"
 
 #include <list>
+
 #include "ast.h"
 #include "gtest/gtest.h"
 #include "lexer.h"
@@ -167,8 +168,7 @@ TEST(Parser, TestInvalidLocal)
 
 TEST(Parser, TestInvalidTuple)
 {
-    testParseError("{a b}",
-                   R"(test:1:4: expected token OPERATOR but got (IDENTIFIER, "b"))");
+    testParseError("{a b}", R"(test:1:4: expected token OPERATOR but got (IDENTIFIER, "b"))");
     testParseError("{a = b}", "test:1:2: expected one of :, ::, :::, +:, +::, +:::, got: =");
     testParseError("{a :::: b}", "test:1:2: expected one of :, ::, :::, +:, +::, +:::, got: ::::");
 }
@@ -248,8 +248,7 @@ TEST(Parser, TestInvalidUnexpectedFunction)
 
 TEST(Parser, TestInvalidArray)
 {
-    testParseError("[(a b), 2, 3]",
-                   R"_(test:1:5: expected token ")" but got (IDENTIFIER, "b"))_");
+    testParseError("[(a b), 2, 3]", R"_(test:1:5: expected token ")" but got (IDENTIFIER, "b"))_");
     testParseError("[1, (a b), 2, 3]",
                    R"_(test:1:8: expected token ")" but got (IDENTIFIER, "b"))_");
     testParseError("[a for b in [1 2 3]]",
@@ -280,8 +279,7 @@ TEST(Parser, TestInvalidAssert)
     // TODO(jsonnet-team): The error output of this differs from the Go
     // implementation, which is:
     // test:1:16: expected token ";" but got (",", ",")
-    testParseError("assert a: 'foo', true",
-                   R"(test:1:16: expected token ";" but got ",")");
+    testParseError("assert a: 'foo', true", R"(test:1:16: expected token ";" but got ",")");
     testParseError("assert a: 'foo'; (a b)",
                    R"_(test:1:21: expected token ")" but got (IDENTIFIER, "b"))_");
 }
@@ -295,8 +293,7 @@ TEST(Parser, TestInvalidIf)
 {
     testParseError("if (a b) then c",
                    R"_(test:1:7: expected token ")" but got (IDENTIFIER, "b"))_");
-    testParseError("if a b c",
-                   R"(test:1:6: expected token then but got (IDENTIFIER, "b"))");
+    testParseError("if a b c", R"(test:1:6: expected token then but got (IDENTIFIER, "b"))");
     testParseError("if a then (b c)",
                    R"_(test:1:14: expected token ")" but got (IDENTIFIER, "c"))_");
     testParseError("if a then b else (c d)",

--- a/core/pass.cpp
+++ b/core/pass.cpp
@@ -289,16 +289,16 @@ void CompilerPass::visit(Unary *ast)
     expr(ast->expr);
 }
 
-#define VISIT(var,astType,astClass) \
-   case astType: { \
-     assert(dynamic_cast<astClass *>(var)); \
-     auto *ast = static_cast<astClass *>(var); \
-     visit(ast); \
-   } break
+#define VISIT(var, astType, astClass)             \
+    case astType: {                               \
+        assert(dynamic_cast<astClass *>(var));    \
+        auto *ast = static_cast<astClass *>(var); \
+        visit(ast);                               \
+    } break
 
 void CompilerPass::visitExpr(AST *&ast_)
 {
-    switch(ast_->type) {
+    switch (ast_->type) {
         VISIT(ast_, AST_APPLY, Apply);
         VISIT(ast_, AST_APPLY_BRACE, ApplyBrace);
         VISIT(ast_, AST_ARRAY, Array);
@@ -350,16 +350,16 @@ class ClonePass : public CompilerPass {
     virtual void expr(AST *&ast);
 };
 
-#define CLONE(var,astType,astClass) \
-   case astType: { \
-     assert(dynamic_cast<astClass *>(var)); \
-     auto *ast = static_cast<astClass *>(var); \
-     var = alloc.clone(ast); \
-   } break
+#define CLONE(var, astType, astClass)             \
+    case astType: {                               \
+        assert(dynamic_cast<astClass *>(var));    \
+        auto *ast = static_cast<astClass *>(var); \
+        var = alloc.clone(ast);                   \
+    } break
 
 void ClonePass::expr(AST *&ast_)
 {
-    switch(ast_->type) {
+    switch (ast_->type) {
         CLONE(ast_, AST_APPLY, Apply);
         CLONE(ast_, AST_APPLY_BRACE, ApplyBrace);
         CLONE(ast_, AST_ARRAY, Array);

--- a/core/state.h
+++ b/core/state.h
@@ -153,10 +153,7 @@ struct HeapArray : public HeapEntity {
     // time after creation.  Thus, elements are not GCed as the array is being
     // created.
     std::vector<HeapThunk *> elements;
-    HeapArray(const std::vector<HeapThunk *> &elements)
-        : HeapEntity(ARRAY), elements(elements)
-    {
-    }
+    HeapArray(const std::vector<HeapThunk *> &elements) : HeapEntity(ARRAY), elements(elements) {}
 };
 
 /** Supertype of all objects that are not super objects or extended objects.  */
@@ -234,7 +231,11 @@ struct HeapComprehensionObject : public HeapLeafObject {
 
     HeapComprehensionObject(const BindingFrame &up_values, const AST *value, const Identifier *id,
                             const std::map<const Identifier *, HeapThunk *> &comp_values)
-        : HeapLeafObject(COMPREHENSION_OBJECT), upValues(up_values), value(value), id(id), compValues(comp_values)
+        : HeapLeafObject(COMPREHENSION_OBJECT),
+          upValues(up_values),
+          value(value),
+          id(id),
+          compValues(comp_values)
     {
     }
 };
@@ -367,7 +368,7 @@ class Heap {
             if (curr->mark != thisMark) {
                 curr->mark = thisMark;
 
-                switch(curr->type) {
+                switch (curr->type) {
                     case HeapEntity::SIMPLE_OBJECT: {
                         assert(dynamic_cast<HeapSimpleObject *>(curr));
                         auto *obj = static_cast<HeapSimpleObject *>(curr);
@@ -421,12 +422,8 @@ class Heap {
                         }
                         break;
                     }
-                    case HeapEntity::STRING:
-                        assert(dynamic_cast<HeapString *>(curr));
-                        break;
-                    default:
-                        assert(false);
-                        break;
+                    case HeapEntity::STRING: assert(dynamic_cast<HeapString *>(curr)); break;
+                    default: assert(false); break;
                 }
             }
 
@@ -473,7 +470,7 @@ class Heap {
      * last collection cycle (\see gcTuneGrowthTrigger), a collection cycle should be performed.
      */
     template <class T, class... Args>
-    T *makeEntity(Args &&... args)
+    T *makeEntity(Args &&...args)
     {
         T *r = new T(std::forward<Args>(args)...);
         entities.push_back(r);

--- a/core/static_analysis.cpp
+++ b/core/static_analysis.cpp
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include "static_analysis.h"
+
 #include <set>
 
 #include "ast.h"
-#include "static_analysis.h"
 #include "static_error.h"
 
 namespace jsonnet::internal {
@@ -42,180 +43,180 @@ static IdSet static_analysis(AST *ast_, bool in_object, const IdSet &vars)
     IdSet r;
 
     switch (ast_->type) {
-    case AST_APPLY: {
-        assert(dynamic_cast<Apply *>(ast_));
-        auto* ast = static_cast<Apply *>(ast_);
-        append(r, static_analysis(ast->target, in_object, vars));
-        for (const auto &arg : ast->args)
-            append(r, static_analysis(arg.expr, in_object, vars));
-    } break;
-    case AST_APPLY_BRACE: {
-        assert(dynamic_cast<ApplyBrace *>(ast_));
-        // Nothing to do.
-    } break;
-    case AST_ARRAY: {
-        assert(dynamic_cast<Array *>(ast_));
-        auto* ast = static_cast<Array *>(ast_);
-        for (auto &el : ast->elements)
-            append(r, static_analysis(el.expr, in_object, vars));
-    } break;
-    case AST_BINARY: {
-        assert(dynamic_cast<Binary *>(ast_));
-        auto* ast = static_cast<Binary *>(ast_);
-        append(r, static_analysis(ast->left, in_object, vars));
-        append(r, static_analysis(ast->right, in_object, vars));
-    } break;
-    case AST_BUILTIN_FUNCTION: {
-        assert(dynamic_cast<BuiltinFunction *>(ast_));
-        // Nothing to do.
-    } break;
-    case AST_CONDITIONAL: {
-        assert(dynamic_cast<Conditional *>(ast_));
-        auto* ast = static_cast<Conditional *>(ast_);
-        append(r, static_analysis(ast->cond, in_object, vars));
-        append(r, static_analysis(ast->branchTrue, in_object, vars));
-        append(r, static_analysis(ast->branchFalse, in_object, vars));
-    } break;
-    case AST_ERROR: {
-        assert(dynamic_cast<Error *>(ast_));
-        auto* ast = static_cast<Error *>(ast_);
-        append(r, static_analysis(ast->expr, in_object, vars));
-    } break;
-    case AST_FUNCTION: {
-        assert(dynamic_cast<Function *>(ast_));
-        auto* ast = static_cast<Function *>(ast_);
-        auto new_vars = vars;
-        IdSet params;
-        for (const auto &p : ast->params) {
-            if (params.find(p.id) != params.end()) {
-                std::string msg = "Duplicate function parameter: " + encode_utf8(p.id->name);
-                throw StaticError(ast_->location, msg);
+        case AST_APPLY: {
+            assert(dynamic_cast<Apply *>(ast_));
+            auto *ast = static_cast<Apply *>(ast_);
+            append(r, static_analysis(ast->target, in_object, vars));
+            for (const auto &arg : ast->args)
+                append(r, static_analysis(arg.expr, in_object, vars));
+        } break;
+        case AST_APPLY_BRACE: {
+            assert(dynamic_cast<ApplyBrace *>(ast_));
+            // Nothing to do.
+        } break;
+        case AST_ARRAY: {
+            assert(dynamic_cast<Array *>(ast_));
+            auto *ast = static_cast<Array *>(ast_);
+            for (auto &el : ast->elements)
+                append(r, static_analysis(el.expr, in_object, vars));
+        } break;
+        case AST_BINARY: {
+            assert(dynamic_cast<Binary *>(ast_));
+            auto *ast = static_cast<Binary *>(ast_);
+            append(r, static_analysis(ast->left, in_object, vars));
+            append(r, static_analysis(ast->right, in_object, vars));
+        } break;
+        case AST_BUILTIN_FUNCTION: {
+            assert(dynamic_cast<BuiltinFunction *>(ast_));
+            // Nothing to do.
+        } break;
+        case AST_CONDITIONAL: {
+            assert(dynamic_cast<Conditional *>(ast_));
+            auto *ast = static_cast<Conditional *>(ast_);
+            append(r, static_analysis(ast->cond, in_object, vars));
+            append(r, static_analysis(ast->branchTrue, in_object, vars));
+            append(r, static_analysis(ast->branchFalse, in_object, vars));
+        } break;
+        case AST_ERROR: {
+            assert(dynamic_cast<Error *>(ast_));
+            auto *ast = static_cast<Error *>(ast_);
+            append(r, static_analysis(ast->expr, in_object, vars));
+        } break;
+        case AST_FUNCTION: {
+            assert(dynamic_cast<Function *>(ast_));
+            auto *ast = static_cast<Function *>(ast_);
+            auto new_vars = vars;
+            IdSet params;
+            for (const auto &p : ast->params) {
+                if (params.find(p.id) != params.end()) {
+                    std::string msg = "Duplicate function parameter: " + encode_utf8(p.id->name);
+                    throw StaticError(ast_->location, msg);
+                }
+                params.insert(p.id);
+                new_vars.insert(p.id);
             }
-            params.insert(p.id);
-            new_vars.insert(p.id);
-        }
 
-        auto fv = static_analysis(ast->body, in_object, new_vars);
-        for (const auto &p : ast->params) {
-            if (p.expr != nullptr)
-                append(fv, static_analysis(p.expr, in_object, new_vars));
-        }
-        for (const auto &p : ast->params)
-            fv.erase(p.id);
-        append(r, fv);
-    } break;
-    case AST_IMPORT: {
-        assert(dynamic_cast<Import *>(ast_));
-        // Nothing to do.
-    } break;
-    case AST_IMPORTSTR: {
-        assert(dynamic_cast<Importstr *>(ast_));
-        // Nothing to do.
-    } break;
-    case AST_IMPORTBIN: {
-        assert(dynamic_cast<Importbin *>(ast_));
-        // Nothing to do.
-    } break;
-    case AST_IN_SUPER: {
-        assert(dynamic_cast<const InSuper *>(ast_));
-        auto* ast = static_cast<const InSuper *>(ast_);
-        if (!in_object)
-            throw StaticError(ast_->location, "Can't use super outside of an object.");
-        append(r, static_analysis(ast->element, in_object, vars));
-    } break;
-    case AST_INDEX: {
-        assert(dynamic_cast<const Index *>(ast_));
-        auto* ast = static_cast<const Index *>(ast_);
-        append(r, static_analysis(ast->target, in_object, vars));
-        append(r, static_analysis(ast->index, in_object, vars));
-    } break;
-    case AST_LOCAL: {
-        assert(dynamic_cast<const Local *>(ast_));
-        auto* ast = static_cast<const Local *>(ast_);
-        IdSet ast_vars;
-        for (const auto &bind : ast->binds) {
-            ast_vars.insert(bind.var);
-        }
-        auto new_vars = vars;
-        append(new_vars, ast_vars);
-        IdSet fvs;
-        for (const auto &bind : ast->binds) {
-            append(fvs, static_analysis(bind.body, in_object, new_vars));
-        }
+            auto fv = static_analysis(ast->body, in_object, new_vars);
+            for (const auto &p : ast->params) {
+                if (p.expr != nullptr)
+                    append(fv, static_analysis(p.expr, in_object, new_vars));
+            }
+            for (const auto &p : ast->params)
+                fv.erase(p.id);
+            append(r, fv);
+        } break;
+        case AST_IMPORT: {
+            assert(dynamic_cast<Import *>(ast_));
+            // Nothing to do.
+        } break;
+        case AST_IMPORTSTR: {
+            assert(dynamic_cast<Importstr *>(ast_));
+            // Nothing to do.
+        } break;
+        case AST_IMPORTBIN: {
+            assert(dynamic_cast<Importbin *>(ast_));
+            // Nothing to do.
+        } break;
+        case AST_IN_SUPER: {
+            assert(dynamic_cast<const InSuper *>(ast_));
+            auto *ast = static_cast<const InSuper *>(ast_);
+            if (!in_object)
+                throw StaticError(ast_->location, "Can't use super outside of an object.");
+            append(r, static_analysis(ast->element, in_object, vars));
+        } break;
+        case AST_INDEX: {
+            assert(dynamic_cast<const Index *>(ast_));
+            auto *ast = static_cast<const Index *>(ast_);
+            append(r, static_analysis(ast->target, in_object, vars));
+            append(r, static_analysis(ast->index, in_object, vars));
+        } break;
+        case AST_LOCAL: {
+            assert(dynamic_cast<const Local *>(ast_));
+            auto *ast = static_cast<const Local *>(ast_);
+            IdSet ast_vars;
+            for (const auto &bind : ast->binds) {
+                ast_vars.insert(bind.var);
+            }
+            auto new_vars = vars;
+            append(new_vars, ast_vars);
+            IdSet fvs;
+            for (const auto &bind : ast->binds) {
+                append(fvs, static_analysis(bind.body, in_object, new_vars));
+            }
 
-        append(fvs, static_analysis(ast->body, in_object, new_vars));
+            append(fvs, static_analysis(ast->body, in_object, new_vars));
 
-        for (const auto &bind : ast->binds)
-            fvs.erase(bind.var);
+            for (const auto &bind : ast->binds)
+                fvs.erase(bind.var);
 
-        append(r, fvs);
-    } break;
-    case AST_LITERAL_BOOLEAN: {
-        assert(dynamic_cast<const LiteralBoolean *>(ast_));
-        // Nothing to do.
-    } break;
-    case AST_LITERAL_NUMBER: {
-        assert(dynamic_cast<const LiteralNumber *>(ast_));
-        // Nothing to do.
-    } break;
-    case AST_LITERAL_STRING: {
-        assert(dynamic_cast<const LiteralString *>(ast_));
-        // Nothing to do.
-    } break;
-    case AST_LITERAL_NULL: {
-        assert(dynamic_cast<const LiteralNull *>(ast_));
-        // Nothing to do.
-    } break;
-    case AST_DESUGARED_OBJECT: {
-        assert(dynamic_cast<DesugaredObject *>(ast_));
-        auto* ast = static_cast<DesugaredObject *>(ast_);
-        for (auto &field : ast->fields) {
-            append(r, static_analysis(field.name, in_object, vars));
-            append(r, static_analysis(field.body, true, vars));
-        }
-        for (AST *assert : ast->asserts) {
-            append(r, static_analysis(assert, true, vars));
-        }
-    } break;
-    case AST_OBJECT_COMPREHENSION_SIMPLE: {
-        assert(dynamic_cast<ObjectComprehensionSimple *>(ast_));
-        auto* ast = static_cast<ObjectComprehensionSimple *>(ast_);
-        auto new_vars = vars;
-        new_vars.insert(ast->id);
-        append(r, static_analysis(ast->field, false, new_vars));
-        append(r, static_analysis(ast->value, true, new_vars));
-        r.erase(ast->id);
-        append(r, static_analysis(ast->array, in_object, vars));
-    } break;
-    case AST_SELF: {
-        assert(dynamic_cast<const Self *>(ast_));
-        if (!in_object)
-            throw StaticError(ast_->location, "Can't use self outside of an object.");
-    } break;
-    case AST_SUPER_INDEX: {
-        assert(dynamic_cast<const SuperIndex *>(ast_));
-        auto* ast = static_cast<const SuperIndex *>(ast_);
-        if (!in_object)
-            throw StaticError(ast_->location, "Can't use super outside of an object.");
-        append(r, static_analysis(ast->index, in_object, vars));
-    } break;
-    case AST_UNARY: {
-        assert(dynamic_cast<const Unary *>(ast_));
-        auto* ast = static_cast<const Unary *>(ast_);
-        append(r, static_analysis(ast->expr, in_object, vars));
-    } break;
-    case AST_VAR: {
-        assert(dynamic_cast<const Var *>(ast_));
-        auto* ast = static_cast<const Var *>(ast_);
-        if (vars.find(ast->id) == vars.end()) {
-            throw StaticError(ast->location, "Unknown variable: " + encode_utf8(ast->id->name));
-        }
-        r.insert(ast->id);
-    } break;
-    default:
-        std::cerr << "INTERNAL ERROR: Unknown AST: " << ast_ << std::endl;
-        std::abort();
-        break;
+            append(r, fvs);
+        } break;
+        case AST_LITERAL_BOOLEAN: {
+            assert(dynamic_cast<const LiteralBoolean *>(ast_));
+            // Nothing to do.
+        } break;
+        case AST_LITERAL_NUMBER: {
+            assert(dynamic_cast<const LiteralNumber *>(ast_));
+            // Nothing to do.
+        } break;
+        case AST_LITERAL_STRING: {
+            assert(dynamic_cast<const LiteralString *>(ast_));
+            // Nothing to do.
+        } break;
+        case AST_LITERAL_NULL: {
+            assert(dynamic_cast<const LiteralNull *>(ast_));
+            // Nothing to do.
+        } break;
+        case AST_DESUGARED_OBJECT: {
+            assert(dynamic_cast<DesugaredObject *>(ast_));
+            auto *ast = static_cast<DesugaredObject *>(ast_);
+            for (auto &field : ast->fields) {
+                append(r, static_analysis(field.name, in_object, vars));
+                append(r, static_analysis(field.body, true, vars));
+            }
+            for (AST *assert : ast->asserts) {
+                append(r, static_analysis(assert, true, vars));
+            }
+        } break;
+        case AST_OBJECT_COMPREHENSION_SIMPLE: {
+            assert(dynamic_cast<ObjectComprehensionSimple *>(ast_));
+            auto *ast = static_cast<ObjectComprehensionSimple *>(ast_);
+            auto new_vars = vars;
+            new_vars.insert(ast->id);
+            append(r, static_analysis(ast->field, false, new_vars));
+            append(r, static_analysis(ast->value, true, new_vars));
+            r.erase(ast->id);
+            append(r, static_analysis(ast->array, in_object, vars));
+        } break;
+        case AST_SELF: {
+            assert(dynamic_cast<const Self *>(ast_));
+            if (!in_object)
+                throw StaticError(ast_->location, "Can't use self outside of an object.");
+        } break;
+        case AST_SUPER_INDEX: {
+            assert(dynamic_cast<const SuperIndex *>(ast_));
+            auto *ast = static_cast<const SuperIndex *>(ast_);
+            if (!in_object)
+                throw StaticError(ast_->location, "Can't use super outside of an object.");
+            append(r, static_analysis(ast->index, in_object, vars));
+        } break;
+        case AST_UNARY: {
+            assert(dynamic_cast<const Unary *>(ast_));
+            auto *ast = static_cast<const Unary *>(ast_);
+            append(r, static_analysis(ast->expr, in_object, vars));
+        } break;
+        case AST_VAR: {
+            assert(dynamic_cast<const Var *>(ast_));
+            auto *ast = static_cast<const Var *>(ast_);
+            if (vars.find(ast->id) == vars.end()) {
+                throw StaticError(ast->location, "Unknown variable: " + encode_utf8(ast->id->name));
+            }
+            r.insert(ast->id);
+        } break;
+        default:
+            std::cerr << "INTERNAL ERROR: Unknown AST: " << ast_ << std::endl;
+            std::abort();
+            break;
     }
 
     for (auto *id : r)

--- a/core/string_utils.cpp
+++ b/core/string_utils.cpp
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include "string_utils.h"
+
 #include <iomanip>
 
 #include "static_error.h"
-#include "string_utils.h"
 
 namespace jsonnet::internal {
 
@@ -95,7 +96,8 @@ bool is_bmp_codepoint(const unsigned long codepoint)
     return codepoint < 0xd800 || (codepoint >= 0xe000 && codepoint < 0x10000);
 }
 
-char32_t decode_utf16_surrogates(const LocationRange &loc, const unsigned long high, const unsigned long low)
+char32_t decode_utf16_surrogates(const LocationRange &loc, const unsigned long high,
+                                 const unsigned long low)
 {
     if (high >= 0xd800 && high < 0xdc00 && low >= 0xdc00 && low < 0xe000) {
         return 0x10000 + ((high & 0x03ff) << 10) + (low & 0x03ff);
@@ -139,22 +141,22 @@ UString jsonnet_string_unescape(const LocationRange &loc, const UString &s)
                         // the outer for loop.
                         c += 3;
                         if (!is_bmp_codepoint(codepoint)) {
-                           if (*(++c) != '\\') {
+                            if (*(++c) != '\\') {
                                 std::stringstream ss;
                                 ss << "Invalid non-BMP Unicode escape in string literal";
                                 throw StaticError(loc, ss.str());
-                           }
-                           if (*(++c) != 'u') {
+                            }
+                            if (*(++c) != 'u') {
                                 std::stringstream ss;
                                 ss << "Invalid non-BMP Unicode escape in string literal";
                                 throw StaticError(loc, ss.str());
-                           }
-                           ++c;
-                           unsigned long codepoint2 = jsonnet_string_parse_unicode(loc, c);
-                           c += 3;
-                           codepoint = decode_utf16_surrogates(loc, codepoint, codepoint2);
-                       }
-                       r += codepoint;
+                            }
+                            ++c;
+                            unsigned long codepoint2 = jsonnet_string_parse_unicode(loc, c);
+                            c += 3;
+                            codepoint = decode_utf16_surrogates(loc, codepoint, codepoint2);
+                        }
+                        r += codepoint;
                     } break;
 
                     case '\0': {

--- a/cpp/libjsonnet++_test.cpp
+++ b/cpp/libjsonnet++_test.cpp
@@ -14,19 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "libjsonnet++.h"
-
 #include <fstream>
 #include <streambuf>
 #include <string>
 
 #include "gtest/gtest.h"
+#include "libjsonnet++.h"
 
 namespace jsonnet {
 std::string readFile(const std::string& filename)
 {
     std::ifstream in(filename);
-    if (!in.good()){
+    if (!in.good()) {
         ADD_FAILURE() << "Could not open: " << filename;
         return "";
     }

--- a/include/libjsonnet.h
+++ b/include/libjsonnet.h
@@ -69,12 +69,14 @@ void jsonnet_string_output(struct JsonnetVm *vm, int v);
  *     process's CWD.  This is necessary so that imports from the content of the imported file can
  *     be resolved correctly.  Allocate memory with jsonnet_realloc.  Only use when *success = 1.
  * \param success Set this byref param to 1 to indicate success and 0 for failure.
- * \param buf Set this byref param to the content of the imported file, or an error message.  Allocate memory with jsonnet_realloc.  Do not include a null terminator byte.
+ * \param buf Set this byref param to the content of the imported file, or an error message.
+ * Allocate memory with jsonnet_realloc.  Do not include a null terminator byte.
  * \param buflen Set this byref param to the length of the data returned in buf.
- * \returns 0 to indicate success and 1 for failure.  On success, the content is in *buf.  On failure, an error message is in *buf.
+ * \returns 0 to indicate success and 1 for failure.  On success, the content is in *buf.  On
+ * failure, an error message is in *buf.
  */
-typedef int JsonnetImportCallback(void *ctx, const char *base, const char *rel,
-                                  char **found_here, char **buf, size_t *buflen);
+typedef int JsonnetImportCallback(void *ctx, const char *base, const char *rel, char **found_here,
+                                  char **buf, size_t *buflen);
 
 /** An opaque type which can only be utilized via the jsonnet_json_* family of functions.
  */

--- a/test_cmd/simple4.golden.stderr.cpp
+++ b/test_cmd/simple4.golden.stderr.cpp
@@ -1,1 +1,1 @@
-Opening input file: nosuchfile.jsonnet: No such file or directory
+Opening input file : nosuchfile.jsonnet : No such file or directory

--- a/test_cmd/version1.golden.stdout.cpp
+++ b/test_cmd/version1.golden.stdout.cpp
@@ -1,1 +1,1 @@
-Jsonnet commandline interpreter v0.20.0
+Jsonnet commandline interpreter v0 .20.0

--- a/test_cmd/version2.golden.stdout.cpp
+++ b/test_cmd/version2.golden.stdout.cpp
@@ -1,1 +1,1 @@
-Jsonnet commandline interpreter v0.20.0
+Jsonnet commandline interpreter v0 .20.0


### PR DESCRIPTION
This touches ~everything by reformatting with clang-format on all .cpp and .h files (by running `make reformat`). And then enables the format checks in the GitHub workflow, to detect regressions.

However, note that in general unless everyone working on the code gets into the habit of having clang-format run automatically before commit (e.g., format-on-save in your editor) then regressions are extremely likely, and that is highly frustrating as it will lead to always failing format checks.

So we should consider whether we want to enforce formatting or not - if not, we can just delete the format-check part of the GitHub workflow and let people style code how they want (rely on manual review to prevent egregious stylistic problems). Or if we do want to enforce it then we probably need a smoother way of doing it - at least good instructions for how to configure various editors to format automatically, and probably a provided git pre-commit hook or something similar.