### PR TITLE
Fix field visibility of object comprehension fields to inherit

### DIFF
--- a/core/vm.cpp
+++ b/core/vm.cpp
@@ -748,7 +748,7 @@ class Interpreter {
 
         } else if (auto *obj = dynamic_cast<const HeapComprehensionObject *>(obj_)) {
             for (const auto &f : obj->compValues)
-                r[f.first] = ObjectField::VISIBLE;
+                r[f.first] = ObjectField::INHERIT;
         }
         return r;
     }

--- a/test_suite/object.jsonnet
+++ b/test_suite/object.jsonnet
@@ -80,6 +80,11 @@ local obj = {
 
 std.assertEqual(obj, { ["f" + x + y + z]: { x: x, y: y, z: z } for x in [1, 2, 3] for y in [1, 4, 6] if x + 2 < y for z in [true, false] }) &&
 
+// Tests for #1111 - object comprehension fields should use "inherit" visibility.
+std.assertEqual(std.objectFields({ x: 1 } + { [k]: 2 for k in ['x'] }), ['x']) &&
+std.assertEqual(std.objectFields({ x:: 1 } + { [k]: 2 for k in ['x'] }), []) &&
+std.assertEqual(std.objectFields({ x::: 1 } + { [k]: 2 for k in ['x'] }), ['x']) &&
+
 std.assertEqual({ f: { foo: 7, bar: 1 } { [self.name]+: 3, name:: "foo" }, name:: "bar" },
                 { f: { foo: 7, bar: 4 } }) &&
 

--- a/test_suite/object.jsonnet.fmt.golden
+++ b/test_suite/object.jsonnet.fmt.golden
@@ -80,6 +80,11 @@ local obj = {
 
 std.assertEqual(obj, { ['f' + x + y + z]: { x: x, y: y, z: z } for x in [1, 2, 3] for y in [1, 4, 6] if x + 2 < y for z in [true, false] }) &&
 
+// Tests for #1111 - object comprehension fields should use "inherit" visibility.
+std.assertEqual(std.objectFields({ x: 1 } + { [k]: 2 for k in ['x'] }), ['x']) &&
+std.assertEqual(std.objectFields({ x:: 1 } + { [k]: 2 for k in ['x'] }), []) &&
+std.assertEqual(std.objectFields({ x::: 1 } + { [k]: 2 for k in ['x'] }), ['x']) &&
+
 std.assertEqual({ f: { foo: 7, bar: 1 } { [self.name]+: 3, name:: 'foo' }, name:: 'bar' },
                 { f: { foo: 7, bar: 4 } }) &&
 


### PR DESCRIPTION
This should make C++ Jsonnet match the existing behaviour of Go-Jsonnet.

Object comprehensions do not support differing field visibility, that is an object comprehension with a "hidden" or "forced-visible" field such as `{[k]::1 for k in ["x"]}` is rejected with a syntax error.

Intuitively the `{[key_expr]: value_expr for x in ...}` syntax should behave similarly to a normal (non-comprehension) object that uses default field visibility. Default field visibility is to 'inherit' visibility when merging objects with the + operator, and this is the existing behaviour of Go-Jsonnet.

Example case:

```
./jsonnet -e '{"one":: "base"} + {[k]: "derived" for k in ["one"]}'
```

Before this commit, Go-Jsonnet output:
`{ }`

Before this commit, C++ Jsonnet output:
`{ "one": "derived" }`

After this commit, both produce `{ }`

Fixes #1111 