### PR TITLE
Remove Bazel module dependency on rules_jsonnet

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,6 @@ build_defs = use_extension("//tools/build_defs:extensions.bzl", "build_defs")
 use_repo(
     build_defs,
     "default_python3_headers",
-    "io_bazel_rules_jsonnet",
 )
 
 register_toolchains("//platform_defs:default_python3_toolchain")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,7 @@
 module(name = "jsonnet", version = "0.0.0")
 
 bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest")
+bazel_dep(name = "rules_python", version = "0.40.0")
 
 build_defs = use_extension("//tools/build_defs:extensions.bzl", "build_defs")
 use_repo(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,7 @@
-module(name = "jsonnet", version = "0.0.0")
+module(
+    name = "jsonnet",
+    version = "0.0.0",
+)
 
 bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest")
 bazel_dep(name = "rules_python", version = "0.40.0")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,13 +3,6 @@ workspace(name = "jsonnet")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
-    name = "io_bazel_rules_jsonnet",
-    commit = "ad2b4204157ddcf7919e8bd210f607f8a801aa7f",
-    remote = "https://github.com/bazelbuild/rules_jsonnet.git",
-    shallow_since = "1556260764 +0200",
-)
-
-git_repository(
     name = "com_google_googletest",
     # If updating googletest version, also update CMakeLists.txt.in.
     commit = "2fe3bd994b3189899d93f1d5a881e725e046fdc2",  # release: release-1.8.1

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,9 +11,9 @@ git_repository(
 
 git_repository(
     name = "com_google_googletest",
-    remote = "https://github.com/google/googletest.git",
     # If updating googletest version, also update CMakeLists.txt.in.
-    commit = "2fe3bd994b3189899d93f1d5a881e725e046fdc2", # release: release-1.8.1
+    commit = "2fe3bd994b3189899d93f1d5a881e725e046fdc2",  # release: release-1.8.1
+    remote = "https://github.com/google/googletest.git",
     shallow_since = "1535728917 -0400",
 )
 
@@ -22,5 +22,5 @@ register_toolchains("//platform_defs:default_python3_toolchain")
 
 # This allows building C++ against python3 headers.
 load("//tools/build_defs:python_repo.bzl", "python_headers")
-python_headers(name = "default_python3_headers")
 
+python_headers(name = "default_python3_headers")

--- a/cpp/testdata/BUILD
+++ b/cpp/testdata/BUILD
@@ -1,10 +1,10 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl",
-    "jsonnet_to_json_test",
     "jsonnet_library",
+    "jsonnet_to_json_test",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 jsonnet_to_json_test(
     name = "example_test",

--- a/cpp/testdata/BUILD
+++ b/cpp/testdata/BUILD
@@ -1,38 +1,25 @@
-load(
-    "@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl",
-    "jsonnet_library",
-    "jsonnet_to_json_test",
-)
+load("//tools/build_defs:golden_test.bzl", "jsonnet_json_golden_test")
 
 package(default_visibility = ["//visibility:public"])
 
-jsonnet_to_json_test(
+jsonnet_json_golden_test(
     name = "example_test",
     src = "example.jsonnet",
     golden = "example_golden.json",
 )
 
-jsonnet_to_json_test(
+jsonnet_json_golden_test(
     name = "importing_test",
     src = "importing.jsonnet",
+    data = ["example.jsonnet"],
     golden = "importing_golden.json",
-    imports = ["."],
-    deps = [":testlib"],
 )
 
-jsonnet_to_json_test(
+jsonnet_json_golden_test(
     name = "invalid_test",
     src = "invalid.jsonnet",
-    error = 1,
+    expect_error = True,
     golden = "invalid.out",
-)
-
-jsonnet_library(
-    name = "testlib",
-    srcs = [
-        "example.jsonnet",
-        "importing.jsonnet",
-    ],
 )
 
 filegroup(

--- a/platform_defs/BUILD
+++ b/platform_defs/BUILD
@@ -16,6 +16,6 @@ py_runtime_pair(
 toolchain(
     name = "default_python3_toolchain",
     toolchain = ":just_python3",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+    toolchain_type = "@rules_python//python:toolchain_type",
 )
 

--- a/platform_defs/BUILD
+++ b/platform_defs/BUILD
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
+load("@rules_python//python:defs.bzl", "py_runtime", "py_runtime_pair")
 
 py_runtime(
     name = "python3",

--- a/platform_defs/BUILD
+++ b/platform_defs/BUILD
@@ -3,8 +3,8 @@ load("@rules_python//python:defs.bzl", "py_runtime", "py_runtime_pair")
 py_runtime(
     name = "python3",
     interpreter_path = "/usr/bin/python3",
-    stub_shebang = "#!/usr/bin/env python3",
     python_version = "PY3",
+    stub_shebang = "#!/usr/bin/env python3",
 )
 
 py_runtime_pair(
@@ -18,4 +18,3 @@ toolchain(
     toolchain = ":just_python3",
     toolchain_type = "@rules_python//python:toolchain_type",
 )
-

--- a/python/BUILD
+++ b/python/BUILD
@@ -23,8 +23,8 @@ py_test(
     srcs = ["_jsonnet_test.py"],
     data = [
         "testdata/basic_check.jsonnet",
-        "testdata/binary1230123.bin",
         "testdata/binary123.bin",
+        "testdata/binary1230123.bin",
         "testdata/trivial.jsonnet",
         "testdata/trivial_no_eol.jsonnet",
     ],

--- a/python/BUILD
+++ b/python/BUILD
@@ -1,3 +1,5 @@
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
 cc_binary(
     name = "_jsonnet.so",
     srcs = ["_jsonnet.c"],

--- a/stdlib/BUILD
+++ b/stdlib/BUILD
@@ -7,8 +7,8 @@ filegroup(
 
 cc_library(
     name = "std",
-    hdrs = ["std.jsonnet.h"],
     srcs = [":gen-std-jsonnet-h"],
+    hdrs = ["std.jsonnet.h"],
     includes = ["."],
     linkstatic = 1,
 )

--- a/test_suite/BUILD
+++ b/test_suite/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:private"])
+
+# Export the tests.source so it can be used by Bazel tests elsewhere in the repo.
+sh_library(
+    name = "tests_sh_lib",
+    srcs = ["tests.source"],
+    visibility = ["//tools/build_defs:__pkg__"],
+)

--- a/third_party/json/BUILD
+++ b/third_party/json/BUILD
@@ -1,4 +1,5 @@
 licenses(["permissive"])
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -10,4 +11,3 @@ cc_library(
     ],
     includes = ["."],
 )
-

--- a/third_party/md5/BUILD
+++ b/third_party/md5/BUILD
@@ -1,4 +1,5 @@
 licenses(["permissive"])
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -9,7 +10,6 @@ cc_library(
     hdrs = [
         "md5.h",
     ],
-    linkopts = ["-lm"],
     includes = ["."],
+    linkopts = ["-lm"],
 )
-

--- a/tools/build_defs/extensions.bzl
+++ b/tools/build_defs/extensions.bzl
@@ -3,10 +3,10 @@ load(":python_repo.bzl", "python_headers")
 
 def _impl(repository_ctx):
     git_repository(
-         name = "io_bazel_rules_jsonnet",
-         commit = "ad2b4204157ddcf7919e8bd210f607f8a801aa7f",
-         remote = "https://github.com/bazelbuild/rules_jsonnet.git",
-         shallow_since = "1556260764 +0200",
+        name = "io_bazel_rules_jsonnet",
+        commit = "ad2b4204157ddcf7919e8bd210f607f8a801aa7f",
+        remote = "https://github.com/bazelbuild/rules_jsonnet.git",
+        shallow_since = "1556260764 +0200",
     )
 
     python_headers(name = "default_python3_headers")

--- a/tools/build_defs/extensions.bzl
+++ b/tools/build_defs/extensions.bzl
@@ -1,14 +1,7 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+# load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load(":python_repo.bzl", "python_headers")
 
 def _impl(repository_ctx):
-    git_repository(
-        name = "io_bazel_rules_jsonnet",
-        commit = "ad2b4204157ddcf7919e8bd210f607f8a801aa7f",
-        remote = "https://github.com/bazelbuild/rules_jsonnet.git",
-        shallow_since = "1556260764 +0200",
-    )
-
     python_headers(name = "default_python3_headers")
 
 build_defs = module_extension(

--- a/tools/build_defs/golden_test.bzl
+++ b/tools/build_defs/golden_test.bzl
@@ -1,0 +1,87 @@
+"""Bazel rules for running golden tests."""
+
+def _gen_test_script(ctx):
+    return """\
+#!/bin/bash
+
+set -uo pipefail
+
+# We don't run 'init' or 'deinit' from tests.source, as these
+# just create & remove a TMP dir and Bazel deals with that for us;
+# instead we just need to ensure that the path for the  Bazel
+# managed temp dir is available in TMP_DIR.
+
+TMP_DIR="$TEST_TMPDIR"
+VERBOSE=true
+DISABLE_ERROR_TESTS=
+SUMMARY_ONLY=
+
+source ./test_suite/tests.source
+
+GOLDEN_OUTPUT=$(cat '{golden_path}')
+
+test_eval '{jsonnet_path}' '{input_path}' '{expected_exit_code}' "$GOLDEN_OUTPUT" '{golden_kind}'
+
+if [ $FAILED -eq 0 ] ; then
+    echo "$0: All $EXECUTED test scripts pass."
+    exit 0
+else
+    echo "$0: FAILED: $FAILED / $EXECUTED"
+    exit 1
+fi
+""".format(
+        jsonnet_path = ctx.executable.jsonnet.short_path,
+        input_path = ctx.file.src.short_path,
+        expected_exit_code = 1 if ctx.attr.expect_error else 0,
+        golden_path = ctx.file.golden.short_path,
+        golden_kind = "PLAIN",
+    )
+
+def _jsonnet_json_golden_test_impl(ctx):
+    test_script = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(
+        output = test_script,
+        is_executable = True,
+        content = _gen_test_script(ctx),
+    )
+    return DefaultInfo(
+        executable = test_script,
+        runfiles = ctx.runfiles(
+            transitive_files = ctx.attr._test_sh_lib.files,
+            files = [
+                ctx.executable.jsonnet,
+                ctx.file.src,
+                ctx.file.golden,
+            ] + ctx.files.data,
+        ),
+    )
+
+jsonnet_json_golden_test = rule(
+    implementation = _jsonnet_json_golden_test_impl,
+    test = True,
+    attrs = {
+        "src": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+        ),
+        "data": attr.label_list(allow_files = True),
+        "golden": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+        ),
+        "jsonnet": attr.label(
+            default = "//cmd:jsonnet",
+            executable = True,
+            cfg = "exec",
+        ),
+        "expect_error": attr.bool(
+            doc = "If True, the golden file is the expected stderr output from jsonnet",
+        ),
+        "canonicalize_golden": attr.bool(
+            doc = "If True, the golden file will be reformatted prior to comparing against the jsonnet output",
+        ),
+        "_test_sh_lib": attr.label(
+            default = "//test_suite:tests_sh_lib",
+        ),
+    },
+)

--- a/tools/build_defs/python_repo.bzl
+++ b/tools/build_defs/python_repo.bzl
@@ -14,26 +14,27 @@ cc_library(
 """
 
 def _impl(repository_ctx):
-  rctx = repository_ctx
-  if "/" in rctx.attr.path or "\\" in rctx.attr.path:
-    # Canonicalize the path
-    realpath = rctx.path(rctx.attr.path)
-  else:
-    # Find it in $PATH
-    realpath = rctx.which(rctx.attr.path)
-  rctx.symlink(realpath, "bin/python")
-  include_path = rctx.execute([
-      realpath, "-c", "import distutils.sysconfig; print(distutils.sysconfig.get_python_inc())",
-  ])
-  if include_path.return_code != 0:
-    fail("Failed to locate Python headers:\n" + include_path.stderr)
-  rctx.symlink(include_path.stdout.strip(), "include")
-  rctx.file(
-      "WORKSPACE",
-      'workspace(name = "{}")\n'.format(rctx.name),
-  )
-  rctx.file("BUILD", build_file_contents)
-
+    rctx = repository_ctx
+    if "/" in rctx.attr.path or "\\" in rctx.attr.path:
+        # Canonicalize the path
+        realpath = rctx.path(rctx.attr.path)
+    else:
+        # Find it in $PATH
+        realpath = rctx.which(rctx.attr.path)
+    rctx.symlink(realpath, "bin/python")
+    include_path = rctx.execute([
+        realpath,
+        "-c",
+        "import distutils.sysconfig; print(distutils.sysconfig.get_python_inc())",
+    ])
+    if include_path.return_code != 0:
+        fail("Failed to locate Python headers:\n" + include_path.stderr)
+    rctx.symlink(include_path.stdout.strip(), "include")
+    rctx.file(
+        "WORKSPACE",
+        'workspace(name = "{}")\n'.format(rctx.name),
+    )
+    rctx.file("BUILD", build_file_contents)
 
 python_headers = repository_rule(
     implementation = _impl,


### PR DESCRIPTION
This starts with the commits from #1189, and adds commits to remove the Bazel module dependency on rules_jsonnet. 

Although rules_jsonnet is the appropriate Bazel module for external Jsonnet users to use for their Jsonnet build actions, using it internally within the jsonnet repo itself is actually a little difficult as it creates a mutually recursive dependency.

Since the only thing it's being used for is the jsonnet_json_test rule, and we have scripts to runs such tests anyway, it's relatively easy to define our own jsonnet_json_golden_test rule and avoid the recursive dependency.

Our current import of rules_jsonnet points to a very old commit which is no longer compatible with current versions of Bazel, so my first attempt here was to just upgrate to the most recent rules_jsonnet release (0.6.0), however I then ran into difficulties of rules_jsonnet wanting to pull in jsonnet itself (which I don't want because the tests need to test the jsonnet binary built from the local workspace).