### PR TITLE
docs: document array parameter support in std.stripChars/lstripChars/rstripChars

### DIFF
--- a/doc/ref/stdlib.html
+++ b/doc/ref/stdlib.html
@@ -625,6 +625,14 @@ title: Standard Library
       <p>
         Example: <code>std.stripChars("cacabbbbaacc", "ac")</code> yields <code>"bbbb"</code>.
       </p>
+      <p>
+        The <code>chars</code> parameter may also be an array of single-character strings. When an
+        array is provided, only single-character string elements are used as characters to strip;
+        non-string elements and multi-character strings are silently ignored.
+      </p>
+      <p>
+        Example: <code>std.stripChars("abcba", ["a", "c"])</code> yields <code>"bcb"</code>.
+      </p>
     </div>
     <div style="clear: both"></div>
   </div>
@@ -660,6 +668,14 @@ title: Standard Library
       <p>
         Example: <code>std.lstripChars("cacabbbbaacc", "ac")</code> yields <code>"bbbbaacc"</code>.
       </p>
+      <p>
+        The <code>chars</code> parameter may also be an array of single-character strings. When an
+        array is provided, only single-character string elements are used as characters to strip;
+        non-string elements and multi-character strings are silently ignored.
+      </p>
+      <p>
+        Example: <code>std.lstripChars("abcba", ["a", "c"])</code> yields <code>"bcba"</code>.
+      </p>
     </div>
     <div style="clear: both"></div>
   </div>
@@ -694,6 +710,14 @@ title: Standard Library
       </p>
       <p>
         Example: <code>std.rstripChars("cacabbbbaacc", "ac")</code> yields <code>"cacabbbb"</code>.
+      </p>
+      <p>
+        The <code>chars</code> parameter may also be an array of single-character strings. When an
+        array is provided, only single-character string elements are used as characters to strip;
+        non-string elements and multi-character strings are silently ignored.
+      </p>
+      <p>
+        Example: <code>std.rstripChars("abcba", ["a", "c"])</code> yields <code>"abcb"</code>.
       </p>
     </div>
     <div style="clear: both"></div>


### PR DESCRIPTION
## Summary

- Document that `std.stripChars`, `std.lstripChars`, and `std.rstripChars` accept an array of single-character strings as the `chars` parameter
- Add examples showing array usage for each function

## Motivation

The reference implementation in `stdlib/std.jsonnet` inherently supports arrays because it uses `std.member(chars, str[0])`, which works with both strings and arrays. This behavior is consistent across all major implementations (cpp-jsonnet, go-jsonnet, sjsonnet, jrsonnet) but is not documented.

When `chars` is an array:
- Single-character string elements are used as characters to strip
- Non-string elements and multi-character strings are silently ignored

## Modification

Added a paragraph and example to each of the three function documentation sections in `doc/ref/stdlib.html`:
- `std.stripChars`
- `std.lstripChars`
- `std.rstripChars`

## Result

Users can now discover and rely on the array parameter behavior, which is already supported by all implementations.

## Cross-implementation verification

| Expression | cpp-jsonnet | go-jsonnet | sjsonnet | jrsonnet |
|------------|-------------|------------|----------|----------|
| `std.stripChars("abcba", ["a", "c"])` | `"bcb"` | `"bcb"` | `"bcb"` | `"bcb"` |
| `std.lstripChars("abcba", ["a", "c"])` | `"bcba"` | `"bcba"` | `"bcba"` | `"bcba"` |
| `std.rstripChars("abcba", ["a", "c"])` | `"abcb"` | `"abcb"` | `"abcb"` | `"abcb"` |

Closes #1325