### PR TITLE
CI: Build wheels for MacOS as well

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -50,9 +50,9 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        #os: [ubuntu-22.04, windows-latest, macos-latest]
-        os: [ubuntu-22.04, windows-latest]
+        os: [ubuntu-22.04, windows-latest, macos-13, macos-latest]
 
     permissions:
       contents: read


### PR DESCRIPTION
With the most recent fixes it seems that building wheels (prebuilt Python extension binaries) on MacOS is now reasonably easy, so let's do that.