### PR TITLE
Add explicit std::array<> template args to support C++14 build

### DIFF
--- a/core/unicode_test.cpp
+++ b/core/unicode_test.cpp
@@ -59,7 +59,7 @@ TEST(Unicode, TestUTF8)
 
 TEST(Unicode, TestUTF8RejectBad)
 {
-    const auto test_cases = std::array{
+    const auto test_cases = std::array<const char*, 20>{
         "\x80",  // Continuation byte without leading byte
         "\xa0",  // Continuation byte without leading byte
         "\xbf",  // Continuation byte without leading byte


### PR DESCRIPTION
Not all the build systems make it easy to specify the C++ standard to use (somehow, Bazel doesn't). C++14 doesn't support deducing the template arguments for std::array. But it seems like there's only one place that needs to be changed to make a C++14 build work ok.