### PR TITLE
Initialize Jsonnet::vm_ field to nullptr

### DIFF
--- a/cpp/libjsonnet++.cpp
+++ b/cpp/libjsonnet++.cpp
@@ -17,7 +17,7 @@ limitations under the License.
 #include "libjsonnet++.h"
 
 namespace jsonnet {
-Jsonnet::Jsonnet() {}
+Jsonnet::Jsonnet(): vm_(nullptr) {}
 
 Jsonnet::~Jsonnet()
 {


### PR DESCRIPTION
The `Jsonnet` class constructor doesn't set up the VM; this is deferred until the user calls `init()`. However it's important for the `vm_` field to itself be initialised to a known value. The `Jsonnet` destructor will attempt to destroy the VM only if the `vm_` field is not null.