### PR TITLE
Include cstdint for int64_t in vm.h

### DIFF
--- a/core/vm.h
+++ b/core/vm.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define JSONNET_VM_H
 
 #include <libjsonnet.h>
+#include <cstdint>
 
 #include "ast.h"
 


### PR DESCRIPTION
Missing this causes a build failure in some environments.