### PR TITLE
Escape strings printed by `std.assertEqual`

### DIFF
--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -831,10 +831,14 @@ limitations under the License.
       std.map(map_func, std.filter(filter_func, arr)),
 
   assertEqual(a, b)::
+    // If the values are strings, escape them for printing.
+    // If not, they'll be JSON-stringified anyway by the later string concatenation.
+    local astr = if std.type(a) == 'string' then std.escapeStringJson(a) else a;
+    local bstr = if std.type(b) == 'string' then std.escapeStringJson(b) else b;
     if a == b then
       true
     else
-      error 'Assertion failed. ' + a + ' != ' + b,
+      error 'Assertion failed. ' + astr + ' != ' + bstr,
 
   abs(n)::
     if !std.isNumber(n) then

--- a/test_suite/error.assert_equal_obj.jsonnet
+++ b/test_suite/error.assert_equal_obj.jsonnet
@@ -1,0 +1,17 @@
+/*
+Copyright 2024 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+std.assertEqual({ a: 1 }, { b: 1 })

--- a/test_suite/error.assert_equal_obj.jsonnet.golden
+++ b/test_suite/error.assert_equal_obj.jsonnet.golden
@@ -1,0 +1,3 @@
+RUNTIME ERROR: Assertion failed. {"a": 1} != {"b": 1}
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
+	error.assert_equal_obj.jsonnet:17:1-36	

--- a/test_suite/error.assert_equal_str.jsonnet
+++ b/test_suite/error.assert_equal_str.jsonnet
@@ -1,0 +1,17 @@
+/*
+Copyright 2024 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+std.assertEqual('one\ntwo', 'three\nfour\n')

--- a/test_suite/error.assert_equal_str.jsonnet.golden
+++ b/test_suite/error.assert_equal_str.jsonnet.golden
@@ -1,0 +1,3 @@
+RUNTIME ERROR: Assertion failed. "one\ntwo" != "three\nfour\n"
+	std.jsonnet:<stdlib_position_redacted>	function <anonymous>
+	error.assert_equal_str.jsonnet:17:1-45	


### PR DESCRIPTION
Fixes #363.

When `std.assertEqual` fails, the error message it produces includes the values that were passed in. This PR uses `std.escapeStringJson` to escape strings passed to `std.assertEqual`. Other values are concatenated as normal (relying on the string concatenation to stringize them as before).

An alternative is to call `std.manifestJson` on both arguments regardless of type. However it's not clear to me that `std.manifestJson` will produce the same output as the (internal) `toString` performed by string concatenation.

PR adds test cases for std.assertEqual with two unequal strings and with two unequal objects.