### PR TITLE
Reduce safe integer range to exclude +/- 2^53 and match JavaScript safe-integer bounds

### DIFF
--- a/core/vm.h
+++ b/core/vm.h
@@ -130,25 +130,6 @@ std::vector<std::string> jsonnet_vm_execute_stream(
     double gc_min_objects, double gc_growth_trigger, const VmNativeCallbackMap &natives,
     JsonnetImportCallback *import_callback, void *import_callback_ctx, bool string_output);
 
-/** Safely converts a double to an int64_t, with range and validity checks.
- *
- * This function is used primarily for bitwise operations which require integer operands.
- * It performs two safety checks:
- * 1. Verifies the value is finite (not NaN or Infinity)
- * 2. Ensures the value is within the safe integer range [-2^53, 2^53]
- *
- * The safe integer range limitation is necessary because IEEE 754 double precision
- * floating point numbers can only precisely represent integers in the range [-2^53, 2^53].
- * Beyond this range, precision is lost, which would lead to unpredictable results
- * in bitwise operations that depend on exact bit patterns.
- *
- * \param value The double value to convert
- * \param loc The location in source code (for error reporting)
- * \throws StaticError if value is not finite or outside the safe integer range
- * \returns The value converted to int64_t
- */
-int64_t safeDoubleToInt64(double value, const LocationRange& loc);
-
 }  // namespace jsonnet::internal
 
 #endif

--- a/doc/ref/language.html.md
+++ b/doc/ref/language.html.md
@@ -133,7 +133,7 @@ Strings can be constructed as literals, slices of existing strings, concatenatio
 
 Jsonnet numbers are 64-bit floating point numbers as defined in IEEE754 excluding `nan` and `inf` values. Operations resulting in infinity or not a number are errors.
 
-Integers can be precisely represented as a Jsonnet number in the range [-2^53,2^53]. This is [a direct consequence of IEEE754 spec](https://en.wikipedia.org/wiki/Double-precision_floating-point_format).
+Integers can be safely represented as a Jsonnet number in the range [-2^53 + 1,2^53 - 1]. This is [a direct consequence of IEEE754 spec](https://en.wikipedia.org/wiki/Double-precision_floating-point_format), with the requirements that a safe integer is representable exactly, and cannot be produced by rounding any other integer to fit the IEEE-754 representation. See also, the JavaScript [`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER), [`Number.MIN_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER), and [`Number.isSafeInteger`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger) definitions.
 
 ### Function
 

--- a/test_suite/error.integer_conversion.jsonnet
+++ b/test_suite/error.integer_conversion.jsonnet
@@ -1,3 +1,3 @@
-// Value just beyond MAX_SAFE_INTEGER (2^53)
-local beyond_max = 9007199254740994;  // 2^53 + 1
+// Value just beyond MAX_SAFE_INTEGER (2^53 - 1)
+local beyond_max = 9007199254740992;  // 2^53
 beyond_max << 1  // Should throw error "numeric value outside safe integer range for bitwise operation"

--- a/test_suite/error.integer_conversion.jsonnet.golden
+++ b/test_suite/error.integer_conversion.jsonnet.golden
@@ -1,1 +1,2 @@
-STATIC ERROR: error.integer_conversion.jsonnet:3:1-16: numeric value outside safe integer range for bitwise operation.
+RUNTIME ERROR: numeric value outside safe integer range for bitwise operation.
+	error.integer_conversion.jsonnet:3:1-16	

--- a/test_suite/error.integer_left_shift.jsonnet.golden
+++ b/test_suite/error.integer_left_shift.jsonnet.golden
@@ -1,1 +1,2 @@
-STATIC ERROR: error.integer_left_shift.jsonnet:3:1-17: numeric value outside safe integer range for bitwise operation.
+RUNTIME ERROR: numeric value outside safe integer range for bitwise operation.
+	error.integer_left_shift.jsonnet:3:1-17	

--- a/test_suite/safe_integer_conversion.jsonnet
+++ b/test_suite/safe_integer_conversion.jsonnet
@@ -1,11 +1,11 @@
 // Test values at boundary of safe integer range
-local max_safe = 9007199254740992; // 2^53
-local min_safe = -9007199254740992; // -2^53
+local max_safe = 9007199254740991;  // 2^53 - 1
+local min_safe = -9007199254740991;  // -(2^53 - 1)
 
-std.assertEqual(max_safe & 1, 0) && // Check 2^53
-std.assertEqual(min_safe & 1, 0) && // Check -2^53
-std.assertEqual((max_safe - 1) & 1, 1) && // Check 2^53 - 1
-std.assertEqual((min_safe + 1) & 1, 1) && // Check -2^53 + 1
+std.assertEqual(max_safe & 1, 1) &&  // Check 2^53
+std.assertEqual(min_safe & 1, 1) &&  // Check -2^53
+std.assertEqual((max_safe - 1) & 1, 0) &&  // Check 2^53 - 1
+std.assertEqual((min_safe + 1) & 1, 0) &&  // Check -2^53
 
 std.assertEqual(~(max_safe - 1), min_safe) &&  // ~(2^53 - 1) == -2^53
 std.assertEqual(~(min_safe + 1), max_safe - 2) &&  // ~(-2^53 + 1) == 2^53 - 2
@@ -17,18 +17,18 @@ std.assertEqual(~(-1), 0) &&
 
 // Test shift operations with large values at safe boundary
 // (2^53 - 1) right shift by 4 bits
-std.assertEqual((max_safe - 1) >> 4, 562949953421311) &&
-// MAX_SAFE_INTEGER (2^53) right shift by 1 bit
-std.assertEqual(max_safe >> 1, 4503599627370496) && // 2^52
-// MIN_SAFE_INTEGER (-2^53) right shift by 1 bit
-std.assertEqual(min_safe >> 1, -4503599627370496) && // -2^52
+std.assertEqual(max_safe >> 4, 562949953421311) &&
+// MAX_SAFE_INTEGER (2^53 - 1) right shift by 1 bit is (2^52 - 1)
+std.assertEqual(max_safe >> 1, 4503599627370495) &&  // 2^52
+// MIN_SAFE_INTEGER -(2^53 - 1) right shift by 1 bit is (-2^52)
+std.assertEqual(min_safe >> 1, -4503599627370496) &&  // -2^52
 
 // Cannot left shift 2^53 without potential overflow/loss of precision issues
 // depending on the shift amount, but can shift smaller numbers up to it.
-// (2^52) left shift by 1 bit (result is 2^53)
-std.assertEqual((max_safe >> 1) << 1, max_safe) &&
-// (-2^52) left shift by 1 bit (result is -2^53)
-std.assertEqual((min_safe >> 1) << 1, min_safe) &&
+// (2^52-1) left shift by 1 bit (result is 2^53-2)
+std.assertEqual(4503599627370495 << 1, max_safe - 1) &&
+// (-(2^52-1)) left shift by 1 bit (result is -(2^53-2))
+std.assertEqual((-4503599627370495) << 1, min_safe + 1) &&
 
 // Test larger values within safe range
 std.assertEqual(~123456789, -123456790) &&

--- a/test_suite/safe_integer_conversion.jsonnet.fmt.golden
+++ b/test_suite/safe_integer_conversion.jsonnet.fmt.golden
@@ -1,11 +1,11 @@
 // Test values at boundary of safe integer range
-local max_safe = 9007199254740992;  // 2^53
-local min_safe = -9007199254740992;  // -2^53
+local max_safe = 9007199254740991;  // 2^53 - 1
+local min_safe = -9007199254740991;  // -(2^53 - 1)
 
-std.assertEqual(max_safe & 1, 0) &&  // Check 2^53
-std.assertEqual(min_safe & 1, 0) &&  // Check -2^53
-std.assertEqual((max_safe - 1) & 1, 1) &&  // Check 2^53 - 1
-std.assertEqual((min_safe + 1) & 1, 1) &&  // Check -2^53 + 1
+std.assertEqual(max_safe & 1, 1) &&  // Check 2^53
+std.assertEqual(min_safe & 1, 1) &&  // Check -2^53
+std.assertEqual((max_safe - 1) & 1, 0) &&  // Check 2^53 - 1
+std.assertEqual((min_safe + 1) & 1, 0) &&  // Check -2^53
 
 std.assertEqual(~(max_safe - 1), min_safe) &&  // ~(2^53 - 1) == -2^53
 std.assertEqual(~(min_safe + 1), max_safe - 2) &&  // ~(-2^53 + 1) == 2^53 - 2
@@ -17,18 +17,18 @@ std.assertEqual(~(-1), 0) &&
 
 // Test shift operations with large values at safe boundary
 // (2^53 - 1) right shift by 4 bits
-std.assertEqual((max_safe - 1) >> 4, 562949953421311) &&
-// MAX_SAFE_INTEGER (2^53) right shift by 1 bit
-std.assertEqual(max_safe >> 1, 4503599627370496) &&  // 2^52
-// MIN_SAFE_INTEGER (-2^53) right shift by 1 bit
+std.assertEqual(max_safe >> 4, 562949953421311) &&
+// MAX_SAFE_INTEGER (2^53 - 1) right shift by 1 bit is (2^52 - 1)
+std.assertEqual(max_safe >> 1, 4503599627370495) &&  // 2^52
+// MIN_SAFE_INTEGER -(2^53 - 1) right shift by 1 bit is (-2^52)
 std.assertEqual(min_safe >> 1, -4503599627370496) &&  // -2^52
 
 // Cannot left shift 2^53 without potential overflow/loss of precision issues
 // depending on the shift amount, but can shift smaller numbers up to it.
-// (2^52) left shift by 1 bit (result is 2^53)
-std.assertEqual((max_safe >> 1) << 1, max_safe) &&
-// (-2^52) left shift by 1 bit (result is -2^53)
-std.assertEqual((min_safe >> 1) << 1, min_safe) &&
+// (2^52-1) left shift by 1 bit (result is 2^53-2)
+std.assertEqual(4503599627370495 << 1, max_safe - 1) &&
+// (-(2^52-1)) left shift by 1 bit (result is -(2^53-2))
+std.assertEqual((-4503599627370495) << 1, min_safe + 1) &&
 
 // Test larger values within safe range
 std.assertEqual(~123456789, -123456790) &&


### PR DESCRIPTION
As noted in https://github.com/google/jsonnet/pull/1217#issuecomment-2868504070 and discussed in #1238.

Although 2^53 is representable (there is a bit-pattern for a IEEE-754 double precision float which represents this value), it is not safe because as @CertainLach pointed out, it is ambiguous/not distinguishable from 2^53+1 which is not representable and would be rounded down.

This also switches from a StaticError to a RuntimeError when encounting a non-integer-safe value since these values are runtime constructs not parse time (static).

@CertainLach if you have time to review, I'd appreciate it.

Fixes #1238.