### PR TITLE
feat: add `|||-` chomped text block syntax

### DIFF
--- a/core/formatter.cpp
+++ b/core/formatter.cpp
@@ -500,7 +500,11 @@ class Unparser {
                 o << encode_utf8(ast->value);
                 o << "'";
             } else if (ast->tokenKind == LiteralString::BLOCK) {
-                o << "|||\n";
+                o << "|||";
+                if (ast->value.back() != U'\n') {
+                    o << "-";
+                }
+                o << "\n";
                 if (ast->value.c_str()[0] != U'\n')
                     o << ast->blockIndent;
                 for (const char32_t *cp = ast->value.c_str(); *cp != U'\0'; ++cp) {
@@ -512,6 +516,9 @@ class Unparser {
                     if (*cp == U'\n' && *(cp + 1) != U'\n' && *(cp + 1) != U'\0') {
                         o << ast->blockIndent;
                     }
+                }
+                if (ast->value.back() != U'\n') {
+                    o << "\n";
                 }
                 o << ast->blockTermIndent << "|||";
             } else if (ast->tokenKind == LiteralString::VERBATIM_DOUBLE) {

--- a/core/lexer.cpp
+++ b/core/lexer.cpp
@@ -704,6 +704,13 @@ Tokens jsonnet_lex(const std::string &filename, const char *input)
                     // Text block
                     if (*c == '|' && *(c + 1) == '|' && *(c + 2) == '|') {
                         c += 3;  // Skip the "|||".
+
+                        bool chomp_trailing_nl = false;
+                        if (*c == '-') {
+                            chomp_trailing_nl = true;
+                            c++;
+                        }
+
                         while (is_horz_ws(*c)) ++c;  // Chomp whitespace at end of line.
                         if (*c != '\n') {
                             auto msg = "text block syntax requires new line after |||.";
@@ -762,6 +769,10 @@ Tokens jsonnet_lex(const std::string &filename, const char *input)
                                 c += 3;  // Leave after the last |
                                 data = block.str();
                                 kind = Token::STRING_BLOCK;
+                                if (chomp_trailing_nl) {
+                                    assert(data.back() == '\n');
+                                    data.pop_back();
+                                }
                                 break;  // Out of the while loop.
                             }
                         }

--- a/doc/js/codemirror-mode-jsonnet.js
+++ b/doc/js/codemirror-mode-jsonnet.js
@@ -176,7 +176,7 @@
         }
 
         // Enter text block.
-        if (stream.match(/\|\|\|/)) {
+        if (stream.match(/\|\|\|-?/)) {
           state.textBlock = true;
           state.textBlockIndent = null;
           return "string";

--- a/doc/ref/spec.html
+++ b/doc/ref/spec.html
@@ -168,15 +168,19 @@ div.rules {
               subsequent non-quoted <code>'</code>
             </li>
             <li>
-              Text block, beginning with <code>|||</code>, followed by optional whitespace and a
-              new-line.  The next non-empty line must be prefixed with some non-zero length
-              whitespace <i>W</i>.  The block ends at the first subsequent line that is non-empty
-              and does not begin with <i>W</i>, and it is an error if this line does not contain
-              some optional whitespace followed by <code>|||</code>.  The content of the string is
-              the concatenation of all the lines between the two <code>|||</code>, which either
-              begin with <i>W</i> (in which case that prefix is stripped) or they are empty lines
-              (in which case they remain as empty lines).  The line ending style in the file is
-              preserved in the string.  This form cannot be used in <code>import</code> statements.
+              Text block, beginning with <code>|||</code> followed by an optional
+              <code>-</code>, then optional whitespace and a new-line.  The next non-empty
+              line must be prefixed with some non-zero length whitespace <i>W</i>.  The
+              block ends at the first subsequent line that is non-empty and does not begin
+              with <i>W</i>, and it is an error if this line does not contain some
+              optional whitespace followed by <code>|||</code>.  The content of the string
+              is the concatenation of all the lines between the two <code>|||</code>,
+              which either begin with <i>W</i> (in which case that prefix is stripped) or
+              they are empty lines (in which case they remain as empty lines).  The line
+              ending style in the file is preserved in the string.  If the beginning
+              <code>|||</code> was followed by <code>-</code> then the final new-line is
+              stripped from the resulting string.  This form cannot be used in
+              <code>import</code> statements.
             </li>
           </ul>
           <p>

--- a/doc/third_party/MathJax-2.7.2/unpacked/jax/element/mml/optable/BasicLatin.js
+++ b/doc/third_party/MathJax-2.7.2/unpacked/jax/element/mml/optable/BasicLatin.js
@@ -26,7 +26,8 @@
     OPTABLE: {
       prefix: {
         '||': [0,0,TEXCLASS.BIN,{fence: true, stretchy: true, symmetric: true}], // multiple character operator: ||
-        '|||': [0,0,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}]  // multiple character operator: |||
+        '|||': [0,0,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}],  // multiple character operator: |||
+        '|||-': [0,0,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}]  // multiple character operator: |||-
       },
       postfix: {
         '!!': [1,0,TEXCLASS.BIN], // multiple character operator: !!
@@ -36,7 +37,8 @@
         '..': [0,0,TEXCLASS.BIN], // multiple character operator: ..
         '...': MO.ORD,         // multiple character operator: ...
         '||': [0,0,TEXCLASS.BIN,{fence: true, stretchy: true, symmetric: true}], // multiple character operator: ||
-        '|||': [0,0,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}]  // multiple character operator: |||
+        '|||': [0,0,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}],  // multiple character operator: |||
+        '|||-': [0,0,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}]  // multiple character operator: |||-
       },
       infix: {
         '!=': MO.BIN4,         // multiple character operator: !=
@@ -55,7 +57,8 @@
         '>=': MO.BIN5,         // multiple character operator: >=
         '@': MO.ORD11,         // commercial at
         '||': [2,2,TEXCLASS.BIN,{fence: true, stretchy: true, symmetric: true}], // multiple character operator: ||
-        '|||': [2,2,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}]  // multiple character operator: |||
+        '|||': [0,0,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}],  // multiple character operator: |||
+        '|||-': [0,0,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}]  // multiple character operator: |||-
       }
     }
   });

--- a/doc/third_party/MathJax-2.7.2/unpacked/jax/element/mml/optable/BasicLatin.js
+++ b/doc/third_party/MathJax-2.7.2/unpacked/jax/element/mml/optable/BasicLatin.js
@@ -26,8 +26,7 @@
     OPTABLE: {
       prefix: {
         '||': [0,0,TEXCLASS.BIN,{fence: true, stretchy: true, symmetric: true}], // multiple character operator: ||
-        '|||': [0,0,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}],  // multiple character operator: |||
-        '|||-': [0,0,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}]  // multiple character operator: |||-
+        '|||': [0,0,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}]  // multiple character operator: |||
       },
       postfix: {
         '!!': [1,0,TEXCLASS.BIN], // multiple character operator: !!
@@ -37,8 +36,7 @@
         '..': [0,0,TEXCLASS.BIN], // multiple character operator: ..
         '...': MO.ORD,         // multiple character operator: ...
         '||': [0,0,TEXCLASS.BIN,{fence: true, stretchy: true, symmetric: true}], // multiple character operator: ||
-        '|||': [0,0,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}],  // multiple character operator: |||
-        '|||-': [0,0,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}]  // multiple character operator: |||-
+        '|||': [0,0,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}]  // multiple character operator: |||
       },
       infix: {
         '!=': MO.BIN4,         // multiple character operator: !=
@@ -57,8 +55,7 @@
         '>=': MO.BIN5,         // multiple character operator: >=
         '@': MO.ORD11,         // commercial at
         '||': [2,2,TEXCLASS.BIN,{fence: true, stretchy: true, symmetric: true}], // multiple character operator: ||
-        '|||': [0,0,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}],  // multiple character operator: |||
-        '|||-': [0,0,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}]  // multiple character operator: |||-
+        '|||': [2,2,TEXCLASS.ORD,{fence: true, stretchy: true, symmetric: true}]  // multiple character operator: |||
       }
     }
   });

--- a/test_suite/text_block.jsonnet
+++ b/test_suite/text_block.jsonnet
@@ -58,6 +58,33 @@ local bash_mixed = |||
 std.assertEqual(bash_golden, bash_mixed) &&
 
 
+// Chomp trailing newline
+local str1 = |||-
+  foo bar baz
+|||;
+
+std.assertEqual(str1, "foo bar baz") &&
+
+
+// Chomp just one trailing newline
+local str1 = |||-
+  foo bar baz
+
+|||;
+
+std.assertEqual(str1, "foo bar baz\n") &&
+
+
+// Concatenate chomped blocks
+local str1 = |||-
+    foo bar baz
+||| + " " + |||-
+    biz buzz
+|||;
+
+std.assertEqual(str1, "foo bar baz biz buzz") &&
+
+
 // More indent
 local str1 = |||
         text

--- a/test_suite/text_block.jsonnet.fmt.golden
+++ b/test_suite/text_block.jsonnet.fmt.golden
@@ -58,6 +58,32 @@ local bash_mixed = |||
 std.assertEqual(bash_golden, bash_mixed) &&
 
 
+// Chomp trailing newline
+local str1 = |||-
+  foo bar baz
+|||;
+
+std.assertEqual(str1, 'foo bar baz') &&
+
+
+// Chomp just one trailing newline
+local str1 = |||
+  foo bar baz
+|||;
+
+std.assertEqual(str1, 'foo bar baz\n') &&
+
+
+// Concatenate chomped blocks
+local str1 = |||-
+  foo bar baz
+||| + ' ' + |||-
+  biz buzz
+|||;
+
+std.assertEqual(str1, 'foo bar baz biz buzz') &&
+
+
 // More indent
 local str1 = |||
   text


### PR DESCRIPTION
Resolves #289!

Was pretty easy to add as you can see. 🙂

Let me know if you have any concerns or feedback!

Only part I'm not sure of is the changes to [doc/third_party/MathJax-2.7.2/unpacked](https://github.com/google/jsonnet/compare/master...vergenzt:vergenzt%2Fgh-289-text-block-chomp?body=&expand=1#diff-558e4aab873bdaac5dc5907b5de80ba0db1e18f053f079dd0024cdaf3d3ca6a5) -- it looks like like at https://github.com/google/jsonnet/blob/9952fc5143097706919e73d4dd94287247461f2e/doc/_layouts/base.html#L22 we link to the root "packed" version of `MathJax.js`, but I can't figure out to re-"pack" the unpacked code. 🤔 I'm also not sure how critical it is though. 🤷🏻‍♂️ 

Note: I'm working on a companion PR to [google/go-jsonnet](https://github.com/google/go-jsonnet) too.