### PR TITLE
Fixes build on CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7...4.0)
+cmake_minimum_required(VERSION 3.5...4.1)
 project(jsonnet C CXX)
 
 include(ExternalProject)

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,7 +1,7 @@
 # CMake script run a generation-time. This must be separate from the main
 # CMakeLists.txt file to allow downloading and building googletest at generation
 # time.
-cmake_minimum_required(VERSION 2.8.2...4.0)
+cmake_minimum_required(VERSION 3.5...4.1)
 
 project(googletest-download NONE)
 


### PR DESCRIPTION
This patch resolves an issue where the project fails to build with newer versions of CMake, specifically CMake 4.0, which has removed backward compatibility with versions older than 3.5.

The bug was originally reported on the Debian issue tracker at #1113063:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1113063

The project's CMakeLists.txt and CMakeLists.txt.in files specify a cmake_minimum_required version of 2.8.7...4.0. 
This causes the build process to terminate with a fatal error on CMake 4.0 or later.

The fix updates the required minimum version to 3.5...4.1 to align with the latest CMake policies and allow the project to build successfully.
This change will be beneficial not only for Debian but for all other Linux distributions and operating systems running a modern CMake version.