### PR TITLE
fix: Clean build artifacts for successful repackage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ $(RELEASE_FILE): bins
 dist: $(RELEASE_FILE)
 
 clean:
-	rm -vf */*~ *~ .*~ */.*.swp .*.swp $(ALL) *.o core/*.jsonnet.h Makefile.depend *.so.* $(RELEASE_FILE)
+	rm -rvf */*~ *~ .*~ */.*.swp .*.swp $(ALL) *.o core/*.jsonnet.h Makefile.depend *.so.* build jsonnet.egg-info $(RELEASE_FILE)
 
 -include Makefile.depend
 


### PR DESCRIPTION
The clean target in the Makefile wasn't removing all the temporary build files and directories, specifically build and jsonnet.egg-info. This caused a problem when trying to repackage the source for Debian. For more details about the problem, see the following bug report: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1047367

This patch simply adds these to the clean command, ensuring a truly clean build environment, which is required by Debian policy. This change isn't just for Debian; it will also benefit other distributions that package Jsonnet, as it ensures a consistent and reliable build process across all platforms.