### PR TITLE
Allow manually triggering the build-and-test workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,6 +11,7 @@ on:
       - "prepare-release"
     tags:
       - v*
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Occasionally useful to be able to manually trigger the build-and-test workflow (which is normally triggered for pull requests).