### PR TITLE
chore: add .bazelignore to fix some build failures

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,9 @@
+# The bazel example is an entirely separate bazel module and should
+# not be built as part of the main library module.
+examples/bazel
+
+# The README instructions for building with CMake involve initialising the
+# CMake build directory as a subdirectory called build, that directory
+# ends up containing other bazel BUILD files, which then interfere with a
+# bazel build. Therefore, exclude it.
+build


### PR DESCRIPTION
If you have build using CMake following the build instructions in the README, and then you subsequently try to build everything (`//...`) with bazel without first cleaning the CMake output, then the bazel build fails. This is because the CMake build (when following the README) pulls down googletest (and maybe other things?) into the build/ directory, which means there are random BUILD files under build/, and bazel will find these and try to use them as part of the module.

So ignore a 'build' directory.

Also ignore the examples/bazel directory, since that is explicitly an example of how to _use_ jsonnet from a separate bazel module.