### PR TITLE
Add digit separators

### DIFF
--- a/core/lexer.cpp
+++ b/core/lexer.cpp
@@ -227,10 +227,10 @@ std::string lex_number(const char *&c, const std::string &filename, const Locati
         AFTER_ONE_TO_NINE,
         AFTER_DOT,
         AFTER_DIGIT,
+        AFTER_UNDERSCORE,
         AFTER_E,
         AFTER_EXP_SIGN,
         AFTER_EXP_DIGIT,
-        AFTER_UNDERSCORE,
         AFTER_EXP_UNDERSCORE
     } state;
 

--- a/core/lexer_test.cpp
+++ b/core/lexer_test.cpp
@@ -115,8 +115,27 @@ TEST(Lexer, TestNumbers)
             "1e+!",
             {},
             "number 1e+!:1:1: couldn't lex number, junk after exponent sign: !");
+}
 
+TEST(Lexer, TestNumbersWithSeparators)
+{
     testLex("number 123_456", "123_456", {Token(Token::Kind::NUMBER, "123456")}, "");
+    testLex("number 1_750_000", "1_750_000", {Token(Token::Kind::NUMBER, "1750000")}, "");
+    testLex("number 1_2_3", "1_2_3", {Token(Token::Kind::NUMBER, "123")}, "");
+    testLex("number 3.141_592", "3.141_592", {Token(Token::Kind::NUMBER, "3.141592")}, "");
+
+    testLex("number 1_2.0", "1_2.0", {Token(Token::Kind::NUMBER, "12.0")}, "");
+    testLex("number 0e1_01", "0e1_01", {Token(Token::Kind::NUMBER, "0e101")}, "");
+    testLex("number 10_10e3", "10_10e3", {Token(Token::Kind::NUMBER, "1010e3")}, "");
+    testLex("number 2_3e1_2", "2_3e1_2", {Token(Token::Kind::NUMBER, "23e12")}, "");
+    testLex("number 1.1_2e100", "1.1_2e100", {Token(Token::Kind::NUMBER, "1.12e100")}, "");
+    testLex("number 1.1e-10_1", "1.1e-10_1", {Token(Token::Kind::NUMBER, "1.1e-101")}, "");
+
+    testLex("number 123456_!", "123456_!", {}, "number 123456_!:1:1: couldn't lex number, junk after _: !");
+    testLex("number 123__456",
+            "123__456",
+            {},
+            "number 123__456:1:1: couldn't lex number, multiple consecutive _'s");
 }
 
 TEST(Lexer, TestDoubleStrings)
@@ -330,6 +349,7 @@ TEST(Lexer, TestIdentifier)
             "foo bar123",
             {Token(Token::Kind::IDENTIFIER, "foo"), Token(Token::Kind::IDENTIFIER, "bar123")},
             "");
+    testLex("identifier _123", "_123", {Token(Token::Kind::IDENTIFIER, "_123")}, "");
 }
 
 TEST(Lexer, TestComments)

--- a/core/lexer_test.cpp
+++ b/core/lexer_test.cpp
@@ -130,6 +130,7 @@ TEST(Lexer, TestNumbersWithSeparators)
     testLex("number 2_3e1_2", "2_3e1_2", {Token(Token::Kind::NUMBER, "23e12")}, "");
     testLex("number 1.1_2e100", "1.1_2e100", {Token(Token::Kind::NUMBER, "1.12e100")}, "");
     testLex("number 1.1e-10_1", "1.1e-10_1", {Token(Token::Kind::NUMBER, "1.1e-101")}, "");
+    testLex("number 9.109_383_56e-31", "9.109_383_56e-31", {Token(Token::Kind::NUMBER, "9.10938356e-31")}, "");
 
     testLex("number 123456_!",
             "123456_!",
@@ -159,6 +160,10 @@ TEST(Lexer, TestNumbersWithSeparators)
             "200e-_2",
             {},
             "number 200e-_2:1:1: couldn't lex number, junk after exponent sign: _");
+    testLex("number 200e+_2",
+            "200e+_2",
+            {},
+            "number 200e+_2:1:1: couldn't lex number, junk after exponent sign: _");
 }
 
 TEST(Lexer, TestDoubleStrings)

--- a/core/lexer_test.cpp
+++ b/core/lexer_test.cpp
@@ -123,19 +123,42 @@ TEST(Lexer, TestNumbersWithSeparators)
     testLex("number 1_750_000", "1_750_000", {Token(Token::Kind::NUMBER, "1750000")}, "");
     testLex("number 1_2_3", "1_2_3", {Token(Token::Kind::NUMBER, "123")}, "");
     testLex("number 3.141_592", "3.141_592", {Token(Token::Kind::NUMBER, "3.141592")}, "");
-
-    testLex("number 1_2.0", "1_2.0", {Token(Token::Kind::NUMBER, "12.0")}, "");
+    testLex("number 01_100", "01_100", {Token(Token::Kind::NUMBER, "0"), Token(Token::Kind::NUMBER, "1100")}, "");
+    testLex("number 1_200.0", "1_200.0", {Token(Token::Kind::NUMBER, "1200.0")}, "");
     testLex("number 0e1_01", "0e1_01", {Token(Token::Kind::NUMBER, "0e101")}, "");
     testLex("number 10_10e3", "10_10e3", {Token(Token::Kind::NUMBER, "1010e3")}, "");
     testLex("number 2_3e1_2", "2_3e1_2", {Token(Token::Kind::NUMBER, "23e12")}, "");
     testLex("number 1.1_2e100", "1.1_2e100", {Token(Token::Kind::NUMBER, "1.12e100")}, "");
     testLex("number 1.1e-10_1", "1.1e-10_1", {Token(Token::Kind::NUMBER, "1.1e-101")}, "");
 
-    testLex("number 123456_!", "123456_!", {}, "number 123456_!:1:1: couldn't lex number, junk after _: !");
+    testLex("number 123456_!",
+            "123456_!",
+            {},
+            "number 123456_!:1:1: couldn't lex number, junk after _: !");
     testLex("number 123__456",
             "123__456",
             {},
             "number 123__456:1:1: couldn't lex number, multiple consecutive _'s");
+    testLex("number 1_200_.0",
+            "1_200_.0",
+            {},
+            "number 1_200_.0:1:1: couldn't lex number, junk after _: .");
+    testLex("number 1_200._0",
+            "1_200._0",
+            {},
+            "number 1_200._0:1:1: couldn't lex number, junk after decimal point: _");
+    testLex("number 1_200_e2",
+            "1_200_e2",
+            {},
+            "number 1_200_e2:1:1: couldn't lex number, junk after _: e");
+    testLex("number 1_200e_2",
+            "1_200e_2",
+            {},
+            "number 1_200e_2:1:1: couldn't lex number, junk after 'E': _");
+    testLex("number 200e-_2",
+            "200e-_2",
+            {},
+            "number 200e-_2:1:1: couldn't lex number, junk after exponent sign: _");
 }
 
 TEST(Lexer, TestDoubleStrings)

--- a/core/lexer_test.cpp
+++ b/core/lexer_test.cpp
@@ -115,6 +115,8 @@ TEST(Lexer, TestNumbers)
             "1e+!",
             {},
             "number 1e+!:1:1: couldn't lex number, junk after exponent sign: !");
+
+    testLex("number 123_456", "123_456", {Token(Token::Kind::NUMBER, "123456")}, "");
 }
 
 TEST(Lexer, TestDoubleStrings)


### PR DESCRIPTION
This is a draft implementation of adding digit separators (`1_000`) to Jsonnet's numeric constants.

Accompanying issue: https://github.com/google/jsonnet/issues/1155