### PR TITLE
docs: fix assertion example with correct condition

### DIFF
--- a/doc/learning/tutorial.html
+++ b/doc/learning/tutorial.html
@@ -493,7 +493,7 @@ title: Tutorial
         <li>To assert a condition before an expression: <code>assert "foo";</code></li>
         <li>A custom failure message: <code>assert "foo" : "message";</code></li>
         <li>Assert fields have a property: <code>assert self.f == 10,</code></li>
-        <li>With custom failure message: <code>assert "foo" : "message",</code></li>
+        <li>With custom failure message: <code>assert self.f == 10 : "message",</code></li>
       </ul>
       <p>
         Try modifying the code below to trigger the assertion failures, and observe the error


### PR DESCRIPTION
From the context of the text, the `assert` condition should include a field property from the above example.