### PR TITLE
Document jpathdir option in Python binding docs

### DIFF
--- a/doc/ref/bindings.html
+++ b/doc/ref/bindings.html
@@ -128,6 +128,7 @@ title: Bindings
         Keyword arguments to these functions are used to control the virtual machine.  They are:
       </p>
       <ul>
+        <li><tt>jpathdir</tt>&nbsp;&nbsp; (string or list of strings)</li>
         <li><tt>max_stack</tt>&nbsp;&nbsp; (number)</li>
         <li><tt>gc_min_objects</tt>&nbsp;&nbsp; (number)</li>
         <li><tt>gc_growth_trigger</tt>&nbsp;&nbsp; (number)</li>


### PR DESCRIPTION
Add missing keyword arg to the list.