### PR TITLE
Implement std.objectRemoveKey as a builtin which retains hidden fields

### DIFF
--- a/core/desugarer.cpp
+++ b/core/desugarer.cpp
@@ -36,7 +36,7 @@ struct BuiltinDecl {
     std::vector<UString> params;
 };
 
-static unsigned long max_builtin = 40;
+static unsigned long max_builtin = 41;
 BuiltinDecl jsonnet_builtin_decl(unsigned long builtin)
 {
     switch (builtin) {
@@ -81,6 +81,7 @@ BuiltinDecl jsonnet_builtin_decl(unsigned long builtin)
         case 38: return {U"decodeUTF8", {U"arr"}};
         case 39: return {U"atan2", {U"y", U"x"}};
         case 40: return {U"hypot", {U"a", U"b"}};
+        case 41: return {U"objectRemoveKey", {U"obj", U"key"}};
         default:
             std::cerr << "INTERNAL ERROR: Unrecognized builtin function: " << builtin << std::endl;
             std::abort();

--- a/stdlib/std.jsonnet
+++ b/stdlib/std.jsonnet
@@ -1786,12 +1786,6 @@ limitations under the License.
       std.removeAt(arr, indexes[0])
   ,
 
-  objectRemoveKey(obj, key):: {
-    [k]: obj[k],
-    for k in std.objectFields(obj)
-    if k != key
-  },
-
   sha1(str):: go_only_function,
   sha256(str):: go_only_function,
   sha512(str):: go_only_function,

--- a/test_suite/stdlib.jsonnet
+++ b/test_suite/stdlib.jsonnet
@@ -1630,6 +1630,20 @@ std.assertEqual(std.remove([1, 2, 3], 2), [1, 3]) &&
 std.assertEqual(std.removeAt([1, 2, 3], 1), [1, 3]) &&
 
 std.assertEqual(std.objectRemoveKey({ foo: 1, bar: 2, baz: 3 }, 'foo'), { bar: 2, baz: 3 }) &&
+// objectRemoveKey should retain hidden fields as hidden fields.
+std.assertEqual(std.objectRemoveKey({ foo: 1, bar: 2, baz:: 3 }, 'foo').baz, 3) &&
+// objectRemoveKey doesn't break inheritance within the provided object.
+std.assertEqual(std.objectRemoveKey({ a: 1 } + { b: super.a }, 'a'), { b: 1 }) &&
+// objectRemoveKey works with inheritance outside of the object.
+std.assertEqual({ a: 1 } + std.objectRemoveKey({ b: super.a }, 'a'), { a: 1, b: 1 }) &&
+// Referential transparency still works.
+std.assertEqual(local o1 = { b: super.a }; std.objectRemoveKey({ a: 1 } + o1, 'a'), { b: 1 }) &&
+std.assertEqual(local o1 = { b: super.a }; { a: 1 } + std.objectRemoveKey(o1, 'a'), { a: 1, b: 1 }) &&
+// Hidden fields still work.
+std.assertEqual(std.objectRemoveKey({ a: 1 } + { b:: super.a }, 'a'), {}) &&
+std.assertEqual(std.objectRemoveKey({ a: 1 } + { b:: super.a }, 'a').b, 1) &&
+std.assertEqual(({ a: 1 } + std.objectRemoveKey({ b:: super.a }, 'a')), { a: 1 }) &&
+std.assertEqual(({ a: 1 } + std.objectRemoveKey({ b:: super.a }, 'a')).b, 1) &&
 
 std.assertEqual(std.trim('already trimmed string'), 'already trimmed string') &&
 std.assertEqual(std.trim('    string with spaces on both ends     '), 'string with spaces on both ends') &&


### PR DESCRIPTION
The Go Jsonnet implementation already implements objectRemoveKey as a builtin and retains hidden fields, this brings the C++ Jsonnet into alignment. This implementation is a little tricky because lazy evaluation means that objects are not simple structures but form an inheritance tree. However, it's not too bad as the code is generally happy to strictly enumerate the object's field list without necessarily evaluating field _values_, and for `std.objectRemoveKey` all we need is the field list. Arguably we could even do without that by just storing the set of fields to be removed, but I'd prefer to keep things 'simpler' with a flat field list.

See https://github.com/google/go-jsonnet/issues/830
