### PR TITLE
correct spelling error catched caught

### DIFF
--- a/third_party/rapidyaml/ryml_all.hpp
+++ b/third_party/rapidyaml/ryml_all.hpp
@@ -29082,7 +29082,7 @@ bool Parser::_handle_key_anchors_and_refs()
     }
     else if(C4_UNLIKELY(rem.begins_with('*')))
     {
-        _c4err("not implemented - this should have been catched elsewhere");
+        _c4err("not implemented - this should have been caught elsewhere");
         C4_NEVER_REACH();
         return false;
     }
@@ -29141,7 +29141,7 @@ bool Parser::_handle_val_anchors_and_refs()
     }
     else if(C4_UNLIKELY(rem.begins_with('*')))
     {
-        _c4err("not implemented - this should have been catched elsewhere");
+        _c4err("not implemented - this should have been caught elsewhere");
         C4_NEVER_REACH();
         return false;
     }


### PR DESCRIPTION
Hi

This commit corrects a typo in the third_party/rapidyaml/ryml_all.hpp file.
The error was a misspelling of "caught" as "catched".

Hope this change is helpful and satisfactory.