### PR TITLE
doc/man: Add man pages jsonnet.1 and jsonnetfmt.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ option(BUILD_TESTS "Build and run jsonnet tests." ON)
 option(BUILD_STATIC_LIBS "Build a static libjsonnet." ON)
 option(BUILD_SHARED_LIBS "Build shared libjsonnet." ON)
 option(BUILD_SHARED_BINARIES "Link binaries to the shared libjsonnet instead of the static one." OFF)
+option(BUILD_MAN_PAGES "Build manpages." OFF)
 option(USE_SYSTEM_GTEST "Use system-provided gtest library" OFF)
 option(USE_SYSTEM_JSON "Use the system-provided json library" OFF)
 # TODO: Support using a system Rapid YAML install.
@@ -325,6 +326,39 @@ if(BUILD_TESTS)
 
     add_subdirectory(test_suite)
 endif()  # if(BUILD_TESTS)
+
+#### Man pages
+#
+
+if(BUILD_MAN_PAGES)
+    find_program(HELP2MAN_BINARY NAMES help2man)
+    if (HELP2MAN_BINARY)
+        message(STATUS "help2man found, man pages will be generated.")
+        file(MAKE_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/man/man1)
+        set(CMAKE_INSTALL_MANDIR "share/man" CACHE STRING "Directory for man pages")
+
+        add_custom_command(
+            OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/man/man1/jsonnet.1
+            COMMAND ${HELP2MAN_BINARY}
+            ARGS --section=1 --name="Jsonnet data templating language interpreter" --output=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/man/man1/jsonnet.1 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/jsonnet
+            DEPENDS jsonnet
+        )
+        add_custom_command(
+            OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/man/man1/jsonnetfmt.1
+            COMMAND ${HELP2MAN_BINARY}
+            ARGS --section=1 --name="Jsonnet data templating language interpreter" --output=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/man/man1/jsonnetfmt.1 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/jsonnetfmt
+            DEPENDS jsonnetfmt
+        )
+
+        add_custom_target(jsonnet-man ALL DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/man/man1/jsonnet.1)
+        add_custom_target(jsonnetfmt-man ALL DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/man/man1/jsonnetfmt.1)
+
+        install(FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/man/man1/jsonnet.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+        install(FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/man/man1/jsonnetfmt.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+    else()
+        message(STATUS "help2man not found, man pages will not be generated.")
+    endif()
+endif()  # if(BUILD_MAN_PAGES)
 
 # --- CMake debugging outputs.
 

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,11 @@ SHARED_LDFLAGS ?= -shared
 VERSION := $(shell grep '\#define.*LIB_JSONNET_VERSION' include/libjsonnet.h | head -n 1 | cut -f 2 -d '"' | sed 's/^v//g' )
 SOVERSION = 0
 
+# Define the help2man command with appropriate options
+HELP2MAN ?= help2man
+
+MAN1_DIR ?= man/man1
+
 ################################################################################
 # End of user-servicable parts
 ################################################################################
@@ -122,15 +127,17 @@ ifeq ($(shell uname -s),Darwin)
 	SONAME = -install_name
 endif
 
-default: jsonnet jsonnetfmt
+default: jsonnet jsonnetfmt man
 
-install: bins libs
+install: bins libs man
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	cp $(BINS) $(DESTDIR)$(PREFIX)/bin/
 	mkdir -p $(DESTDIR)$(PREFIX)/lib
 	cp $(LIBS) $(DESTDIR)$(PREFIX)/lib/
 	mkdir -p $(DESTDIR)$(PREFIX)/include
 	cp $(INCS) $(DESTDIR)$(PREFIX)/include/
+	mkdir -p $(DESTDIR)$(PREFIX)/share/$(MAN1_DIR)
+	install -Dm 644 $(addprefix $(MAN1_DIR)/, $(BINS:=.1)) $(DESTDIR)$(PREFIX)/share/$(MAN1_DIR)/
 
 all: $(ALL)
 
@@ -158,6 +165,16 @@ core/desugarer.cpp: core/std.jsonnet.h
 # Object files
 %.o: %.cpp
 	$(CXX) -c $(CXXFLAGS) $< -o $@
+
+# Target to generate the man page
+
+$(MAN1_DIR)/%.1: % | $(MAN1_DIR)
+	$(HELP2MAN) --output=$@ ./$<
+
+man: $(addprefix $(MAN1_DIR)/, $(BINS:=.1))
+
+$(MAN1_DIR):
+	mkdir -p $@
 
 # Commandline executable.
 jsonnet: cmd/jsonnet.cpp cmd/utils.cpp $(LIB_OBJ)
@@ -214,7 +231,7 @@ $(RELEASE_FILE): bins
 dist: $(RELEASE_FILE)
 
 clean:
-	rm -rvf */*~ *~ .*~ */.*.swp .*.swp $(ALL) *.o core/*.jsonnet.h Makefile.depend *.so.* build jsonnet.egg-info $(RELEASE_FILE)
+	rm -rvf */*~ *~ .*~ */.*.swp .*.swp $(ALL) *.o core/*.jsonnet.h Makefile.depend *.so.* build jsonnet.egg-info $(RELEASE_FILE) man
 
 -include Makefile.depend
 


### PR DESCRIPTION
Hi

With this commit, we'd like to add man pages for the jsonnet and jsonnetfmt commands.
The Debian Lintian quality checker warns that each binary should have a manual page, but hopefully this idea would also apply to non-Debian users.
These man pages are created using the help2man command, so the contents are substantially the same as the output of the help option.