### PR TITLE
Attempt to fix Python setup.py build for clang / MacOS

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -46,12 +46,20 @@ jobs:
     runs-on: "ubuntu-22.04"
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
       - name: Build
         run: |
-          python setup.py build
+          pip install build
+          python -m build --sdist --wheel
       - name: Test
         run: |
-          python setup.py test
+          python -m venv --upgrade-deps --clear trial &&
+          cd trial &&
+          source bin/activate &&
+          pip install ../dist/jsonnet-*.whl &&
+          python3 ../python/_jsonnet_test.py
 
   cmake_build:
     name: Build and test using CMake

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+requires = ["setuptools >= 72.2"]


### PR DESCRIPTION
Clang is apparently more strict about using `-std=c++17` only for C++ compilation, rejecting it with an error for C compilation (GCC gives a warning but proceeds).

This is an attempt to fix #1202.