### PR TITLE
Handle unknown json::value_t kinds (by aborting)

### DIFF
--- a/core/vm.cpp
+++ b/core/vm.cpp
@@ -21,6 +21,10 @@ limitations under the License.
 #include <set>
 #include <string>
 
+// charconv is because the RapidYAML 0.5.0 release has a bug in the single-header build.
+// https://github.com/biojppm/rapidyaml/issues/364#issuecomment-1536625415
+#include <charconv>
+
 #include "desugarer.h"
 #include "json.h"
 #include <nlohmann/json.hpp>

--- a/core/vm.cpp
+++ b/core/vm.cpp
@@ -1715,6 +1715,14 @@ class Interpreter {
             case json::value_t::discarded: {
                 abort();
             }
+
+            default: {
+                // Newer mlohmann json.hpp (from v3.8.0 https://github.com/nlohmann/json/pull/1662)
+                // add a `value_t::binary` type, used when dealing with some JSON-adjacent binary
+                // formats (BSON, CBOR, etc). Since it doesn't exist prior to v3.8.0 we can't match
+                // on it explicitly, but we can just treat any unknown type as an error.
+                abort();
+            }
         }
     }
 

--- a/third_party/rapidyaml/rapidyaml.cpp
+++ b/third_party/rapidyaml/rapidyaml.cpp
@@ -1,2 +1,6 @@
+// charconv is because the 0.5.0 release has a bug in the single-header build.
+// https://github.com/biojppm/rapidyaml/issues/364#issuecomment-1536625415
+#include <charconv>
+
 #define RYML_SINGLE_HDR_DEFINE_NOW
 #include "ryml_all.hpp"


### PR DESCRIPTION
This should prevent a compile warning when building against nlohmann json.hpp v3.8.0 or greater, which add an extra value_t kind for binary data, without _requiring_ a newer version to build.

Fixes #1031.

Ref #926 which was a previous attempt to fix this compiler warning, and #1023 which reverted that previous attempt.