### PR TITLE
Add test case for YAML parsing a version number

### DIFF
--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -1510,6 +1510,8 @@ std.assertEqual(
     |||
   ), { f1: 'a\nb\n', f2: 'a\nb\n' }
 ) &&
+// Issue https://github.com/google/jsonnet/issues/1014
+std.assertEqual(std.parseYaml('version: 1.2.3'), { version: '1.2.3' }) &&
 
 std.assertEqual(std.asciiUpper('!@#$%&*()asdfghFGHJKL09876 '), '!@#$%&*()ASDFGHFGHJKL09876 ') &&
 std.assertEqual(std.asciiLower('!@#$%&*()asdfghFGHJKL09876 '), '!@#$%&*()asdfghfghjkl09876 ') &&


### PR DESCRIPTION
This was failing previously (https://github.com/google/jsonnet/issues/1014) due to a bug in RapidYAML. Should be passing now. Just adding a test case for it (regression test).