### PR TITLE
Add link to a npmjs wasm module

### DIFF
--- a/doc/ref/bindings.html
+++ b/doc/ref/bindings.html
@@ -210,7 +210,10 @@ for person_id, person in json_obj.items():
           <a href="https://github.com/yuduanchen/luajit-jsonnet">LuaJIT (FFI)</a>
         </li>
         <li>
-          <a href="https://github.com/yosuke-furukawa/node-jsonnet">Node.js</a>
+          <a href="https://github.com/yosuke-furukawa/node-jsonnet">Node.js node-jsonnet</a>: C++ version compiled to JS code
+        </li>
+        <li>
+          <a href="https://github.com/olpa/templating-for-api/tree/master/jsonnet-js-ts">Node.js tplfa-jsonnet</a>: Golang version compiled to WASM code
         </li>
         <li>
           <a href="https://github.com/Neeke/Jsonnet-PHP">PHP</a>


### PR DESCRIPTION
Let me add a link to the npmjs module with bindings for jsonnet. There is already one, but the new module is based on the Golang version and provides "libjsonnet.wasm", which otherwise has to be downloaded from a helper dir on jsonnet's site.