### PR TITLE
Delete declaration for jsonnet_unparse_jsonnet (which doesn't exist)

### DIFF
--- a/core/parser.h
+++ b/core/parser.h
@@ -38,11 +38,6 @@ AST *jsonnet_parse(Allocator *alloc, Tokens &tokens);
  */
 std::string jsonnet_unparse_number(double v);
 
-/** The inverse of jsonnet_parse.
- */
-std::string jsonnet_unparse_jsonnet(const AST *ast, const Fodder &final_fodder, unsigned indent,
-                                    bool pad_arrays, bool pad_objects, char comment_style);
-
 }  // namespace jsonnet::internal
 
 #endif  // JSONNET_PARSER_H


### PR DESCRIPTION
Fixes #1012

The earlier `jsonnet_unparse_jsonnet` implementation was removed in 17c59acbfd455e42ab6bae0e5517157be4bf0b90 when the new formatting (pretty-printing) code was first added. The longer (but unimplemented) declaration was introduced in that commit, and has been untouched since then.