### PR TITLE
Fix doc example formatting for std.manifest{Json,JsonEx,TomlEx,...}

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -1,5 +1,14 @@
 local html = import 'html.libsonnet';
 
+local exampleDocMultiline(mid, ex) =
+  html.spaceless([
+    html.p({}, 'Example:'),
+    html.pre({}, ex.input),
+    html.p({}, mid),
+    html.pre({}, ex.output),
+  ])
+;
+
 {
   intro: html.paragraphs([
     |||
@@ -772,7 +781,7 @@ local html = import 'html.libsonnet';
             |||),
           ],
           examples: [
-            {
+            exampleDocMultiline('Yields a string containing this JSON:', {
               input: |||
                 std.manifestJsonEx(
                 {
@@ -796,8 +805,8 @@ local html = import 'html.libsonnet';
                     y: { a: 1, b: 2, c: [1, 2] },
                   }, '    '
                 ),
-            },
-            {
+            }),
+            exampleDocMultiline('Yields a string containing this JSON:', {
               input: |||
                 std.manifestJsonEx(
                 {
@@ -812,7 +821,7 @@ local html = import 'html.libsonnet';
                     y: { a: 1, b: [1, 2] },
                   }, '', ' ', ' : '
                 ),
-            },
+            }),
           ],
         },
         {
@@ -824,7 +833,7 @@ local html = import 'html.libsonnet';
             it calls <code>std.manifestJsonEx</code> with a 4-space indent:
           |||,
           examples: [
-            {
+            exampleDocMultiline('Yields a string containing this JSON:', {
               input: |||
                 std.manifestJson(
                 {
@@ -848,7 +857,7 @@ local html = import 'html.libsonnet';
                     y: { a: 1, b: 2, c: [1, 2] },
                   }
                 ),
-            },
+            }),
           ],
         },
         {
@@ -860,7 +869,7 @@ local html = import 'html.libsonnet';
             it calls <code>std.manifestJsonEx</code>:
           |||,
           examples: [
-            {
+            exampleDocMultiline('Yields a string containing this JSON:', {
               input: |||
                 std.manifestJsonMinified(
                 {
@@ -884,7 +893,7 @@ local html = import 'html.libsonnet';
                     y: { a: 1, b: 2, c: [1, 2] },
                   }
                 ),
-            },
+            }),
           ],
         },
         {
@@ -1055,7 +1064,7 @@ local html = import 'html.libsonnet';
             one or more whitespaces that are used for indentation:
           |||,
           examples: [
-            {
+            exampleDocMultiline('Yields a string containing this TOML file:', {
               input: |||
                 std.manifestTomlEx({
                   key1: "value",
@@ -1094,7 +1103,7 @@ local html = import 'html.libsonnet';
                   ],
                 }, '  ')
               ),
-            },
+            }),
           ],
         },
       ],
@@ -1602,7 +1611,7 @@ local html = import 'html.libsonnet';
           params: ['o'],
           availableSince: '0.20.0',
           description: |||
-            Returns an array of objects from the given object, each object having two fields: 
+            Returns an array of objects from the given object, each object having two fields:
             <code>key</code> (string) and <code>value</code> (object). Does not include hidden fields.
           |||,
         },

--- a/doc/_stdlib_gen/stdlib.jsonnet
+++ b/doc/_stdlib_gen/stdlib.jsonnet
@@ -15,7 +15,10 @@ local exampleDoc(ex) =
     else
       html.spaceless([html.code({}, ex.input), ' yields ', html.code({}, manifestJsonSingleLine(ex.output))])
   ;
-  html.p({}, html.spaceless(['Example: ', exRep, '.']))
+  if std.objectHas(ex, 'type') then
+    ex
+  else
+    html.p({}, html.spaceless(['Example: ', exRep, '.']))
 ;
 
 local hgroup(body) = html.div({ class: 'hgroup' }, body);

--- a/doc/_stdlib_gen/stdlib.jsonnet
+++ b/doc/_stdlib_gen/stdlib.jsonnet
@@ -73,7 +73,7 @@ local group(group_spec, prefix) =
   ];
 
 local stdlibPage = [
-  in_panel(html.h1({id: 'standard_library'}, 'Standard Library')),
+  in_panel(html.h1({ id: 'standard_library' }, 'Standard Library')),
   '',
   in_panel(content.intro),
   '',

--- a/doc/ref/stdlib.html
+++ b/doc/ref/stdlib.html
@@ -1549,20 +1549,42 @@ e = {"f1": False, "f2": 42}</pre>
         of an object field:
       </p>
       <p>
-        Example: <code>std.manifestJsonEx(
-        {
-            x: [1, 2, 3, true, false, null,
-                "string\nstring"],
-            y: { a: 1, b: 2, c: [1, 2] },
-        }, "    ")</code> yields <code>"{\n    \"x\": [\n        1,\n        2,\n        3,\n        true,\n        false,\n        null,\n        \"string\\nstring\"\n    ],\n    \"y\": {\n        \"a\": 1,\n        \"b\": 2,\n        \"c\": [\n            1,\n            2\n        ]\n    }\n}"</code>.
-      </p>
+        Example:
+      </p><pre>std.manifestJsonEx(
+{
+    x: [1, 2, 3, true, false, null,
+        "string\nstring"],
+    y: { a: 1, b: 2, c: [1, 2] },
+}, "    ")</pre><p>
+        Yields a string containing this JSON:
+      </p><pre>{
+    "x": [
+        1,
+        2,
+        3,
+        true,
+        false,
+        null,
+        "string\nstring"
+    ],
+    "y": {
+        "a": 1,
+        "b": 2,
+        "c": [
+            1,
+            2
+        ]
+    }
+}</pre>
       <p>
-        Example: <code>std.manifestJsonEx(
-        {
-          x: [1, 2, "string\nstring"],
-          y: { a: 1, b: [1, 2] },
-        }, "", " ", " : ")</code> yields <code>"{ \"x\" : [ 1, 2, \"string\\nstring\" ], \"y\" : { \"a\" : 1, \"b\" : [ 1, 2 ] } }"</code>.
-      </p>
+        Example:
+      </p><pre>std.manifestJsonEx(
+{
+  x: [1, 2, "string\nstring"],
+  y: { a: 1, b: [1, 2] },
+}, "", " ", " : ")</pre><p>
+        Yields a string containing this JSON:
+      </p><pre>{ "x" : [ 1, 2, "string\nstring" ], "y" : { "a" : 1, "b" : [ 1, 2 ] } }</pre>
     </div>
     <div style="clear: both"></div>
   </div>
@@ -1591,13 +1613,33 @@ e = {"f1": False, "f2": 42}</pre>
         it calls <code>std.manifestJsonEx</code> with a 4-space indent:
       </p>
       <p>
-        Example: <code>std.manifestJson(
-        {
-            x: [1, 2, 3, true, false, null,
-                "string\nstring"],
-            y: { a: 1, b: 2, c: [1, 2] },
-        })</code> yields <code>"{\n    \"x\": [\n        1,\n        2,\n        3,\n        true,\n        false,\n        null,\n        \"string\\nstring\"\n    ],\n    \"y\": {\n        \"a\": 1,\n        \"b\": 2,\n        \"c\": [\n            1,\n            2\n        ]\n    }\n}"</code>.
-      </p>
+        Example:
+      </p><pre>std.manifestJson(
+{
+    x: [1, 2, 3, true, false, null,
+        "string\nstring"],
+    y: { a: 1, b: 2, c: [1, 2] },
+})</pre><p>
+        Yields a string containing this JSON:
+      </p><pre>{
+    "x": [
+        1,
+        2,
+        3,
+        true,
+        false,
+        null,
+        "string\nstring"
+    ],
+    "y": {
+        "a": 1,
+        "b": 2,
+        "c": [
+            1,
+            2
+        ]
+    }
+}</pre>
     </div>
     <div style="clear: both"></div>
   </div>
@@ -1626,13 +1668,15 @@ e = {"f1": False, "f2": 42}</pre>
         it calls <code>std.manifestJsonEx</code>:
       </p>
       <p>
-        Example: <code>std.manifestJsonMinified(
-        {
-            x: [1, 2, 3, true, false, null,
-                "string\nstring"],
-            y: { a: 1, b: 2, c: [1, 2] },
-        })</code> yields <code>"{\"x\":[1,2,3,true,false,null,\"string\\nstring\"],\"y\":{\"a\":1,\"b\":2,\"c\":[1,2]}}"</code>.
-      </p>
+        Example:
+      </p><pre>std.manifestJsonMinified(
+{
+    x: [1, 2, 3, true, false, null,
+        "string\nstring"],
+    y: { a: 1, b: 2, c: [1, 2] },
+})</pre><p>
+        Yields a string containing this JSON:
+      </p><pre>{"x":[1,2,3,true,false,null,"string\nstring"],"y":{"a":1,"b":2,"c":[1,2]}}</pre>
     </div>
     <div style="clear: both"></div>
   </div>
@@ -1844,24 +1888,48 @@ e = {"f1": False, "f2": 42}</pre>
         one or more whitespaces that are used for indentation:
       </p>
       <p>
-        Example: <code>std.manifestTomlEx({
-          key1: "value",
-          key2: 1,
-          section: {
-            a: 1,
-            b: "str",
-            c: false,
-            d: [1, "s", [2, 3]],
-            subsection: {
-              k: "v",
-            },
-          },
-          sectionArray: [
-            { k: "v1", v: 123 },
-            { k: "v2", c: "value2" },
-          ],
-        }, "  ")</code> yields <code>"key1 = \"value\"\nkey2 = 1\n\n[section]\n  a = 1\n  b = \"str\"\n  c = false\n  d = [\n    1,\n    \"s\",\n    [ 2, 3 ]\n  ]\n\n  [section.subsection]\n    k = \"v\"\n\n[[sectionArray]]\n  k = \"v1\"\n  v = 123\n\n[[sectionArray]]\n  c = \"value2\"\n  k = \"v2\""</code>.
-      </p>
+        Example:
+      </p><pre>std.manifestTomlEx({
+  key1: "value",
+  key2: 1,
+  section: {
+    a: 1,
+    b: "str",
+    c: false,
+    d: [1, "s", [2, 3]],
+    subsection: {
+      k: "v",
+    },
+  },
+  sectionArray: [
+    { k: "v1", v: 123 },
+    { k: "v2", c: "value2" },
+  ],
+}, "  ")</pre><p>
+        Yields a string containing this TOML file:
+      </p><pre>key1 = "value"
+key2 = 1
+
+[section]
+  a = 1
+  b = "str"
+  c = false
+  d = [
+    1,
+    "s",
+    [ 2, 3 ]
+  ]
+
+  [section.subsection]
+    k = "v"
+
+[[sectionArray]]
+  k = "v1"
+  v = 123
+
+[[sectionArray]]
+  c = "value2"
+  k = "v2"</pre>
     </div>
     <div style="clear: both"></div>
   </div>
@@ -3083,7 +3151,7 @@ e = {"f1": False, "f2": 42}</pre>
         </em>
       </p>
       <p>
-        Returns an array of objects from the given object, each object having two fields: 
+        Returns an array of objects from the given object, each object having two fields:
         <code>key</code> (string) and <code>value</code> (object). Does not include hidden fields.
       </p>
       

--- a/doc/ref/stdlib.html
+++ b/doc/ref/stdlib.html
@@ -250,12 +250,16 @@ title: Standard Library
           <ul><code>std.atan2(y, x)</code></ul>
           <ul><code>std.deg2rad(x)</code></ul>
           <ul><code>std.rad2deg(x)</code></ul>
+          <ul><code>std.hypot(a, b)</code></ul>
           <ul><code>std.round(x)</code></ul>
           <ul><code>std.isEven(x)</code></ul>
           <ul><code>std.isOdd(x)</code></ul>
           <ul><code>std.isInteger(x)</code></ul>
           <ul><code>std.isDecimal(x)</code></ul>
       </ul>
+      <p>
+          The constant <code>std.pi</code> is also available.
+      </p>
       <p>
           The function <code>std.mod(a, b)</code> is what the % operator is desugared to. It performs
           modulo arithmetic if the left hand side is a number, or if the left hand side is a string,


### PR DESCRIPTION
For #1205

Also includes regenerating docs from previous changes.
