### PR TITLE
fix: system rapidyaml needs include for c4core

### DIFF
--- a/core/vm.cpp
+++ b/core/vm.cpp
@@ -31,6 +31,7 @@ limitations under the License.
 #include "parser.h"
 #ifdef USE_SYSTEM_RAPIDYAML
 #include <ryml.hpp>
+#include <ryml_std.hpp>
 #else
 #include "rapidyaml-0.10.0.hpp"
 #endif


### PR DESCRIPTION
On Fedora rawhide, this extra header is required for jsonnet 0.22.0