### PR TITLE
docs: Fix escapeStringXML stdlib casing

### DIFF
--- a/doc/_stdlib_gen/stdlib-content.jsonnet
+++ b/doc/_stdlib_gen/stdlib-content.jsonnet
@@ -565,7 +565,7 @@ local exampleDocMultiline(mid, ex) =
           |||,
         },
         {
-          name: 'escapeStringXml',
+          name: 'escapeStringXML',
           params: ['str'],
           availableSince: '0.10.0',
           description: |||

--- a/doc/ref/stdlib.html
+++ b/doc/ref/stdlib.html
@@ -1161,8 +1161,8 @@ title: Standard Library
 <div class="hgroup">
   <div class="hgroup-inline">
     <div class="panel">
-      <h4 id="std-escapeStringXml">
-        std.escapeStringXml(str)
+      <h4 id="std-escapeStringXML">
+        std.escapeStringXML(str)
       </h4>
     </div>
     <div style="clear: both"></div>


### PR DESCRIPTION
## Summary
- align the stdlib docs entry with the actual stdlib function name `std.escapeStringXML`
- regenerate `doc/ref/stdlib.html` from `doc/_stdlib_gen/stdlib-content.jsonnet`

The implementation in `stdlib/std.jsonnet` and the existing `test_suite/stdlib.jsonnet` cases already use `std.escapeStringXML`.

## Tests
- `JSONNET_BIN=/opt/homebrew/bin/jsonnet doc/_stdlib_gen/run_tests.sh`
