### PR TITLE
Keep hidden fields in std.prune

### DIFF
--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1625,7 +1625,7 @@ limitations under the License.
       [std.prune(x) for x in a if isContent($.prune(x))]
     else if std.isObject(a) then {
       [x]: $.prune(a[x])
-      for x in std.objectFields(a)
+      for x in std.objectFieldsAll(a)
       if isContent(std.prune(a[x]))
     } else
       a,


### PR DESCRIPTION
According to the [docs](https://github.com/google/jsonnet/blob/913281d203578bb394995bacc792f2576371e06c/doc/ref/stdlib.html#L202-L204), `std.prune`:
> Recursively remove all "empty" members of a. "Empty" is defined as zero length `arrays`, zero length `objects`, or `null` values. The argument a may have any type.

However, it also removes hidden fields from objects because it uses `std.objectFields` to traverse it. This PR changes that to use `std.objectFieldsAll` instead, which keeps hidden fields as promised by the docs.

Sort of relates to #1167.