### PR TITLE
Support for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.7...4.0)
 project(jsonnet C CXX)
 
 include(ExternalProject)
@@ -7,7 +7,10 @@ include(GNUInstallDirs)
 # User-configurable options.
 option(BUILD_JSONNET "Build jsonnet command-line tool." ON)
 option(BUILD_JSONNETFMT "Build jsonnetfmt command-line tool." ON)
-option(BUILD_TESTS "Build and run jsonnet tests." ON)
+if(MSVC)
+	option(BUILD_TESTS "Build and run jsonnet tests." OFF)
+endif()
+
 option(BUILD_STATIC_LIBS "Build a static libjsonnet." ON)
 option(BUILD_SHARED_BINARIES "Link binaries to the shared libjsonnet instead of the static one." OFF)
 option(USE_SYSTEM_GTEST "Use system-provided gtest library" OFF)
@@ -39,12 +42,17 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" OR
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -Wimplicit-fallthrough -pedantic -std=c99 ${OPT}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra -Wimplicit-fallthrough -Woverloaded-virtual -pedantic -std=c++17 -fPIC ${OPT}")
 else()
-    # TODO: Windows support.
-    message(FATAL_ERROR "Compiler ${CMAKE_CXX_COMPILER_ID} not supported")
+	if(MSVC)
+		#nothing 
+	else()
+    	message(FATAL_ERROR "Compiler ${CMAKE_CXX_COMPILER_ID} not supported")
+    endif()
 endif()
 
 set(CMAKE_CXX_STANDARD 17)
-
+if(MSVC)
+    set( CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/release )
+endif()
 
 # Include external googletest project. This runs a CMake sub-script
 # (CMakeLists.txt.in) that downloads googletest source. It's then built as part
@@ -126,7 +134,9 @@ add_subdirectory(third_party/rapidyaml)
 add_subdirectory(core)
 add_subdirectory(cpp)
 add_subdirectory(cmd)
-add_subdirectory(test_suite)
+if(NOT MSVC)
+	add_subdirectory(test_suite)
+endfi()
 
 if (BUILD_TESTS)
     # s`run_tests` target builds and runs all tests. The cmake-generated `test`

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -3,12 +3,25 @@
 add_executable(to_c_array to_c_array.cpp)
 
 # Custom command that will only build stdlib when it changes.
+
+if(MSVC)
+
+add_custom_command(
+	OUTPUT ${PROJECT_SOURCE_DIR}/core/std.jsonnet.h
+	COMMAND ${CMAKE_BINARY_DIR}/$<CONFIG>/to_c_array
+			    ${PROJECT_SOURCE_DIR}/stdlib/std.jsonnet
+					${PROJECT_SOURCE_DIR}/core/std.jsonnet.h
+	DEPENDS to_c_array std.jsonnet)
+
+else()
+
 add_custom_command(
 	OUTPUT ${PROJECT_SOURCE_DIR}/core/std.jsonnet.h
 	COMMAND ${GLOBAL_OUTPUT_PATH}/to_c_array
 			    ${PROJECT_SOURCE_DIR}/stdlib/std.jsonnet
 					${PROJECT_SOURCE_DIR}/core/std.jsonnet.h
 	DEPENDS to_c_array std.jsonnet)
+endif()
 
 # Standard library build target that libjsonnet can depend on.
 add_custom_target(stdlib ALL


### PR DESCRIPTION
1. In this pull request it is quick implementation for MSVC
2. This quick fix is not intended for merge in to main branch
3. Intention is to show how, what and where fix might be to support MSVC

After applying this patch and build using VS this will produce next files:

$\release\bin\jsonnet.dll
$\release\bin\jsonnet.exe
$\release\lib\jsonnet.lib
$\release\bin\jsonnet++.dll
$\release\lib\jsonnet++.lib
$\release\bin\jsonnetfmt.exe
$\release\include\libjsonnet.h
$\release\include\libjsonnet_fmt.h
$\release\include\libjsonnet++.h