### PR TITLE
chore: use modern cmake version detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if(USE_SYSTEM_JSON)
 endif()
 
 if(USE_SYSTEM_RAPIDYAML)
-    find_package(ryml REQUIRED VERSION 0.10.0)
+    find_package(ryml 0.10.0 REQUIRED)
 endif()
 
 #### Utility function to configure a target with our preferred C and C++ compilation flags.


### PR DESCRIPTION
cmake4 appears to have dropped the old syntax.  This should work on all the cmake versions listed in CMakeLists.txt.