### PR TITLE
Free output string in jsonnetfmt in the in-place no-diff path

### DIFF
--- a/cmd/jsonnetfmt.cpp
+++ b/cmd/jsonnetfmt.cpp
@@ -282,6 +282,8 @@ int main(int argc, const char **argv)
                             jsonnet_destroy(vm);
                             return EXIT_FAILURE;
                         }
+                    } else {
+                        jsonnet_realloc(vm, output, 0);
                     }
                 }
             }


### PR DESCRIPTION
Makes the leak detector happy.