### PR TITLE
Fix typo in license text

### DIFF
--- a/test_suite/error.parse.text_block_indent_spaces.jsonnet
+++ b/test_suite/error.parse.text_block_indent_spaces.jsonnet
@@ -9,7 +9,7 @@ You may obtain a copy of the License at
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUTHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */


### PR DESCRIPTION
It was a typo